### PR TITLE
Fixing the order of sub-layer-folders

### DIFF
--- a/src/util/ConfigParser.js
+++ b/src/util/ConfigParser.js
@@ -787,7 +787,7 @@ Ext.define('BasiGX.util.ConfigParser', {
                     mergedNode.expanded = node.expanded;
 
                     if (parent) {
-                        parent.getLayers().getArray().unshift(me.createLayer(mergedNode));
+                        parent.getLayers().getArray().push(me.createLayer(mergedNode));
                         if (node.checked) {
                             parent.set('visible', true);
                             var nextParent = parent.get('parentFolder');


### PR DESCRIPTION
This PR fixes the order of layerfolders that are contained in a parent folder. This is only relevant when using an application with SHOGun1 appcontext. Its the missing piece of this already merged PR:
https://github.com/terrestris/BasiGX/pull/52