### PR TITLE
Fixed buttons to be mobile compatible again

### DIFF
--- a/src/view/button/AddWms.js
+++ b/src/view/button/AddWms.js
@@ -48,7 +48,6 @@ Ext.define("BasiGX.view.button.AddWms", {
      *
      */
     bind: {
-        tooltip: '{tooltip}',
         text: '{text}'
     },
 
@@ -80,5 +79,11 @@ Ext.define("BasiGX.view.button.AddWms", {
      */
     constructor: function(config) {
         this.callParent([config]);
+
+        if (this.setTooltip) {
+            var bind = this.config.bind;
+            bind.tooltip = this.getViewModel().get('tooltip');
+            this.setBind(bind);
+        }
     }
 });

--- a/src/view/button/CoordinateTransform.js
+++ b/src/view/button/CoordinateTransform.js
@@ -47,7 +47,6 @@ Ext.define("BasiGX.view.button.CoordinateTransform", {
      *
      */
     bind: {
-        tooltip: '{tooltip}',
         text: '{text}'
     },
 
@@ -91,5 +90,11 @@ Ext.define("BasiGX.view.button.CoordinateTransform", {
      */
     constructor: function(config) {
         this.callParent([config]);
+
+        if (this.setTooltip) {
+            var bind = this.config.bind;
+            bind.tooltip = this.getViewModel().get('tooltip');
+            this.setBind(bind);
+        }
     }
 });

--- a/src/view/button/Help.js
+++ b/src/view/button/Help.js
@@ -43,7 +43,6 @@ Ext.define("BasiGX.view.button.Help", {
      *
      */
     bind: {
-        tooltip: '{tooltip}',
         text: '{text}'
     },
 
@@ -70,5 +69,11 @@ Ext.define("BasiGX.view.button.Help", {
      */
     constructor: function(config) {
         this.callParent([config]);
+
+        if (this.setTooltip) {
+            var bind = this.config.bind;
+            bind.tooltip = this.getViewModel().get('tooltip');
+            this.setBind(bind);
+        }
     }
 });

--- a/src/view/button/Hsi.js
+++ b/src/view/button/Hsi.js
@@ -42,7 +42,6 @@ Ext.define("BasiGX.view.button.Hsi", {
      *
      */
     bind: {
-        tooltip: '{tooltip}',
         text: '{text}'
     },
 
@@ -83,6 +82,13 @@ Ext.define("BasiGX.view.button.Hsi", {
      */
     constructor: function(config) {
         this.callParent([config]);
+
+        if (this.setTooltip) {
+            var bind = this.config.bind;
+            bind.tooltip = this.getViewModel().get('tooltip');
+            this.setBind(bind);
+        }
+
         this.toggleButton();
     },
 

--- a/src/view/button/Permalink.js
+++ b/src/view/button/Permalink.js
@@ -44,7 +44,6 @@ Ext.define("BasiGX.view.button.Permalink", {
     },
 
     bind: {
-        tooltip: '{tooltip}',
         text: '{text}'
     },
 
@@ -71,5 +70,11 @@ Ext.define("BasiGX.view.button.Permalink", {
      */
     constructor: function(config) {
         this.callParent([config]);
+
+        if (this.setTooltip) {
+            var bind = this.config.bind;
+            bind.tooltip = this.getViewModel().get('tooltip');
+            this.setBind(bind);
+        }
     }
 });

--- a/src/view/button/ToggleLegend.js
+++ b/src/view/button/ToggleLegend.js
@@ -42,7 +42,6 @@ Ext.define("BasiGX.view.button.ToggleLegend", {
      *
      */
     bind: {
-        tooltip: '{tooltip}',
         text: '{text}'
     },
 
@@ -81,5 +80,11 @@ Ext.define("BasiGX.view.button.ToggleLegend", {
      */
     constructor: function(config) {
         this.callParent([config]);
+
+        if (this.setTooltip) {
+            var bind = this.config.bind;
+            bind.tooltip = this.getViewModel().get('tooltip');
+            this.setBind(bind);
+        }
     }
 });

--- a/src/view/button/ZoomIn.js
+++ b/src/view/button/ZoomIn.js
@@ -39,7 +39,6 @@ Ext.define("BasiGX.view.button.ZoomIn", {
     },
 
     bind: {
-        tooltip: '{tooltip}',
         text: '{text}'
     },
 
@@ -86,5 +85,11 @@ Ext.define("BasiGX.view.button.ZoomIn", {
      */
     constructor: function(config) {
         this.callParent([config]);
+
+        if (this.setTooltip) {
+            var bind = this.config.bind;
+            bind.tooltip = this.getViewModel().get('tooltip');
+            this.setBind(bind);
+        }
     }
 });

--- a/src/view/button/ZoomOut.js
+++ b/src/view/button/ZoomOut.js
@@ -42,7 +42,6 @@ Ext.define("BasiGX.view.button.ZoomOut", {
      *
      */
     bind: {
-        tooltip: '{tooltip}',
         text: '{text}'
     },
 
@@ -86,5 +85,11 @@ Ext.define("BasiGX.view.button.ZoomOut", {
      */
     constructor: function(config) {
         this.callParent([config]);
+
+        if (this.setTooltip) {
+            var bind = this.config.bind;
+            bind.tooltip = this.getViewModel().get('tooltip');
+            this.setBind(bind);
+        }
     }
 });

--- a/src/view/button/ZoomToExtent.js
+++ b/src/view/button/ZoomToExtent.js
@@ -44,7 +44,6 @@ Ext.define("BasiGX.view.button.ZoomToExtent", {
      *
      */
     bind: {
-        tooltip: '{tooltip}',
         text: '{text}'
     },
 
@@ -106,6 +105,12 @@ Ext.define("BasiGX.view.button.ZoomToExtent", {
      */
     constructor: function(config) {
         this.callParent([config]);
+
+        if (this.setTooltip) {
+            var bind = this.config.bind;
+            bind.tooltip = this.getViewModel().get('tooltip');
+            this.setBind(bind);
+        }
 
         if(this.getZoom() && this.getResolution()){
             Ext.raise('No zoom and resolution set for Extent Button!' +


### PR DESCRIPTION
This PR contains a change that has been removed by accident in a previous commit.
We still need to check if the `setTooltip` function is available before we bind the value, as in fact a tooltip for a button does not exist in the modern toolkit.