### PR TITLE
Use attributes default values from print-servlet

### DIFF
--- a/src/view/form/Print.js
+++ b/src/view/form/Print.js
@@ -548,6 +548,7 @@ Ext.define("BasiGX.view.form.Print", {
             xtype: 'textfield',
             name: attributeRec.get('name'),
             fieldLabel: attributeRec.get('name'),
+            value: attributeRec.get('default'),
             allowBlank: false
         };
     },


### PR DESCRIPTION
MapFish-Print 3.4. supports default values for attributes
so we use it.