### PR TITLE
Hiding the redline vector layer in the layertree

### DIFF
--- a/src/view/container/Redlining.js
+++ b/src/view/container/Redlining.js
@@ -185,6 +185,8 @@ Ext.define("BasiGX.view.container.Redlining", {
        var me = this;
        var mapComponent = Ext.ComponentQuery.query('gx_component_map')[0];
        var map = mapComponent.getMap();
+       var displayInLayerSwitcherKey = BasiGX.util.Layer.
+           KEY_DISPLAY_IN_LAYERSWITCHER;
 
        if (!me.redliningVectorLayer) {
            me.redlineFeatures = new ol.Collection();
@@ -192,6 +194,7 @@ Ext.define("BasiGX.view.container.Redlining", {
                source: new ol.source.Vector({features: me.redlineFeatures}),
                style: me.getRedlineStyleFunction()
            });
+           me.redliningVectorLayer.set(displayInLayerSwitcherKey, false);
            map.addLayer(me.redliningVectorLayer);
        }
 


### PR DESCRIPTION
Usually, the redline vector layer should be hidden, so we set the specific property on instanciaton.
The treestore still needs the filter respecting this property for the filtering to work