### PR TITLE
Removed the incorrect mapping from startbbox to restricted extent

### DIFF
--- a/src/util/ConfigParser.js
+++ b/src/util/ConfigParser.js
@@ -422,8 +422,6 @@ Ext.define('BasiGX.util.ConfigParser', {
                   zoom: config.startZoom || 2,
                   maxResolution: config.maxResolution,
                   minResolution: config.minResolution,
-                  extent: me.convertStringToNumericArray(
-                      'float', config.startBbox),
                   projection: config.mapConfig.projection || 'EPSG:3857',
                   units: 'm',
                   resolutions: me.convertStringToNumericArray(


### PR DESCRIPTION
Like the title says, i removed the invalid mapping from startbbox to (restricted) extent.
Use center and zoom to set your maps initial start appearance