### PR TITLE
Sort apps, formats and layouts alphabetically

### DIFF
--- a/src/view/form/Print.js
+++ b/src/view/form/Print.js
@@ -103,6 +103,7 @@ Ext.define("BasiGX.view.form.Print", {
                     Ext.each(records, function(rec){
                         rawValues.push(rec.data);
                     });
+                    Ext.Array.sort(rawValues);
                     this.down('combo[name=appCombo]').setStore(rawValues);
                 },
                 scope: this
@@ -388,6 +389,7 @@ Ext.define("BasiGX.view.form.Print", {
     addFormatCombo: function(provider){
         var fs = this.down('fieldset[name=generic-fieldset]');
         var formatStore = provider.capabilityRec.get('formats');
+        Ext.Array.sort(formatStore);
         var formatCombo = {
             xtype: 'combo',
             name: 'format',
@@ -407,6 +409,7 @@ Ext.define("BasiGX.view.form.Print", {
     addLayoutCombo: function(provider){
         var fs = this.down('fieldset[name=generic-fieldset]');
         var layoutStore = provider.capabilityRec.layouts();
+        layoutStore.sort('name', 'ASC');
         var layoutCombo = {
             xtype: 'combo',
             name: 'layout',


### PR DESCRIPTION
This PR suggest that the print-combos for `apps`, `formats` and `layouts` are sorted alphabetically in ascending order.

I decided against configurabillity, since I cannot imagine a case where we want to have descending order.

The methods used to sort are diffenrent, as `apps` and `formats` are plain arrays, while `layouts()` actually gives us a store. The store can be soreted against any field of `GeoExt.data.model.print.Layout`, useful in our case s the name.

Please review and merge at your own will.