### PR TITLE
Be more cautious when creating a tilegrid

### DIFF
--- a/src/util/ConfigParser.js
+++ b/src/util/ConfigParser.js
@@ -549,8 +549,11 @@ Ext.define('BasiGX.util.ConfigParser', {
                 };
 
                 // set a tilegrid if needed
-                if (me.appContext && config.type === "TileWMS" ||
-                    config.type === "XYZ") {
+                if (me.appContext &&
+                    me.appContext.mapConfig &&
+                    me.appContext.mapConfig.resolutions &&
+                    (config.type === "TileWMS" || config.type === "XYZ") &&
+                    config.tileGrid === undefined) {
                         cfg.tileGrid = new ol.tilegrid.TileGrid({
                             extent: map.getView().getProjection().getExtent(),
                             resolutions: me.convertStringToNumericArray(
@@ -826,8 +829,14 @@ Ext.define('BasiGX.util.ConfigParser', {
          * @returns {Array} arr - the parsed array
          */
         convertStringToNumericArray: function(type, string) {
-            if (Ext.isEmpty(string) || Ext.isEmpty(type) ||
-                Ext.isArray(string)) {
+            if (Ext.isEmpty(string) || Ext.isEmpty(type)) {
+                Ext.log.warn('Cannot convert string to numeric array. Passed ' +
+                    'type was: ' + type + '; Passed string was: ' + string);
+                return string;
+            }
+            if (Ext.isArray(string)) {
+                Ext.log.warn('Passed array instead of string to convert to ' +
+                    ' array of ' + type + '. Returning input array unchanged.');
                 return string;
             }
             var arr = [];


### PR DESCRIPTION
Since 71e66d5ee6ef7bd70f94538f998ff3df3fb3eeba we overwrite a layers `tileGrid` configuration without checking if …

1. … such a `tileGrid` was already defined in the configuration
2. … the needed inputs for the generation are defined in the `mapConfig`

For 1. we should respect what we were given, and for 2. we should check if the key `resolutions` exists in `appContext.mapConfig`.

Additionally we should really be logging that something unexpected happened in the method `convertStringToNumericArray` instead of silently returning the input.

This is a follow-up for PR #62.