### PR TITLE
Folders visible and expanded state

### DIFF
--- a/src/util/ConfigParser.js
+++ b/src/util/ConfigParser.js
@@ -746,6 +746,7 @@ Ext.define('BasiGX.util.ConfigParser', {
                 } else if (node.leaf === false) {
                     // handling folders
                     var folder = me.createFolder(node);
+                    folder.set('expanded', node.expanded);
 
                     if (parent) {
                         parent.getLayers().push(folder);

--- a/src/util/ConfigParser.js
+++ b/src/util/ConfigParser.js
@@ -749,6 +749,7 @@ Ext.define('BasiGX.util.ConfigParser', {
 
                     if (parent) {
                         parent.getLayers().push(folder);
+                        folder.set('parentFolder', parent);
                     } else {
                         me.layerArray.push(folder);
                     }
@@ -770,6 +771,14 @@ Ext.define('BasiGX.util.ConfigParser', {
 
                     if (parent) {
                         parent.getLayers().getArray().unshift(me.createLayer(mergedNode));
+                        if (node.checked) {
+                            parent.set('visible', true);
+                            var nextParent = parent.get('parentFolder');
+                            while (nextParent) {
+                                nextParent.set('visible', true);
+                                nextParent = nextParent.get('parentFolder');
+                            }
+                        }
                     } else {
                         me.layerArray.push(me.createLayer(mergedNode));
                     }


### PR DESCRIPTION
This PR fixes an issue with SHOGun 1 appContext: 
Folders that contain checked / visible layers will now also get checked and set to visible. The expanded state of a node needs to be propagated to get used in the treepanel again to correctly show the state of the gizmo treepanel.