### PR TITLE
Added missing viewModel requires

### DIFF
--- a/src/view/button/AddWms.js
+++ b/src/view/button/AddWms.js
@@ -27,6 +27,7 @@ Ext.define("BasiGX.view.button.AddWms", {
 
     requires: [
         'Ext.window.Window',
+        'Ext.app.ViewModel',
         'BasiGX.view.form.AddWms',
         'BasiGX.util.Animate'
     ],

--- a/src/view/button/CoordinateTransform.js
+++ b/src/view/button/CoordinateTransform.js
@@ -27,6 +27,7 @@ Ext.define("BasiGX.view.button.CoordinateTransform", {
 
     requires: [
         'Ext.window.Window',
+        'Ext.app.ViewModel',
         'BasiGX.view.form.CoordinateTransform',
         'BasiGX.util.Animate'
     ],

--- a/src/view/button/Help.js
+++ b/src/view/button/Help.js
@@ -25,7 +25,8 @@ Ext.define("BasiGX.view.button.Help", {
     xtype: 'basigx-button-help',
 
     requires: [
-        'BasiGX.ux.ContextSensitiveHelp'
+        'BasiGX.ux.ContextSensitiveHelp',
+        'Ext.app.ViewModel'
     ],
 
     /**

--- a/src/view/button/Hsi.js
+++ b/src/view/button/Hsi.js
@@ -23,6 +23,9 @@
 Ext.define("BasiGX.view.button.Hsi", {
     extend: "Ext.Button",
     xtype: 'basigx-button-hsi',
+    requires: [
+        'Ext.app.ViewModel'
+    ],
 
     /**
      *

--- a/src/view/button/Measure.js
+++ b/src/view/button/Measure.js
@@ -25,7 +25,8 @@ Ext.define("BasiGX.view.button.Measure", {
     xtype: 'basigx-button-measure',
 
     requires: [
-        "BasiGX.util.Layer"
+        "BasiGX.util.Layer",
+        "Ext.app.ViewModel"
     ],
 
    /**

--- a/src/view/button/Permalink.js
+++ b/src/view/button/Permalink.js
@@ -26,6 +26,7 @@ Ext.define("BasiGX.view.button.Permalink", {
 
     requires: [
         'Ext.window.Window',
+        'Ext.app.ViewModel',
         'BasiGX.view.form.Permalink',
         'BasiGX.util.Animate',
         'BasiGX.util.Application'

--- a/src/view/button/ToggleLegend.js
+++ b/src/view/button/ToggleLegend.js
@@ -23,6 +23,9 @@
 Ext.define("BasiGX.view.button.ToggleLegend", {
     extend: "Ext.Button",
     xtype: 'basigx-button-togglelegend',
+    requires: [
+        'Ext.app.ViewModel'
+    ],
 
     /**
      *

--- a/src/view/button/ZoomIn.js
+++ b/src/view/button/ZoomIn.js
@@ -23,6 +23,9 @@
 Ext.define("BasiGX.view.button.ZoomIn", {
     extend: "Ext.Button",
     xtype: 'basigx-button-zoomin',
+    requires: [
+        'Ext.app.ViewModel'
+    ],
 
     /**
      *

--- a/src/view/button/ZoomOut.js
+++ b/src/view/button/ZoomOut.js
@@ -23,6 +23,9 @@
 Ext.define("BasiGX.view.button.ZoomOut", {
     extend: "Ext.Button",
     xtype: 'basigx-button-zoomout',
+    requires: [
+        'Ext.app.ViewModel'
+    ],
 
     /**
      *

--- a/src/view/button/ZoomToExtent.js
+++ b/src/view/button/ZoomToExtent.js
@@ -24,7 +24,10 @@ Ext.define("BasiGX.view.button.ZoomToExtent", {
     extend: "Ext.Button",
     xtype: 'basigx-button-zoomtoextent',
 
-    requires: ['BasiGX.util.Application'],
+    requires: [
+        'BasiGX.util.Application',
+        'Ext.app.ViewModel'
+    ],
 
     /**
      *

--- a/src/view/form/AddWms.js
+++ b/src/view/form/AddWms.js
@@ -25,7 +25,8 @@ Ext.define("BasiGX.view.form.AddWms", {
     xtype: 'basigx-form-addwms',
 
     requires: [
-        'Ext.button.Button'
+        'Ext.button.Button',
+        'Ext.app.ViewModel'
     ],
 
     viewModel: {

--- a/src/view/form/CoordinateTransform.js
+++ b/src/view/form/CoordinateTransform.js
@@ -25,7 +25,8 @@ Ext.define("BasiGX.view.form.CoordinateTransform", {
     xtype: 'basigx-form-coordinatetransform',
 
     requires: [
-        'Ext.button.Button'
+        'Ext.button.Button',
+        'Ext.app.ViewModel'
     ],
 
     viewModel: {

--- a/src/view/form/Permalink.js
+++ b/src/view/form/Permalink.js
@@ -26,7 +26,8 @@ Ext.define("BasiGX.view.form.Permalink", {
     xtype: 'basigx-form-permalink',
 
     requires: [
-        'Ext.button.Button'
+        'Ext.button.Button',
+        'Ext.app.ViewModel'
     ],
 
     viewModel: {

--- a/src/view/form/Print.js
+++ b/src/view/form/Print.js
@@ -26,6 +26,7 @@ Ext.define("BasiGX.view.form.Print", {
 
     requires: [
         "Ext.window.Toast",
+        "Ext.app.ViewModel",
         "Ext.form.action.StandardSubmit",
 
         "BasiGX.util.Layer",

--- a/src/view/panel/LayerSetChooser.js
+++ b/src/view/panel/LayerSetChooser.js
@@ -38,7 +38,8 @@ Ext.define("BasiGX.view.panel.LayerSetChooser", {
     xtype: "basigx-panel-layersetchooser",
 
     requires: [
-        "BasiGX.view.view.LayerSet"
+        "BasiGX.view.view.LayerSet",
+        "Ext.app.ViewModel"
     ],
 
     viewModel: {

--- a/src/view/panel/LegendTree.js
+++ b/src/view/panel/LegendTree.js
@@ -25,7 +25,8 @@ Ext.define("BasiGX.view.panel.LegendTree", {
     xtype: "basigx-panel-legendtree",
 
     requires: [
-        'BasiGX.ux.RowExpanderWithComponents'
+        'BasiGX.ux.RowExpanderWithComponents',
+        'Ext.app.ViewModel'
     ],
 
     viewModel: {

--- a/src/view/panel/MapContainer.js
+++ b/src/view/panel/MapContainer.js
@@ -28,6 +28,7 @@ Ext.define("BasiGX.view.panel.MapContainer", {
 
     requires: [
         "Ext.dom.Query",
+        "Ext.app.ViewModel",
         "GeoExt.data.store.LayersTree",
         "GeoExt.component.OverviewMap",
 

--- a/src/view/panel/Menu.js
+++ b/src/view/panel/Menu.js
@@ -26,7 +26,8 @@ Ext.define("BasiGX.view.panel.Menu", {
     xtype: "basigx-panel-menu",
 
     requires: [
-        "Ext.layout.container.Accordion"
+        "Ext.layout.container.Accordion",
+        "Ext.app.ViewModel"
     ],
 
     viewModel: {


### PR DESCRIPTION
Requires of `Ext.app.ViewModel` have been added to enable production builds on modern toolkits