### PR TITLE
Fixed layerorder while parsing shogun context

### DIFF
--- a/src/util/ConfigParser.js
+++ b/src/util/ConfigParser.js
@@ -769,7 +769,7 @@ Ext.define('BasiGX.util.ConfigParser', {
                     mergedNode.expanded = node.expanded;
 
                     if (parent) {
-                        parent.getLayers().push(me.createLayer(mergedNode));
+                        parent.getLayers().getArray().unshift(me.createLayer(mergedNode));
                     } else {
                         me.layerArray.push(me.createLayer(mergedNode));
                     }


### PR DESCRIPTION
This fixes the ordering of layers that are contained in folders when using SHOGun 1 as backend serving the application context