### PR TITLE
Use additional configs to determine map component dynamically

### DIFF
--- a/src/util/Animate.js
+++ b/src/util/Animate.js
@@ -17,7 +17,9 @@
  * @class BasiGX.util.Animate
  */
 Ext.define('BasiGX.util.Animate', {
-
+    requires: [
+        'BasiGX.util.Map'
+    ],
     statics: {
        shake: function(component, duration, amplitude){
            duration = duration || 200;
@@ -46,7 +48,7 @@ Ext.define('BasiGX.util.Animate', {
        },
 
        flashFeature: function(feature, duration) {
-           var map = Ext.ComponentQuery.query('gx_map')[0].getMap();
+           var map = BasiGX.util.Map.getMapComponent().getMap();
            var start = new Date().getTime();
            var listenerKey;
 
@@ -91,7 +93,7 @@ Ext.define('BasiGX.util.Animate', {
         * Useful e.g. when hovering clustered features to show their children
         */
        moveFeature: function(featureToMove, duration, pixel, style, doneFn) {
-           var map = Ext.ComponentQuery.query('gx_map')[0].getMap();
+           var map = BasiGX.util.Map.getMapComponent().getMap();
            var listenerKey;
 
            var geometry = featureToMove.getGeometry();

--- a/src/util/Application.js
+++ b/src/util/Application.js
@@ -26,9 +26,9 @@ Ext.define('BasiGX.util.Application', {
 
     statics: {
 
-        getAppContext: function(){
+        getAppContext: function(mapComponentXType){
             var mapComponent = Ext.ComponentQuery
-                .query('basigx-component-map')[0];
+                .query(mapComponentXType)[0];
 
             if(mapComponent && mapComponent.appContext){
                 return mapComponent.appContext.data.merge;
@@ -37,9 +37,9 @@ Ext.define('BasiGX.util.Application', {
             }
         },
 
-        getRoute: function(){
+        getRoute: function(mapComponentXType){
                 var mapComponent = Ext.ComponentQuery
-                    .query('basigx-component-map')[0];
+                    .query(mapComponentXType)[0];
                 var map = mapComponent.getMap();
                 var zoom = map.getView().getZoom();
                 var center = map.getView().getCenter().toString();

--- a/src/util/Application.js
+++ b/src/util/Application.js
@@ -27,8 +27,14 @@ Ext.define('BasiGX.util.Application', {
     statics: {
 
         getAppContext: function(mapComponentXType){
-            var mapComponent = Ext.ComponentQuery
-                .query(mapComponentXType)[0];
+            var mapComponent;
+
+            if (mapComponentXType) {
+                mapComponent = Ext.ComponentQuery.query(mapComponentXType)[0];
+            } else {
+                // fallback
+                mapComponent = Ext.ComponentQuery.query('basigx-component-map')[0];
+            }
 
             if(mapComponent && mapComponent.appContext){
                 return mapComponent.appContext.data.merge;
@@ -38,24 +44,30 @@ Ext.define('BasiGX.util.Application', {
         },
 
         getRoute: function(mapComponentXType){
-                var mapComponent = Ext.ComponentQuery
-                    .query(mapComponentXType)[0];
-                var map = mapComponent.getMap();
-                var zoom = map.getView().getZoom();
-                var center = map.getView().getCenter().toString();
-                var visibleLayers = BasiGX.util.Layer
-                    .getVisibleLayers(map);
-                var visibleLayerRoutingIds = [];
+            var mapComponent;
 
-                Ext.each(visibleLayers, function(layer){
-                    visibleLayerRoutingIds.push(layer.get('routingId'));
-                });
+            if (mapComponentXType) {
+                mapComponent = Ext.ComponentQuery.query(mapComponentXType)[0];
+            } else {
+                // fallback
+                mapComponent = Ext.ComponentQuery.query('basigx-component-map')[0];
+            }
+            var map = mapComponent.getMap();
+            var zoom = map.getView().getZoom();
+            var center = map.getView().getCenter().toString();
+            var visibleLayers = BasiGX.util.Layer
+                .getVisibleLayers(map);
+            var visibleLayerRoutingIds = [];
 
-                var hash = 'center/' + center +
-                           '|zoom/' + zoom +
-                           '|layers/' + visibleLayerRoutingIds.toString();
+            Ext.each(visibleLayers, function(layer){
+                visibleLayerRoutingIds.push(layer.get('routingId'));
+            });
 
-                return hash;
+            var hash = 'center/' + center +
+                       '|zoom/' + zoom +
+                       '|layers/' + visibleLayerRoutingIds.toString();
+
+            return hash;
         }
     }
 });

--- a/src/util/Application.js
+++ b/src/util/Application.js
@@ -22,19 +22,15 @@
  */
 Ext.define('BasiGX.util.Application', {
 
-    requires: ['BasiGX.util.Layer'],
+    requires: [
+        'BasiGX.util.Layer',
+        'BasiGX.util.Map'
+        ],
 
     statics: {
 
         getAppContext: function(mapComponentXType){
-            var mapComponent;
-
-            if (mapComponentXType) {
-                mapComponent = Ext.ComponentQuery.query(mapComponentXType)[0];
-            } else {
-                // fallback
-                mapComponent = Ext.ComponentQuery.query('basigx-component-map')[0];
-            }
+            var mapComponent = BasiGX.util.Map.getMapComponent(mapComponentXType);
 
             if(mapComponent && mapComponent.appContext){
                 return mapComponent.appContext.data.merge;
@@ -44,14 +40,7 @@ Ext.define('BasiGX.util.Application', {
         },
 
         getRoute: function(mapComponentXType){
-            var mapComponent;
-
-            if (mapComponentXType) {
-                mapComponent = Ext.ComponentQuery.query(mapComponentXType)[0];
-            } else {
-                // fallback
-                mapComponent = Ext.ComponentQuery.query('basigx-component-map')[0];
-            }
+            var mapComponent = BasiGX.util.Map.getMapComponent(mapComponentXType);
             var map = mapComponent.getMap();
             var zoom = map.getView().getZoom();
             var center = map.getView().getCenter().toString();

--- a/src/util/Layer.js
+++ b/src/util/Layer.js
@@ -22,7 +22,9 @@
  * @class BasiGX.util.Layer
  */
 Ext.define('BasiGX.util.Layer', {
-
+    requires: [
+        'BasiGX.util.Map'
+    ],
     statics: {
         KEY_DISPLAY_IN_LAYERSWITCHER: 'bp_displayInLayerSwitcher',
 
@@ -43,7 +45,7 @@ Ext.define('BasiGX.util.Layer', {
                 layers = collection.getArray ?
                     collection.getArray() : collection;
             } else {
-                var map = Ext.ComponentQuery.query('gx_map')[0].getMap();
+                var map = BasiGX.util.Map.getMapComponent().getMap();
                 layers = map.getLayers().getArray();
             }
 
@@ -89,7 +91,7 @@ Ext.define('BasiGX.util.Layer', {
                 layers = collection.getArray ?
                     collection.getArray() : collection;
             } else {
-                var map = Ext.ComponentQuery.query('gx_map')[0].getMap();
+                var map = BasiGX.util.Map.getMapComponent().getMap();
                 layers = map.getLayers().getArray();
             }
 

--- a/src/util/Map.js
+++ b/src/util/Map.js
@@ -86,6 +86,6 @@ Ext.define('BasiGX.util.Map', {
                 legendComponent = Ext.ComponentQuery.query('basigx-panel-legendtree')[0];
             }
             return legendComponent;
-        },
+        }
     }
 });

--- a/src/util/Map.js
+++ b/src/util/Map.js
@@ -39,6 +39,53 @@ Ext.define('BasiGX.util.Map', {
             var inchesPerMeter = 39.37;
 
             return res * mpu * inchesPerMeter * dpi;
-        }
+        },
+
+        /**
+         * Determine map component depending on provided xtype.
+         * If no xtype was specified, `basigx-component-map` component will be
+         * used as fallback. If this also could not be found, use the most
+         * common GeoExt map component `gx_map`.
+         * @param {String} mapCompXtype Provided map component xtype
+         * @return {Object} mapComponent
+         */
+        getMapComponent: function(mapCompXType){
+            var mapComponent;
+            if (mapCompXType) {
+                mapComponent = Ext.ComponentQuery.query(mapCompXType)[0];
+            }
+
+            //fallback to basigx map component
+            if (Ext.isEmpty(mapComponent)) {
+                mapComponent = Ext.ComponentQuery.query('basigx-component-map')[0];
+            }
+
+            //fallback to the most common GeoExt map component
+            if (Ext.isEmpty(mapComponent)) {
+                mapComponent = Ext.ComponentQuery.query('gx_map')[0];
+            }
+
+            return mapComponent;
+        },
+
+        /**
+         * Determine legendtree panel component depending on provided xtype.
+         * If no xtype was specified, `basigx-panel-legendtree` component will be
+         * used as fallback.
+         * @param {String} legendCompXType Provided map component xtype
+         * @return {Object} legendComponent
+         */
+        getLegendTreePanel: function(legendCompXType){
+            var legendComponent;
+
+            if (legendCompXType) {
+                legendComponent = Ext.ComponentQuery.query(legendCompXType)[0];
+            }
+            //fallback to basigx legendtree panel component
+            if (Ext.isEmpty(legendComponent)) {
+                legendComponent = Ext.ComponentQuery.query('basigx-panel-legendtree')[0];
+            }
+            return legendComponent;
+        },
     }
 });

--- a/src/view/button/Hsi.js
+++ b/src/view/button/Hsi.js
@@ -63,6 +63,12 @@ Ext.define("BasiGX.view.button.Hsi", {
     buttonPressed: true,
 
     /**
+     * Placeholder for the xtype of the map component (e.g. 'basigx-component-map').
+     * Will be used to be able to determine the map component dynamically
+     */
+    mapPanelXType: null,
+
+    /**
      *
      */
     config: {
@@ -97,7 +103,13 @@ Ext.define("BasiGX.view.button.Hsi", {
      *
      */
     setControlStatus: function(status){
-        var mapComponent = Ext.ComponentQuery.query('basigx-component-map')[0];
+        var me = this,
+            mapComponent = Ext.ComponentQuery.query(me.mapPanelXType)[0];
+
+        //fallback
+        if (Ext.isEmpty(mapComponent)) {
+            mapComponent = Ext.ComponentQuery.query('basigx-component-map')[0];
+        }
         mapComponent.setPointerRest(status);
     }
 });

--- a/src/view/button/Hsi.js
+++ b/src/view/button/Hsi.js
@@ -24,7 +24,8 @@ Ext.define("BasiGX.view.button.Hsi", {
     extend: "Ext.Button",
     xtype: 'basigx-button-hsi',
     requires: [
-        'Ext.app.ViewModel'
+        'Ext.app.ViewModel',
+        'BasiGX.util.Map'
     ],
 
     /**
@@ -63,15 +64,14 @@ Ext.define("BasiGX.view.button.Hsi", {
     buttonPressed: true,
 
     /**
-     * Placeholder for the xtype of the map component (e.g. 'basigx-component-map').
-     * Will be used to be able to determine the map component dynamically
-     */
-    mapPanelXType: null,
-
-    /**
      *
      */
     config: {
+        /**
+         * Placeholder for the xtype of the map component (e.g. 'basigx-component-map').
+         * Will be used to be able to determine the map component dynamically
+         */
+        mapPanelXType: null,
         handler: function() {
             this.buttonPressed = !this.buttonPressed;
             this.toggleButton();
@@ -103,13 +103,10 @@ Ext.define("BasiGX.view.button.Hsi", {
      *
      */
     setControlStatus: function(status){
-        var me = this,
-            mapComponent = Ext.ComponentQuery.query(me.mapPanelXType)[0];
+        var me = this;
+        var mapComponent;
 
-        //fallback
-        if (Ext.isEmpty(mapComponent)) {
-            mapComponent = Ext.ComponentQuery.query('basigx-component-map')[0];
-        }
+        mapComponent = BasiGX.util.Map.getMapComponent(me.getMapPanelXtype());
         mapComponent.setPointerRest(status);
     }
 });

--- a/src/view/button/Measure.js
+++ b/src/view/button/Measure.js
@@ -26,6 +26,7 @@ Ext.define("BasiGX.view.button.Measure", {
 
     requires: [
         "BasiGX.util.Layer",
+        "BasiGX.util.Map",
         "Ext.app.ViewModel"
     ],
 
@@ -141,7 +142,7 @@ Ext.define("BasiGX.view.button.Measure", {
             }),
             measureLayer;
 
-        me.map = Ext.ComponentQuery.query('gx_map')[0].getMap();
+        me.map = BasiGX.util.Map.getMapComponent().getMap();
 
         var btnText = (me.measureType === 'line' ? '{textline}' : '{textpoly}');
         me.setBind({

--- a/src/view/button/ToggleLegend.js
+++ b/src/view/button/ToggleLegend.js
@@ -52,17 +52,30 @@ Ext.define("BasiGX.view.button.ToggleLegend", {
     glyph: 'xf022@FontAwesome',
     html: '<i class="fa fa-list-alt fa-2x"></i>',
 
+    /**
+     * Placeholder for the xtype of the legend tree component
+     * (e.g. 'basigx-panel-legendtree').
+     * Will be used to be able to determine the component dynamically.
+     */
+    legendPanelXType: null,
+
     config: {
         handler: function(button){
-            // TODO refactor so this works even outside of the mapcontainer
-            var legendPanel = button.up("basigx-panel-mapcontainer")
-                .down('basigx-panel-legendtree');
-            if(legendPanel.getCollapsed()) {
-                legendPanel.expand();
-            } else {
-                legendPanel.collapse();
+            var me = this,
+                legendPanel = Ext.ComponentQuery.query(me.legendPanelXType)[0];
+
+            //fallback
+            if (Ext.isEmpty(legendPanel)) {
+                legendPanel = Ext.ComponentQuery.query('basigx-panel-legendtree')[0];
             }
-            button.blur();
+            if (legendPanel) {
+                if(legendPanel.getCollapsed()) {
+                    legendPanel.expand();
+                } else {
+                    legendPanel.collapse();
+                }
+                button.blur();
+            }
         }
     },
 

--- a/src/view/button/ToggleLegend.js
+++ b/src/view/button/ToggleLegend.js
@@ -24,7 +24,8 @@ Ext.define("BasiGX.view.button.ToggleLegend", {
     extend: "Ext.Button",
     xtype: 'basigx-button-togglelegend',
     requires: [
-        'Ext.app.ViewModel'
+        'Ext.app.ViewModel',
+        'BasiGX.util.Map'
     ],
 
     /**
@@ -52,22 +53,18 @@ Ext.define("BasiGX.view.button.ToggleLegend", {
     glyph: 'xf022@FontAwesome',
     html: '<i class="fa fa-list-alt fa-2x"></i>',
 
-    /**
-     * Placeholder for the xtype of the legend tree component
-     * (e.g. 'basigx-panel-legendtree').
-     * Will be used to be able to determine the component dynamically.
-     */
-    legendPanelXType: null,
-
     config: {
+        /**
+         * Placeholder for the xtype of the legendtree panel component
+         * (e.g. 'basigx-panel-legendtree').
+         * Will be used to be able to determine the component dynamically.
+         */
+        legendTreeXType: null,
         handler: function(button){
-            var me = this,
-                legendPanel = Ext.ComponentQuery.query(me.legendPanelXType)[0];
+            var me = this;
+            var legendPanel =
+                    BasiGX.util.Map.getLegendTreePanel(me.getLegendTreeXType());
 
-            //fallback
-            if (Ext.isEmpty(legendPanel)) {
-                legendPanel = Ext.ComponentQuery.query('basigx-panel-legendtree')[0];
-            }
             if (legendPanel) {
                 if(legendPanel.getCollapsed()) {
                     legendPanel.expand();

--- a/src/view/button/ZoomIn.js
+++ b/src/view/button/ZoomIn.js
@@ -69,7 +69,7 @@ Ext.define("BasiGX.view.button.ZoomIn", {
                 olMap = Ext.ComponentQuery.query('basigx-component-map')[0];
             }
 
-            olView = olMap.getView(),
+            olView = olMap.getView();
             zoom = ol.animation.zoom({
                 resolution: olView.getResolution(),
                 duration: 500

--- a/src/view/button/ZoomIn.js
+++ b/src/view/button/ZoomIn.js
@@ -24,7 +24,8 @@ Ext.define("BasiGX.view.button.ZoomIn", {
     extend: "Ext.Button",
     xtype: 'basigx-button-zoomin',
     requires: [
-        'Ext.app.ViewModel'
+        'Ext.app.ViewModel',
+        'BasiGX.util.Map'
     ],
 
     /**
@@ -66,7 +67,7 @@ Ext.define("BasiGX.view.button.ZoomIn", {
 
             //fallback
             if (Ext.isEmpty(olMap)) {
-                olMap = Ext.ComponentQuery.query('basigx-component-map')[0];
+                olMap = BasiGX.util.Map.getMapComponent();
             }
 
             olView = olMap.getView();

--- a/src/view/button/ZoomIn.js
+++ b/src/view/button/ZoomIn.js
@@ -43,6 +43,11 @@ Ext.define("BasiGX.view.button.ZoomIn", {
     },
 
     /**
+     * The OL3 map this button is bounded to
+     */
+    olMap: null,
+
+    /**
      * The icons the button should use.
      * Classic Toolkit uses glyphs, modern toolkit uses html
      */
@@ -54,9 +59,18 @@ Ext.define("BasiGX.view.button.ZoomIn", {
      */
     config: {
         handler: function(){
-            var olMap = Ext.ComponentQuery.query('basigx-component-map')[0].getMap();
-            var olView = olMap.getView();
-            var zoom = ol.animation.zoom({
+            var me = this,
+                olMap = me.olMap,
+                olView,
+                zoom;
+
+            //fallback
+            if (Ext.isEmpty(olMap)) {
+                olMap = Ext.ComponentQuery.query('basigx-component-map')[0];
+            }
+
+            olView = olMap.getView(),
+            zoom = ol.animation.zoom({
                 resolution: olView.getResolution(),
                 duration: 500
             });

--- a/src/view/button/ZoomOut.js
+++ b/src/view/button/ZoomOut.js
@@ -69,7 +69,7 @@ Ext.define("BasiGX.view.button.ZoomOut", {
                 olMap = Ext.ComponentQuery.query('basigx-component-map')[0];
             }
 
-            olView = olMap.getView(),
+            olView = olMap.getView();
             zoom = ol.animation.zoom({
                 resolution: olView.getResolution(),
                 duration: 500

--- a/src/view/button/ZoomOut.js
+++ b/src/view/button/ZoomOut.js
@@ -24,7 +24,8 @@ Ext.define("BasiGX.view.button.ZoomOut", {
     extend: "Ext.Button",
     xtype: 'basigx-button-zoomout',
     requires: [
-        'Ext.app.ViewModel'
+        'Ext.app.ViewModel',
+        'BasiGX.util.Map'
     ],
 
     /**
@@ -66,7 +67,7 @@ Ext.define("BasiGX.view.button.ZoomOut", {
 
             // fallback
             if (Ext.isEmpty(olMap)) {
-                olMap = Ext.ComponentQuery.query('basigx-component-map')[0];
+                olMap = BasiGX.util.Map.getMapComponent();
             }
 
             olView = olMap.getView();

--- a/src/view/button/ZoomOut.js
+++ b/src/view/button/ZoomOut.js
@@ -46,6 +46,11 @@ Ext.define("BasiGX.view.button.ZoomOut", {
     },
 
     /**
+     * The OL3 map this button is bounded to
+     */
+    olMap: null,
+
+    /**
      * The icons the button should use.
      * Classic Toolkit uses glyphs, modern toolkit uses html
      */
@@ -54,9 +59,18 @@ Ext.define("BasiGX.view.button.ZoomOut", {
 
     config: {
         handler: function() {
-            var olMap = Ext.ComponentQuery.query('basigx-component-map')[0].getMap();
-            var olView = olMap.getView();
-            var zoom = ol.animation.zoom({
+            var me = this,
+                olMap = me.olMap,
+                olView,
+                zoom;
+
+            // fallback
+            if (Ext.isEmpty(olMap)) {
+                olMap = Ext.ComponentQuery.query('basigx-component-map')[0];
+            }
+
+            olView = olMap.getView(),
+            zoom = ol.animation.zoom({
                 resolution: olView.getResolution(),
                 duration: 500
             });

--- a/src/view/button/ZoomToExtent.js
+++ b/src/view/button/ZoomToExtent.js
@@ -48,6 +48,11 @@ Ext.define("BasiGX.view.button.ZoomToExtent", {
     },
 
     /**
+     * The OL3 map this button is bounded to
+     */
+    olMap: null,
+
+    /**
      * Center is required on instantiation.
      * Either zoom or Resolution is required on instantiation.
      */
@@ -58,15 +63,21 @@ Ext.define("BasiGX.view.button.ZoomToExtent", {
         handler: function(){
             this.setConfigValues();
 
-            var olMap = Ext.ComponentQuery.query('basigx-component-map')[0].getMap();
-            var olView = olMap.getView();
-            var targetCenter = this.getCenter();
-            var targetResolution = this.getResolution();
-            var targetZoom = this.getZoom();
-            var pan = ol.animation.pan({
+            var olMap = this.olMap;
+
+            //fallback
+            if (Ext.isEmpty(olMap)) {
+                olMap = Ext.ComponentQuery.query('basigx-component-map')[0];
+            }
+
+            var olView = olMap.getView(),
+                targetCenter = this.getCenter(),
+                targetResolution = this.getResolution(),
+                targetZoom = this.getZoom(),
+                pan = ol.animation.pan({
                     source: olView.getCenter()
-                });
-            var zoom = ol.animation.zoom({
+                }),
+                zoom = ol.animation.zoom({
                    resolution: olView.getResolution()
                 });
 

--- a/src/view/button/ZoomToExtent.js
+++ b/src/view/button/ZoomToExtent.js
@@ -26,6 +26,7 @@ Ext.define("BasiGX.view.button.ZoomToExtent", {
 
     requires: [
         'BasiGX.util.Application',
+        'BasiGX.util.Map',
         'Ext.app.ViewModel'
     ],
 
@@ -67,7 +68,7 @@ Ext.define("BasiGX.view.button.ZoomToExtent", {
 
             //fallback
             if (Ext.isEmpty(olMap)) {
-                olMap = Ext.ComponentQuery.query('basigx-component-map')[0];
+                olMap = BasiGX.util.Map.getMapComponent();
             }
 
             var olView = olMap.getView(),

--- a/src/view/combo/ScaleCombo.js
+++ b/src/view/combo/ScaleCombo.js
@@ -167,7 +167,8 @@ Ext.define("BasiGX.view.combo.ScaleCombo", {
      * a little getScale helper
      */
     getCurrentScale: function (resolution) {
-        var units = me.map.getView().getProjection().getUnits(),
+        var me = this,
+            units = me.map.getView().getProjection().getUnits(),
             dpi = 25.4 / 0.28,
             mpu = ol.proj.METERS_PER_UNIT[units],
             scale = resolution * mpu * 39.37 * dpi;

--- a/src/view/combo/ScaleCombo.js
+++ b/src/view/combo/ScaleCombo.js
@@ -108,7 +108,7 @@ Ext.define("BasiGX.view.combo.ScaleCombo", {
         var me = this;
 
         if (!me.map) {
-            me.map = Ext.ComponentQuery.query("gx_map")[0].getMap();
+            me.map = BasiGX.util.Map.getMapComponent().getMap();
         }
 
         // using hard scales here as there is no way currently known to
@@ -167,9 +167,7 @@ Ext.define("BasiGX.view.combo.ScaleCombo", {
      * a little getScale helper
      */
     getCurrentScale: function (resolution) {
-        // TODO don't query! And move some other place.
-        var map = Ext.ComponentQuery.query('gx_map')[0].getMap(),
-            units = map.getView().getProjection().getUnits(),
+        var units = me.map.getView().getProjection().getUnits(),
             dpi = 25.4 / 0.28,
             mpu = ol.proj.METERS_PER_UNIT[units],
             scale = resolution * mpu * 39.37 * dpi;

--- a/src/view/component/Map.js
+++ b/src/view/component/Map.js
@@ -28,12 +28,13 @@ Ext.define("BasiGX.view.component.Map", {
 
     requires: [
         "BasiGX.util.ConfigParser",
+        "BasiGX.util.Map",
         "BasiGX.util.Layer"
     ],
 
     inheritableStatics: {
         guess: function(){
-            return Ext.ComponentQuery.query('basigx-component-map')[0];
+            return BasiGX.util.Map.getMapComponent(this.xtype);
         }
     },
 

--- a/src/view/container/LayerSlider.js
+++ b/src/view/container/LayerSlider.js
@@ -114,7 +114,7 @@ Ext.define("BasiGX.view.container.LayerSlider", {
      */
     initComponent: function() {
         var me = this,
-            map = Ext.ComponentQuery.query('gx_map')[0].getMap(),
+            map = BasiGX.util.Map.getMapComponent().getMap(),
             labelItems = me.getLabelItems(),
             items = [];
 

--- a/src/view/container/NominatimSearch.js
+++ b/src/view/container/NominatimSearch.js
@@ -35,7 +35,8 @@ Ext.define("BasiGX.view.container.NominatimSearch", {
         'GeoExt.data.store.Features',
         'GeoExt.grid.column.Symbolizer',
 
-        'BasiGX.util.Animate'
+        'BasiGX.util.Animate',
+        'BasiGX.util.Map'
     ],
 
     viewModel: {
@@ -224,9 +225,16 @@ Ext.define("BasiGX.view.container.NominatimSearch", {
     /**
      *
      */
+    map: null,
+
+    /**
+     *
+     */
     initComponent: function() {
-        var me = this,
-            map = Ext.ComponentQuery.query('gx_map')[0].getMap();
+        var me = this;
+
+        //set map
+        me.map = BasiGX.util.Map.getMapComponent().getMap();
 
         if (!me.searchResultVectorLayer) {
             me.searchResultVectorLayer = new ol.layer.Vector({
@@ -235,7 +243,7 @@ Ext.define("BasiGX.view.container.NominatimSearch", {
                 style: me.getSearchResultFeatureStyle(),
                 visible: !me.clusterResults
             });
-            map.addLayer(me.searchResultVectorLayer);
+            me.map.addLayer(me.searchResultVectorLayer);
         }
 
         if (me.clusterResults && !me.clusterLayer) {
@@ -257,7 +265,7 @@ Ext.define("BasiGX.view.container.NominatimSearch", {
                     return style;
                 }
             });
-            map.addLayer(me.clusterLayer);
+            me.map.addLayer(me.clusterLayer);
 
             // correct the vectorlayerstyle for the grid symbolizer
             me.searchResultVectorLayer.setStyle(me.clusterStyleFn('', 8));
@@ -265,7 +273,7 @@ Ext.define("BasiGX.view.container.NominatimSearch", {
         }
 
         var searchResultStore = Ext.create('GeoExt.data.store.Features', {
-            map: map,
+            map: me.map,
             layer: me.searchResultVectorLayer,
             groupField: 'type'
         });
@@ -501,17 +509,17 @@ Ext.define("BasiGX.view.container.NominatimSearch", {
      * Works with extent or geom.
      */
     zoomToExtent: function(extent){
-        var olMap = Ext.ComponentQuery.query('gx_map')[0].getMap();
-        var olView = olMap.getView();
+        var me = this;
+        var olView = me.map.getView();
         var pan = ol.animation.pan({
             source: olView.getCenter()
         });
         var zoom = ol.animation.zoom({
            resolution: olView.getResolution()
         });
-        olMap.beforeRender(pan, zoom);
+        me.map.beforeRender(pan, zoom);
 
-        olView.fit(extent, olMap.getSize());
+        olView.fit(extent, me.map.getSize());
     },
 
     /**
@@ -531,7 +539,7 @@ Ext.define("BasiGX.view.container.NominatimSearch", {
         if(this.enterEventRec === record){
             return;
         }
-        var map = Ext.ComponentQuery.query('gx_map')[0].getMap();
+        var me = this;
         var feature;
         var radius;
         var text;
@@ -542,7 +550,7 @@ Ext.define("BasiGX.view.container.NominatimSearch", {
         if (this.clusterResults) {
             feature = this.getClusterFeatureFromFeature(record.olObject);
             var featureStyle = this.clusterLayer.getStyle()(
-                feature, map.getView().getResolution())[0];
+                feature, me.map.getView().getResolution())[0];
             radius = featureStyle.getImage().getRadius();
             text = featureStyle.getText().getText();
         } else {

--- a/src/view/container/OverpassSearch.js
+++ b/src/view/container/OverpassSearch.js
@@ -36,6 +36,7 @@ Ext.define("BasiGX.view.container.OverpassSearch", {
         'GeoExt.grid.column.Symbolizer',
 
         'BasiGX.util.Animate',
+        'BasiGX.util.Map',
         'BasiGX.util.MsgBox'
     ],
 
@@ -235,9 +236,16 @@ Ext.define("BasiGX.view.container.OverpassSearch", {
     /**
      *
      */
+    map: null,
+
+    /**
+     *
+     */
     initComponent: function() {
-        var me = this,
-            map = Ext.ComponentQuery.query('gx_map')[0].getMap();
+        var me = this;
+
+        // set map
+        me.map = BasiGX.util.Map.getMapComponent().getMap();
 
         if (!me.searchResultVectorLayer) {
             me.searchResultVectorLayer = new ol.layer.Vector({
@@ -246,7 +254,7 @@ Ext.define("BasiGX.view.container.OverpassSearch", {
                 style: me.getSearchResultFeatureStyle(),
                 visible: !me.clusterResults
             });
-            map.addLayer(me.searchResultVectorLayer);
+            me.map.addLayer(me.searchResultVectorLayer);
         }
 
         if (me.clusterResults && !me.clusterLayer) {
@@ -268,7 +276,7 @@ Ext.define("BasiGX.view.container.OverpassSearch", {
                     return style;
                 }
             });
-            map.addLayer(me.clusterLayer);
+            me.map.addLayer(me.clusterLayer);
 
             // correct the vectorlayerstyle for the grid symbolizer
             me.searchResultVectorLayer.setStyle(me.clusterStyleFn('', 8));
@@ -293,7 +301,7 @@ Ext.define("BasiGX.view.container.OverpassSearch", {
         });
 
         var searchResultStore = Ext.create('GeoExt.data.store.Features', {
-            map: map,
+            map: me.map,
             layer: me.searchResultVectorLayer,
             groupField: 'type'
         });
@@ -600,17 +608,16 @@ Ext.define("BasiGX.view.container.OverpassSearch", {
      * Works with extent or geom.
      */
     zoomToExtent: function(extent){
-        var olMap = Ext.ComponentQuery.query('gx_map')[0].getMap();
-        var olView = olMap.getView();
+        var olView = me.map.getView();
         var pan = ol.animation.pan({
             source: olView.getCenter()
         });
         var zoom = ol.animation.zoom({
            resolution: olView.getResolution()
         });
-        olMap.beforeRender(pan, zoom);
+        me.map.beforeRender(pan, zoom);
 
-        olView.fit(extent, olMap.getSize());
+        olView.fit(extent, me.map.getSize());
     },
 
     /**
@@ -630,7 +637,6 @@ Ext.define("BasiGX.view.container.OverpassSearch", {
         if(this.enterEventRec === record){
             return;
         }
-        var map = Ext.ComponentQuery.query('gx_map')[0].getMap();
         var feature;
         var radius;
         var text;
@@ -641,7 +647,7 @@ Ext.define("BasiGX.view.container.OverpassSearch", {
         if (this.clusterResults) {
             feature = this.getClusterFeatureFromFeature(record.olObject);
             var featureStyle = this.clusterLayer.getStyle()(
-                feature, map.getView().getResolution())[0];
+                feature, me.map.getView().getResolution())[0];
             radius = featureStyle.getImage().getRadius();
             text = featureStyle.getText().getText();
         } else {

--- a/src/view/container/OverpassSearch.js
+++ b/src/view/container/OverpassSearch.js
@@ -608,6 +608,7 @@ Ext.define("BasiGX.view.container.OverpassSearch", {
      * Works with extent or geom.
      */
     zoomToExtent: function(extent){
+        var me = this;
         var olView = me.map.getView();
         var pan = ol.animation.pan({
             source: olView.getCenter()
@@ -647,7 +648,7 @@ Ext.define("BasiGX.view.container.OverpassSearch", {
         if (this.clusterResults) {
             feature = this.getClusterFeatureFromFeature(record.olObject);
             var featureStyle = this.clusterLayer.getStyle()(
-                feature, me.map.getView().getResolution())[0];
+                feature, this.map.getView().getResolution())[0];
             radius = featureStyle.getImage().getRadius();
             text = featureStyle.getText().getText();
         } else {

--- a/src/view/container/Redlining.js
+++ b/src/view/container/Redlining.js
@@ -220,7 +220,7 @@ Ext.define("BasiGX.view.container.Redlining", {
        //set map
        me.map = BasiGX.util.Map.getMapComponent().getMap();
 
-       if (!me.redlmapiningVectorLayer) {
+       if (!me.redliningVectorLayer) {
            me.redlineFeatures = new ol.Collection();
            me.redliningVectorLayer = new ol.layer.Vector({
                source: new ol.source.Vector({features: me.redlineFeatures}),

--- a/src/view/container/Redlining.js
+++ b/src/view/container/Redlining.js
@@ -123,6 +123,11 @@ Ext.define("BasiGX.view.container.Redlining", {
      */
     redliningToolsWin : null,
 
+    /**
+     *
+     */
+    map: null,
+
    /**
     *
     */
@@ -209,19 +214,20 @@ Ext.define("BasiGX.view.container.Redlining", {
     */
    initComponent: function() {
        var me = this;
-       var mapComponent = Ext.ComponentQuery.query('gx_component_map')[0];
-       var map = mapComponent.getMap();
        var displayInLayerSwitcherKey = BasiGX.util.Layer.
            KEY_DISPLAY_IN_LAYERSWITCHER;
 
-       if (!me.redliningVectorLayer) {
+       //set map
+       me.map = BasiGX.util.Map.getMapComponent().getMap();
+
+       if (!me.redlmapiningVectorLayer) {
            me.redlineFeatures = new ol.Collection();
            me.redliningVectorLayer = new ol.layer.Vector({
                source: new ol.source.Vector({features: me.redlineFeatures}),
                style: me.getRedlineStyleFunction()
            });
            me.redliningVectorLayer.set(displayInLayerSwitcherKey, false);
-           map.addLayer(me.redliningVectorLayer);
+           me.map.addLayer(me.redliningVectorLayer);
        }
 
        me.items = me.getRedlineItems();
@@ -233,8 +239,6 @@ Ext.define("BasiGX.view.container.Redlining", {
     */
    getRedlineItems: function() {
        var me = this;
-       var mapComponent = Ext.ComponentQuery.query('gx_component_map')[0];
-       var map = mapComponent.getMap();
 
        return [
            {
@@ -250,7 +254,7 @@ Ext.define("BasiGX.view.container.Redlining", {
                                features: me.redlineFeatures,
                                type: 'Point'
                            });
-                           map.addInteraction(me.drawPointInteraction);
+                           me.map.addInteraction(me.drawPointInteraction);
                        }
                        if (pressed) {
                            me.drawPointInteraction.setActive(true);
@@ -272,7 +276,7 @@ Ext.define("BasiGX.view.container.Redlining", {
                                features: me.redlineFeatures,
                                type: 'LineString'
                            });
-                           map.addInteraction(me.drawLineInteraction);
+                           me.map.addInteraction(me.drawLineInteraction);
                        }
                        if (pressed) {
                            me.drawLineInteraction.setActive(true);
@@ -294,7 +298,7 @@ Ext.define("BasiGX.view.container.Redlining", {
                                features: me.redlineFeatures,
                                type: 'Polygon'
                            });
-                           map.addInteraction(me.drawPolygonInteraction);
+                           me.map.addInteraction(me.drawPolygonInteraction);
                        }
                        if (pressed) {
                            me.drawPolygonInteraction.setActive(true);
@@ -327,7 +331,7 @@ Ext.define("BasiGX.view.container.Redlining", {
                                    })
                                })
                            });
-                           map.addInteraction(me.drawPostitInteraction);
+                           me.map.addInteraction(me.drawPostitInteraction);
                        }
                        if (pressed) {
                            me.drawPostitInteraction.setActive(true);
@@ -361,7 +365,7 @@ Ext.define("BasiGX.view.container.Redlining", {
 
                                me.copySelectInteraction.getFeatures().clear();
                            });
-                           map.addInteraction(me.copySelectInteraction);
+                           me.map.addInteraction(me.copySelectInteraction);
                        }
                        if (pressed) {
                            me.copySelectInteraction.setActive(true);
@@ -381,13 +385,13 @@ Ext.define("BasiGX.view.container.Redlining", {
                        if (!me.translateInteraction) {
                            me.translateSelectInteraction =
                                new ol.interaction.Select();
-                           map.addInteraction(me.translateSelectInteraction);
+                           me.map.addInteraction(me.translateSelectInteraction);
                            me.translateInteraction =
                                new ol.interaction.Translate({
                                    features: me.translateSelectInteraction
                                        .getFeatures()
                            });
-                           map.addInteraction(me.translateInteraction);
+                           me.map.addInteraction(me.translateInteraction);
                        }
                        if (pressed) {
                            me.translateInteraction.setActive(true);
@@ -414,7 +418,7 @@ Ext.define("BasiGX.view.container.Redlining", {
                                        .singleClick(event);
                                }
                            });
-                           map.addInteraction(me.modifyInteraction);
+                           me.map.addInteraction(me.modifyInteraction);
                        }
                        if (pressed) {
                            me.modifyInteraction.setActive(true);
@@ -434,7 +438,7 @@ Ext.define("BasiGX.view.container.Redlining", {
                        if (!me.deleteSelectInteraction) {
                            me.deleteSelectInteraction =
                                new ol.interaction.Select();
-                           map.addInteraction(me.deleteSelectInteraction);
+                           me.map.addInteraction(me.deleteSelectInteraction);
                            me.deleteSelectInteraction.getFeatures().on('add',
                                function(evt) {
 
@@ -451,11 +455,11 @@ Ext.define("BasiGX.view.container.Redlining", {
                                        .singleClick(event);
                                }
                            });
-                           map.addInteraction(me.deleteModifyInteraction);
+                           me.map.addInteraction(me.deleteModifyInteraction);
                            me.deleteSnapInteraction = new ol.interaction.Snap({
                                features: me.redlineFeatures
                            });
-                           map.addInteraction(me.deleteSnapInteraction);
+                           me.map.addInteraction(me.deleteSnapInteraction);
                        }
                        if (pressed) {
                            me.deleteSelectInteraction.setActive(true);

--- a/src/view/container/WfsSearch.js
+++ b/src/view/container/WfsSearch.js
@@ -34,7 +34,8 @@ Ext.define("BasiGX.view.container.WfsSearch", {
         'GeoExt.data.store.Features',
         'GeoExt.grid.column.Symbolizer',
 
-        'BasiGX.util.Animate'
+        'BasiGX.util.Animate',
+        'BasiGX.util.Map'
     ],
 
     /**
@@ -227,9 +228,16 @@ Ext.define("BasiGX.view.container.WfsSearch", {
     /**
      *
      */
+    map: null,
+
+    /**
+     *
+     */
     initComponent: function() {
-        var me = this,
-            map = Ext.ComponentQuery.query('gx_map')[0].getMap();
+        var me = this;
+
+        //set map
+        me.map = BasiGX.util.Map.getMapComponent().getMap();
 
         if (Ext.isEmpty(me.getLayers())) {
             Ext.log.error('No layers given to search component!');
@@ -241,7 +249,7 @@ Ext.define("BasiGX.view.container.WfsSearch", {
                 style: me.getSearchResultFeatureStyle(),
                 visible: !me.clusterResults
             });
-            map.addLayer(me.searchResultVectorLayer);
+            me.map.addLayer(me.searchResultVectorLayer);
         }
 
         if (me.clusterResults && !me.clusterLayer) {
@@ -262,7 +270,7 @@ Ext.define("BasiGX.view.container.WfsSearch", {
                     return style;
                 }
             });
-            map.addLayer(me.clusterLayer);
+            me.map.addLayer(me.clusterLayer);
 
             // correct the vectorlayerstyle for the grid symbolizer
             me.searchResultVectorLayer.setStyle(me.clusterStyleFn('', 8));
@@ -270,7 +278,7 @@ Ext.define("BasiGX.view.container.WfsSearch", {
         }
 
         var searchResultStore = Ext.create('GeoExt.data.store.Features', {
-            map: map,
+            map: me.map,
             layer: me.searchResultVectorLayer,
             groupField: 'featuretype'
         });
@@ -577,17 +585,17 @@ Ext.define("BasiGX.view.container.WfsSearch", {
      * Works with extent or geom.
      */
     zoomToExtent: function(extent){
-        var olMap = Ext.ComponentQuery.query('gx_map')[0].getMap();
-        var olView = olMap.getView();
+        var me = this;
+        var olView = me.map.getView();
         var pan = ol.animation.pan({
             source: olView.getCenter()
         });
         var zoom = ol.animation.zoom({
            resolution: olView.getResolution()
         });
-        olMap.beforeRender(pan, zoom);
+        me.map.beforeRender(pan, zoom);
 
-        olView.fit(extent, olMap.getSize());
+        olView.fit(extent, me.map.getSize());
     },
 
     /**
@@ -607,7 +615,7 @@ Ext.define("BasiGX.view.container.WfsSearch", {
         if(this.enterEventRec === record){
             return;
         }
-        var map = Ext.ComponentQuery.query('gx_map')[0].getMap();
+        var me = this;
         var feature;
         var radius;
         var text;
@@ -618,7 +626,7 @@ Ext.define("BasiGX.view.container.WfsSearch", {
         if (this.clusterResults) {
             feature = this.getClusterFeatureFromFeature(record.olObject);
             var featureStyle = this.clusterLayer.getStyle()(
-                feature, map.getView().getResolution())[0];
+                feature, me.map.getView().getResolution())[0];
             radius = featureStyle.getImage().getRadius();
             text = featureStyle.getText().getText();
         } else {

--- a/src/view/form/AddWms.js
+++ b/src/view/form/AddWms.js
@@ -38,6 +38,7 @@ Ext.define('BasiGX.view.form.AddWms', {
         'Ext.layout.container.HBox',
         'Ext.toolbar.Toolbar',
 
+        'BasiGX.util.Map',
         'BasiGX.util.MsgBox'
     ],
 
@@ -406,7 +407,7 @@ Ext.define('BasiGX.view.form.AddWms', {
             return false;
         }
         var compatible = [];
-        var map = Ext.ComponentQuery.query('gx_map')[0].getMap();
+        var map = BasiGX.util.Map.getMapComponent().getMap();
         var mapProj = map.getView().getProjection().getCode();
 
         // same in both versions
@@ -514,7 +515,7 @@ Ext.define('BasiGX.view.form.AddWms', {
         var me = this;
         var fs = me.down('[name=fs-available-layers]');
         var checkboxes = fs.query('checkbox[checked=true][disabled=false]');
-        var map = Ext.ComponentQuery.query('gx_map')[0].getMap();
+        var map = BasiGX.util.Map.getMapComponent().getMap();
         Ext.each(checkboxes, function(checkbox) {
             me.fireEvent('beforewmsadd', checkbox.olLayer);
             map.addLayer(checkbox.olLayer);

--- a/src/view/form/CoordinateTransform.js
+++ b/src/view/form/CoordinateTransform.js
@@ -46,6 +46,11 @@ Ext.define("BasiGX.view.form.CoordinateTransform", {
 
     scrollable: 'y',
 
+    /**
+     *
+     */
+    map: null,
+
     config: {
         /**
          * Array of Objects containing code in EPSG notation and Name to display
@@ -65,8 +70,10 @@ Ext.define("BasiGX.view.form.CoordinateTransform", {
      */
     initComponent: function() {
         var me = this,
-            crsFieldsets = [],
-            map = Ext.ComponentQuery.query('gx_map')[0].getMap();
+            crsFieldsets = [];
+
+        //set map
+        me.map = BasiGX.util.Map.getMapComponent().getMap();
 
         if (Ext.isEmpty(me.getCoordinateSystemsToUse())) {
             Ext.log.warn('No coordinatesystems given to Component');
@@ -167,18 +174,18 @@ Ext.define("BasiGX.view.form.CoordinateTransform", {
             }
 
             if(me.getTransformCenterOnRender()){
-                var coordToTransform = map.getView().getCenter();
+                var coordToTransform = me.map.getView().getCenter();
                 me.transform(coordToTransform);
             }
         });
 
-        map.on('click', me.transform);
+        me.map.on('click', me.transform);
 
         me.on('beforedestroy', function(){
             var transformvectorlayer = BasiGX.util.Layer.getLayerByName(
                 'transformvectorlayer');
             transformvectorlayer.getSource().clear();
-            map.un('click', me.transform);
+            me.map.un('click', me.transform);
         });
     },
 
@@ -239,8 +246,7 @@ Ext.define("BasiGX.view.form.CoordinateTransform", {
     transform: function(evtOrBtnOrArray) {
         var me = Ext.ComponentQuery.query(
             'basigx-form-coordinatetransform')[0],
-            map = Ext.ComponentQuery.query('gx_map')[0].getMap(),
-            mapProjection = map.getView().getProjection(),
+            mapProjection = me.map.getView().getProjection(),
             fieldSets = me.query('fieldset'),
             transformvectorlayer = BasiGX.util.Layer.getLayerByName(
                 'transformvectorlayer'),
@@ -300,8 +306,7 @@ Ext.define("BasiGX.view.form.CoordinateTransform", {
             });
 
             transformvectorlayer.set(displayInLayerSwitcherKey, false);
-
-            map.addLayer(transformvectorlayer);
+            me.map.addLayer(transformvectorlayer);
         }
 
         var transformedMapCoords = ol.proj.transform(
@@ -314,7 +319,7 @@ Ext.define("BasiGX.view.form.CoordinateTransform", {
         transformvectorlayer.getSource().addFeatures([feature]);
         // recenter if we were not triggered by click in map
         if (!isOlEvt) {
-            map.getView().setCenter(transformedMapCoords);
+            me.map.getView().setCenter(transformedMapCoords);
         }
     }
 });

--- a/src/view/form/Print.js
+++ b/src/view/form/Print.js
@@ -30,6 +30,7 @@ Ext.define("BasiGX.view.form.Print", {
         "Ext.form.action.StandardSubmit",
 
         "BasiGX.util.Layer",
+        "BasiGX.util.Map",
 
         "GeoExt.data.MapfishPrintProvider"
     ],
@@ -294,7 +295,7 @@ Ext.define("BasiGX.view.form.Print", {
      *
      */
     addExtentLayer: function(){
-        var targetMap = Ext.ComponentQuery.query('gx_map')[0];
+        var targetMap = BasiGX.util.Map.getMapComponent().getMap();
 
         // TODO MJ: the lines below are possible better suited at the
         //          cleanupPrintExtent method, but tzhat may currently


### PR DESCRIPTION
With this PR some additional config properties  will be introduced to determine map component dynamically and get rid of hardcoded queries like `Ext.ComponentQuery.query('basigx-component-map')[0]`

This change is neccessary to be able to use `mapComponentConfig` object, if we like to use our own `xtype` of map component in the application.

S. here for example:
https://github.com/terrestris/BasiGX/blob/master/src/view/panel/MapContainer.js#L74.

These additional configs can be provided by instantiation of the corresponding `BasiGX` class in the application. Here example for `BasiGX.view.button.ZoomIn` class:

```js
{
      xtype: 'basigx-button-zoomin', 
      scale: 'small',
      olMap: olMap,
      ui: 'default'
}
```