### PR TITLE
BugFix for LegendTree-RowExpander

### DIFF
--- a/src/ux/RowExpanderWithComponents.js
+++ b/src/ux/RowExpanderWithComponents.js
@@ -206,7 +206,10 @@ Ext.define('BasiGX.ux.RowExpanderWithComponents', {
                 if (record.getOlLayer() && record.getOlLayer().get('type') &&
                     record.getOlLayer().get('type') !== "WFSCluster" &&
                     Ext.isArray(obj.items) && obj.items.length > 1) {
-                        obj.items.pop();
+                        var lastItem = obj.items[obj.items.length - 1];
+                        if(lastItem.xtype === "image"){
+                            obj.items.pop();
+                        }
                 }
             }
         }


### PR DESCRIPTION
This fixes a bug that removes items mistakenly.

This part of code searches for an item that is added twice. And removes it before. The selection of the item wasn't specfic enough so to many items where removed. Now the items is selected more specifcly.