### PR TITLE
Require package 'ext-ux-colorpick', not the generic 'ux' package

### DIFF
--- a/ci/create-sencha-package.sh
+++ b/ci/create-sencha-package.sh
@@ -27,6 +27,9 @@ done
 # Switch to the now properly filled directory in the sencha workspace
 cd $BASIGX_IN_SENCHA_WS_FOLDER
 
+# Debug output: list all available packages
+$SENCHA_CMD package list
+
 # Remove BasiGX package (if any)
 $SENCHA_CMD package remove $BASIGX_PACKAGE_NAME
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "framework": "ext",
     "requires": [
         "GeoExt",
-        "ux"
+        "ext-ux-colorpick"
     ],
     "toolkit": "classic",
     "theme": "theme-neptune",


### PR DESCRIPTION
This is an attempt to fix #77, and also a little shot in the dark. I basically want to see if package building still succeeds and whether (after a merge of this PR) clients can again do `sencha package get BasiGX`.
