### PR TITLE
Read layer properties for hovering from fields

### DIFF
--- a/src/plugin/Hover.js
+++ b/src/plugin/Hover.js
@@ -24,7 +24,23 @@ Ext.define('BasiGX.plugin.Hover', {
 
     inheritableStatics: {
         HOVER_OVERLAY_IDENTIFIER_KEY: 'name',
-        HOVER_OVERLAY_IDENTIFIER_VALUE: 'featureinfooverlay'
+        HOVER_OVERLAY_IDENTIFIER_VALUE: 'featureinfooverlay',
+
+        /**
+         * The property of a layer that holds a boolean value which indicates
+         * whether this layer qualifies for hovering.
+         *
+         * @type {String}
+         */
+        LAYER_HOVERABLE_PROPERTY_NAME: 'hoverable',
+
+        /**
+         * The property of a layer that holds a string value which indicates,
+         * which field of the layer shall be shown when hovering.
+         *
+         * @type {String}
+         */
+        LAYER_HOVERFIELD_PROPERTY_NAME: 'hoverfield'
     },
 
     config: {
@@ -194,6 +210,7 @@ Ext.define('BasiGX.plugin.Hover', {
        var map = mapComponent.getMap();
        var mapView = map.getView();
        var pixel = evt.pixel;
+       var hoverableProp = BasiGX.plugin.Hover.LAYER_HOVERABLE_PROPERTY_NAME;
        var hoverLayers = [];
        var hoverFeatures = [];
 
@@ -203,7 +220,7 @@ Ext.define('BasiGX.plugin.Hover', {
            var source = layer.getSource();
            var resolution = mapView.getResolution();
            var projCode = mapView.getProjection().getCode();
-           var hoverable = layer.get('hoverable');
+           var hoverable = layer.get(hoverableProp);
 
            // a layer will NOT be requested for hovering if there is a
            // "hoverable" property set to false. If this property is not set
@@ -272,12 +289,13 @@ Ext.define('BasiGX.plugin.Hover', {
     *
     */
    hoverLayerFilter: function(candidate) {
-       if(candidate.get('hoverable') ||
-           candidate.get('type') === 'WFSCluster'){
+       var hoverableProp = BasiGX.plugin.Hover.LAYER_HOVERABLE_PROPERTY_NAME;
+       if(candidate.get(hoverableProp) ||
+               candidate.get('type') === 'WFSCluster'){
            return true;
        } else {
            return false;
-      }
+       }
    },
 
    /**
@@ -339,10 +357,11 @@ Ext.define('BasiGX.plugin.Hover', {
     */
    getToolTipHtml: function(layers, features){
        var innerHtml = '';
+       var hoverfieldProp = BasiGX.plugin.Hover.LAYER_HOVERFIELD_PROPERTY_NAME;
 
        Ext.each(features, function(feat){
            var layer = feat.get('layer');
-           var hoverfield = layer.get('hoverfield');
+           var hoverfield = layer.get(hoverfieldProp);
 
            // fallback if hoverfield is not configured
            if(!hoverfield) {

--- a/src/util/ConfigParser.js
+++ b/src/util/ConfigParser.js
@@ -606,13 +606,28 @@ Ext.define('BasiGX.util.ConfigParser', {
                 treeColor: layer.treeColor,
                 routingId: layer.id || null,
                 olStyle: layer.olStyle || null,
-                hoverable: layer.hoverable || !!layer.hoverField,
-                hoverField: layer.hoverField,
+                // TODO we should get rid of `topic`
                 topic: layer.topic || layer.hoverField || null,
                 source: source,
                 type: layer.type,
                 featureType: layer.layers
             };
+
+            // We don't require the hover plugin class to allow for smaller
+            // builds
+            if ('plugin' in BasiGX && 'Hover' in BasiGX.plugin) {
+                var hoverCls = BasiGX.plugin.Hover;
+                var hoverableProp = hoverCls.LAYER_HOVERABLE_PROPERTY_NAME;
+                var hoverfieldProp = hoverCls.LAYER_HOVERFIELD_PROPERTY_NAME;
+                var shallHover = false;
+                if (hoverableProp in layer) {
+                    shallHover = layer[hoverableProp];
+                } else {
+                    shallHover = !!layer[hoverfieldProp];
+                }
+                olLayerConfig[hoverableProp] = shallHover;
+                olLayerConfig[hoverfieldProp] = layer[hoverfieldProp];
+            }
 
             // TODO Refactor ... Do we need an icon or a color...
             if (layer.type === "WFSCluster") {

--- a/test/spec/plugin/Hover.test.js
+++ b/test/spec/plugin/Hover.test.js
@@ -1,6 +1,7 @@
 Ext.Loader.syncRequire(['BasiGX.plugin.Hover', 'BasiGX.view.component.Map']);
 
 describe('BasiGX.plugin.Hover', function() {
+
     describe('Basics', function() {
         it('is defined', function() {
             expect(BasiGX.plugin.Hover).to.not.be(undefined);
@@ -10,6 +11,116 @@ describe('BasiGX.plugin.Hover', function() {
             expect(plugin).to.be.a(BasiGX.plugin.Hover);
         });
     });
+
+    describe('Static properties', function() {
+        describe('they are defined for the base plugin', function(){
+            it('works for #HOVER_OVERLAY_IDENTIFIER_KEY', function(){
+                var prop = BasiGX.plugin.Hover.HOVER_OVERLAY_IDENTIFIER_KEY;
+                expect(prop).to.not.be(undefined);
+            });
+            it('works for #HOVER_OVERLAY_IDENTIFIER_VALUE', function(){
+                var prop = BasiGX.plugin.Hover.HOVER_OVERLAY_IDENTIFIER_VALUE;
+                expect(prop).to.not.be(undefined);
+            });
+            it('works for #LAYER_HOVERABLE_PROPERTY_NAME', function(){
+                var prop = BasiGX.plugin.Hover.LAYER_HOVERABLE_PROPERTY_NAME;
+                expect(prop).to.not.be(undefined);
+            });
+            it('works for #LAYER_HOVERFIELD_PROPERTY_NAME', function(){
+                var prop = BasiGX.plugin.Hover.LAYER_HOVERFIELD_PROPERTY_NAME;
+                expect(prop).to.not.be(undefined);
+            });
+        });
+        describe('they are inherited for subclasses', function() {
+            var ParentClass = BasiGX.plugin.Hover;
+            var ExtendedClass = null;
+            beforeEach(function(){
+                ExtendedClass = Ext.define('TestExtendHover', {
+                    extend: 'BasiGX.plugin.Hover',
+                    alias: 'plugin.test-extend-hover',
+                    pluginId: 'test-hover'
+                });
+            });
+            afterEach(function() {
+                Ext.undefine('TestExtendHover');
+                ExtendedClass = null;
+            });
+            it('works for #HOVER_OVERLAY_IDENTIFIER_KEY', function(){
+                var originalProp = ParentClass.HOVER_OVERLAY_IDENTIFIER_KEY;
+                var prop = ExtendedClass.HOVER_OVERLAY_IDENTIFIER_KEY;
+                expect(prop).to.not.be(undefined);
+                expect(prop).to.be(originalProp);
+            });
+            it('works for #HOVER_OVERLAY_IDENTIFIER_VALUE', function(){
+                var originalProp = ParentClass.HOVER_OVERLAY_IDENTIFIER_VALUE;
+                var prop = ExtendedClass.HOVER_OVERLAY_IDENTIFIER_VALUE;
+                expect(prop).to.not.be(undefined);
+                expect(prop).to.be(originalProp);
+            });
+            it('works for #LAYER_HOVERABLE_PROPERTY_NAME', function(){
+                var originalProp = ParentClass.LAYER_HOVERABLE_PROPERTY_NAME;
+                var prop = ExtendedClass.LAYER_HOVERABLE_PROPERTY_NAME;
+                expect(prop).to.not.be(undefined);
+                expect(prop).to.be(originalProp);
+            });
+            it('works for #LAYER_HOVERFIELD_PROPERTY_NAME', function(){
+                var originalProp = ParentClass.LAYER_HOVERFIELD_PROPERTY_NAME;
+                var prop = ExtendedClass.LAYER_HOVERFIELD_PROPERTY_NAME;
+                expect(prop).to.not.be(undefined);
+                expect(prop).to.be(originalProp);
+            });
+        });
+        describe('they can be overridden for subclasses', function() {
+            var ParentClass = BasiGX.plugin.Hover;
+            var ExtendedClass = null;
+            beforeEach(function(){
+                ExtendedClass = Ext.define('TestExtendHover', {
+                    extend: 'BasiGX.plugin.Hover',
+                    alias: 'plugin.test-extend-hover',
+                    pluginId: 'test-hover',
+                    inheritableStatics: {
+                        HOVER_OVERLAY_IDENTIFIER_KEY: 'a',
+                        HOVER_OVERLAY_IDENTIFIER_VALUE: 'b',
+                        LAYER_HOVERABLE_PROPERTY_NAME: 'c',
+                        LAYER_HOVERFIELD_PROPERTY_NAME: 'd'
+                    }
+                });
+            });
+            afterEach(function() {
+                Ext.undefine('TestExtendHover');
+                ExtendedClass = null;
+            });
+            it('works for #HOVER_OVERLAY_IDENTIFIER_KEY', function(){
+                var originalProp = ParentClass.HOVER_OVERLAY_IDENTIFIER_KEY;
+                var prop = ExtendedClass.HOVER_OVERLAY_IDENTIFIER_KEY;
+                expect(prop).to.not.be(undefined);
+                expect(prop).to.not.be(originalProp);
+                expect(prop).to.be('a');
+            });
+            it('works for #HOVER_OVERLAY_IDENTIFIER_VALUE', function(){
+                var originalProp = ParentClass.HOVER_OVERLAY_IDENTIFIER_VALUE;
+                var prop = ExtendedClass.HOVER_OVERLAY_IDENTIFIER_VALUE;
+                expect(prop).to.not.be(undefined);
+                expect(prop).to.not.be(originalProp);
+                expect(prop).to.be('b');
+            });
+            it('works for #LAYER_HOVERABLE_PROPERTY_NAME', function(){
+                var originalProp = ParentClass.LAYER_HOVERABLE_PROPERTY_NAME;
+                var prop = ExtendedClass.LAYER_HOVERABLE_PROPERTY_NAME;
+                expect(prop).to.not.be(undefined);
+                expect(prop).to.not.be(originalProp);
+                expect(prop).to.be('c');
+            });
+            it('works for #LAYER_HOVERFIELD_PROPERTY_NAME', function(){
+                var originalProp = ParentClass.LAYER_HOVERFIELD_PROPERTY_NAME;
+                var prop = ExtendedClass.LAYER_HOVERFIELD_PROPERTY_NAME;
+                expect(prop).to.not.be(undefined);
+                expect(prop).to.not.be(originalProp);
+                expect(prop).to.be('d');
+            });
+        });
+    });
+
     describe('Usage as plugin for BasiGX.view.component.Map', function() {
         var plugin;
         var mapComponent;
@@ -35,6 +146,7 @@ describe('BasiGX.plugin.Hover', function() {
             expect(plugin.getCmp()).to.be(mapComponent);
         });
     });
+
     describe('Configuration options', function(){
         var div;
         var plugin;
@@ -153,4 +265,5 @@ describe('BasiGX.plugin.Hover', function() {
             });
         });
     });
+
 });

--- a/test/spec/util/ConfigParser.test.js
+++ b/test/spec/util/ConfigParser.test.js
@@ -167,8 +167,12 @@ describe('BasiGX.util.ConfigParser', function() {
                     "ENT=true&LAYERS=OSM-WMS&TILED=true&WIDTH=256&HEIGHT=256&" +
                     "CRS=EPSG%3A3857&STYLES=&BBOX=978393.9620502554%2C7000408" +
                     ".798469583%2C983285.9318605067%2C7005300.768279834",
-                topic: false,
-                visibility: false
+                topic: false, // TODO we should get rid of `topic`
+                visibility: false,
+                // this is our 'standard' for hover-enabled layers, both
+                // `hoverable` and `hoverfield` set
+                hoverable: true,
+                hoverfield: 'HumptyDumpty'
             });
         });
         afterEach(function() {
@@ -226,6 +230,50 @@ describe('BasiGX.util.ConfigParser', function() {
             var retVal = BasiGX.util.ConfigParser.
                 convertStringToNumericArray("float", "3.1415,2.00124,1.512172");
             expect(retVal).to.be.eql([3.1415,2.00124,1.512172]);
+        });
+
+        describe('hoverable and hoverfield configuration', function(){
+            it('reads out and respects hoverable and hoverfield (enabled)',
+                function(){
+                    expect(layer.get('hoverable')).to.be(true);
+                    expect(layer.get('hoverfield')).to.be('HumptyDumpty');
+                }
+            );
+            it('reads out and respects hoverable and hoverfield (disabled)',
+                function(){
+                    var layer2 = BasiGX.util.ConfigParser.createLayer({
+                        name: "Only hoverfield no hoverable",
+                        type: "TileWMS",
+                        // this is our 'standard' for hover-disabled layers,
+                        // both `hoverable` is false and `hoverfield` set
+                        hoverable: false,
+                        hoverfield: null
+                    });
+                    expect(layer2.get('hoverable')).to.be(false);
+                    expect(layer2.get('hoverfield')).to.be(null);
+                }
+            );
+            it('reads out and respects hoverfield (not configured)', function(){
+                var layer3 = BasiGX.util.ConfigParser.createLayer({
+                    name: "Neither hoverfield nor hoverable",
+                    type: "TileWMS"
+                    // what happens if we do not have the props at all?
+                });
+                expect(layer3.get('hoverable')).to.be(false);
+                expect(layer3.get('hoverfield')).to.be(undefined);
+            });
+            it('reads out and respects hoverfield (only hoverfield)',
+                function(){
+                    var layer4 = BasiGX.util.ConfigParser.createLayer({
+                        name: "Only hoverfield no hoverable",
+                        type: "TileWMS",
+                        // what happens if only a `hoverfield` is set
+                        hoverfield: 'HumptyDumpty'
+                    });
+                    expect(layer4.get('hoverable')).to.be(true);
+                    expect(layer4.get('hoverfield')).to.be('HumptyDumpty');
+                }
+            );
         });
     });
 });


### PR DESCRIPTION
This makes it easier for applications to determine the fields
which are used to controll hovering. If, for example you want
to disable hovering of a layer temporarily, you can now just
determine the correct property, and then set the value for it
to `false`.

This commit also adds basic tests that document the behaviour.

Once this is merged, we cannot 100% guarantee, that `hoverfield`
and `hoverable` properties exist on our layer instances.
Applications should now use the static fields from the
hoverplugin.

If an application has the need for different fields for hovering
the plugin class can be extended and the statics can be reassigned
to match the new environment. See the tests for an example of
this.