### PR TITLE
reenable cross origin

### DIFF
--- a/src/util/ConfigParser.js
+++ b/src/util/ConfigParser.js
@@ -536,7 +536,7 @@ Ext.define('BasiGX.util.ConfigParser', {
 
                 cfg = {
                     url: config.url,
-//                    crossOrigin: 'Anonymous',
+                    crossOrigin: config.crossOrigin,
                     attributions: attributions,
                     params: {
                         LAYERS: config.layers,


### PR DESCRIPTION
This PR reenables the crossOrigin attribute on ol.layer.sources.
This has been commented out for no reason, now it gets set dependent on the layer config.