### PR TITLE
Revert "Require 'ext-ux-colorpick', instead of generic 'ux'"

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "framework": "ext",
     "requires": [
         "GeoExt",
-        "ext-ux-colorpick"
+        "ux"
     ],
     "toolkit": "classic",
     "theme": "theme-neptune",


### PR DESCRIPTION
This reverts commit fecd6bc8a2c52db57868affc03658a59ec283738.

See also https://github.com/terrestris/BasiGX/issues/77#issuecomment-210328041 with the above commit things got worse :cry::

```
$ sencha package get BasiGX
Sencha Cmd v6.1.1.76
[INF] Getting package GeoExt/3.0.0
[INF] Package is already local: GeoExt/3.0.0
[INF] Got package GeoExt/3.0.0
[INF] Getting package ext-ux-colorpick/1.0.0.180
[ERR] Error downloading http://terrestris.github.io/BasiGX/cmd/pkgs/ext-ux-colorpick/1.0.0.180/ext-ux-colorpick.pkg
```

I think it's best to first revert the offending commit which changed the depency to `ext-ux-colorpick` and then look further into this.