### PR TITLE
added tilegrid to tiled layers

### DIFF
--- a/src/util/ConfigParser.js
+++ b/src/util/ConfigParser.js
@@ -381,6 +381,8 @@ Ext.define('BasiGX.util.ConfigParser', {
 
     activeRouting: false,
 
+    appContext: null,
+
     statics: {
 
         /**
@@ -406,6 +408,7 @@ Ext.define('BasiGX.util.ConfigParser', {
             }
 
             config = context.data.merge;
+            me.appContext = config;
 
             // TODO Refactor
             if(window.location.hash.indexOf('center') > 0){
@@ -544,6 +547,16 @@ Ext.define('BasiGX.util.ConfigParser', {
                         VERSION: config.version || '1.1.1'
                     }
                 };
+
+                // set a tilegrid if needed
+                if (me.appContext && config.type === "TileWMS" ||
+                    config.type === "XYZ") {
+                        cfg.tileGrid = new ol.tilegrid.TileGrid({
+                            extent: map.getView().getProjection().getExtent(),
+                            resolutions: me.convertStringToNumericArray(
+                                'float', me.appContext.mapConfig.resolutions)
+                        });
+                }
 
                 if ((config.type === "TileWMS" ||
                      config.type === "WMS" ||


### PR DESCRIPTION
PR adds an ol.tilegrid to tiled layers, based on the maps extent and the given resolutions from appcontext. This is needed to avoid some kind of "shrinking" behaviour of tiles on certain zoom levels.