### PR TITLE
Fixed bindings for properties that have no setter method

### DIFF
--- a/src/view/panel/GraphicPool.js
+++ b/src/view/panel/GraphicPool.js
@@ -125,6 +125,8 @@ Ext.define("BasiGX.view.panel.GraphicPool", {
             title: false,
             backendUrls: me.getBackendUrls()
         });
+        var viewModel = me.getViewModel();
+        var btnText = viewModel.get('chooseImageBtnText');
 
         me.items = [me.pictureView];
 
@@ -134,9 +136,7 @@ Ext.define("BasiGX.view.panel.GraphicPool", {
             name: 'file',
             width: 300,
             allowBlank: false,
-            bind: {
-                buttonText: '{chooseImageBtnText}'
-            }
+            buttonText: btnText
         },
         {
             xtype: 'splitter'

--- a/src/view/view/GraphicPool.js
+++ b/src/view/view/GraphicPool.js
@@ -39,10 +39,6 @@ Ext.define("BasiGX.view.view.GraphicPool", {
         }
     },
 
-    bind: {
-        emptyText: '{emptyStoreMsg}'
-    },
-
     /**
      *
      */
@@ -91,6 +87,9 @@ Ext.define("BasiGX.view.view.GraphicPool", {
      */
     initComponent : function() {
         var me = this;
+        var viewModel = me.getViewModel();
+        var emptyText = viewModel.get('emptyStoreMsg');
+        me.emptyText = emptyText;
 
         var store = Ext.create('Ext.data.Store', {
             sorters: 'fileName',


### PR DESCRIPTION
Removed invalid bindings for `buttonText` and `emptyText` as these have no setter methods