### PR TITLE
Fixed coordinatetransform for ol-production builds

### DIFF
--- a/src/view/form/CoordinateTransform.js
+++ b/src/view/form/CoordinateTransform.js
@@ -231,7 +231,8 @@ Ext.define("BasiGX.view.form.CoordinateTransform", {
             fieldSets = me.query('fieldset'),
             transformvectorlayer = BasiGX.util.Layer.getLayerByName(
                 'transformvectorlayer'),
-            isOlEvt = evtOrBtnOrArray instanceof ol.MapBrowserPointerEvent,
+            isOlEvt = Ext.isArray(evtOrBtnOrArray.coordinate) &&
+                evtOrBtnOrArray.coordinate.length === 2,
             isCoordArray = Ext.isArray(evtOrBtnOrArray) &&
                 evtOrBtnOrArray.length === 2,
             coords = [],


### PR DESCRIPTION
Changed the detection of coordinates in events as `ol.MapBrowserPointerEvent` is not available in production builds of ol3