### PR TITLE
Publish the GeoExt-pkg, it's advertized in catalog

### DIFF
--- a/ci/update-gh-pages.sh
+++ b/ci/update-gh-pages.sh
@@ -68,6 +68,22 @@ cp -r $INSTALL_DIR/../repo/pkgs/$BASIGX_PACKAGE_NAME/$BASIGX_PACKAGE_VERSION cmd
 cp $INSTALL_DIR/../repo/pkgs/catalog.json cmd/pkgs/
 cp $INSTALL_DIR/../repo/pkgs/$BASIGX_PACKAGE_NAME/catalog.json cmd/pkgs/$BASIGX_PACKAGE_NAME
 
+# Since the catalog.json also references the GeoExt package, we also republish
+# it here
+#
+# TODO how can we avoid this republishing or optionally at least have the
+#      versions and names be auto-configured?
+#      * One idea would be to simply copy over the complete `repo/pkgs`-folder
+#      * Alternatively, we should probably only advertize the BasiGX package in
+#        the catalog json, but I am unsure, if that fits with the sencha
+#        philosophy. It may be that dependent packages have to provided along
+#        with the main package, to ensure the dependencies can be resolved at
+#        time sencha builds concrete apps / other packages.
+GEOEXT_PACKAGE_NAME=GeoExt
+GEOEXT_PACKAGE_VERSION=3.0.0
+mkdir -p cmd/pkgs/$GEOEXT_PACKAGE_NAME
+rm -Rf cmd/pkgs/$GEOEXT_PACKAGE_NAME/$GEOEXT_PACKAGE_VERSION
+cp -r $INSTALL_DIR/../repo/pkgs/$GEOEXT_PACKAGE_NAME/$GEOEXT_PACKAGE_VERSION cmd/pkgs/$GEOEXT_PACKAGE_NAME
 
 # 2. examples, resources & src copied from repo
 for RAW_CP_DIR in $RAW_CP_DIRS


### PR DESCRIPTION
On the gh-pages branch, we publish the locally created package BasiGX
which itself depends on the GeoExt package. Since in order to create
the BasiGX package, we had to add the GeoExt package, our local catalog
(`catalog.json` in the repo folder) also contains the description of
the GeoExt package.

When someone now tries to use the BasiGX package, that catalog is
queried. Since it also contains a reference to GeoExt (we simply
copied it over), the sencha cmd tries to resolve any GeoExt
dependencies from the BasiGX folder.

This commit ensures that we also publish the GeoExt package to the
BasiGX repo. In the future we may want to change the way we advertize
our catalog. See the TODO in the `update-gh-pages.sh`-file.