### PR TITLE
Show correct initial scale value on first application load

### DIFF
--- a/src/view/combo/ScaleCombo.js
+++ b/src/view/combo/ScaleCombo.js
@@ -126,7 +126,9 @@ Ext.define("BasiGX.view.combo.ScaleCombo", {
         me.callParent([arguments]);
 
         // set the correct default value
-        me.setValue(me.map.getView().getResolution());
+        var defaultScale = Math.round(me.getCurrentScale(
+                me.map.getView().getResolution())).toLocaleString();
+        me.setValue('1:' + defaultScale);
 
         // register listeners to update combo and map
         me.on('select', function(combo, rec) {
@@ -172,6 +174,6 @@ Ext.define("BasiGX.view.combo.ScaleCombo", {
             dpi = 25.4 / 0.28,
             mpu = ol.proj.METERS_PER_UNIT[units],
             scale = resolution * mpu * 39.37 * dpi;
-        return scale;
+        return scale.toFixed(0);
     }
 });

--- a/test/spec/view/combo/ScaleCombo.test.js
+++ b/test/spec/view/combo/ScaleCombo.test.js
@@ -8,6 +8,7 @@ describe('BasiGX.view.combo.ScaleCombo', function() {
     var map;
     var combo;
     var mapComponent;
+    var dpi = 25.4 / 0.28;
     beforeEach(function() {
         div = document.createElement('div');
         document.body.appendChild(div);
@@ -56,9 +57,16 @@ describe('BasiGX.view.combo.ScaleCombo', function() {
     });
     describe('initially selected value', function() {
         it('is taken from the map', function() {
-            expect(combo.getValue()).to.be(map.getView().getResolution());
+            var units = map.getView().getProjection().getUnits();
+            var mpu = ol.proj.METERS_PER_UNIT[units];
+            var scale = map.getView().getResolution() * mpu * 39.37 * dpi;
+            expect(combo.getValue()).to.be(
+                "1:" + Math.round(scale.toLocaleString()).toFixed(0));
         });
+
         it('is taken from map even if not existing in store', function() {
+            var units = map.getView().getProjection().getUnits();
+            var mpu = ol.proj.METERS_PER_UNIT[units];
             map.setView(new ol.View({resolution: 4711}));
             var combo2 = Ext.create('BasiGX.view.combo.ScaleCombo', {
                 map: map,
@@ -66,7 +74,9 @@ describe('BasiGX.view.combo.ScaleCombo', function() {
                     {scale: "1:2.000.000", resolution: 560}
                 ]
             });
-            expect(combo2.getValue()).to.be(4711);
+            var scale = 4711 * mpu * 39.37 * dpi;
+            expect(combo2.getValue()).to.be(
+                    "1:" + Math.round(scale.toLocaleString()).toFixed(0));
         });
     });
     describe('two-way binding', function() {


### PR DESCRIPTION
This PR fixes the shown scale value in `ScaleCombo`, that will initially be shown on the first application load.

Previously ths `resolution` value was shown instead of `scale`.

Please review.

/cc @weskamm 