### PR TITLE
Don't print diff when getting author email

### DIFF
--- a/ci/update-gh-pages.sh
+++ b/ci/update-gh-pages.sh
@@ -36,8 +36,8 @@ DOCS_W_EXT_DIR=$SUB_FOLDER_NAME/docs-w-ext
 
 RAW_CP_DIRS="examples resources src"
 
-ORIGINAL_AUTHOR_NAME=$(git show --format="%aN" $TRAVIS_COMMIT)
-ORIGINAL_AUTHOR_EMAIL=$(git show --format="%ae" $TRAVIS_COMMIT)
+ORIGINAL_AUTHOR_NAME=$(git show -s --format="%aN" $TRAVIS_COMMIT)
+ORIGINAL_AUTHOR_EMAIL=$(git show -s --format="%ae" $TRAVIS_COMMIT)
 
 GH_PAGES_BRANCH=gh-pages
 GH_PAGES_REPO_FROM_SLUG="github.com/$TRAVIS_REPO_SLUG.git"


### PR DESCRIPTION
Use the `-s` option to suppress the diff when getting author email and name.