### PR TITLE
Added WMS-time slider

### DIFF
--- a/src/view/container/WMSTimeSlider.js
+++ b/src/view/container/WMSTimeSlider.js
@@ -1,0 +1,196 @@
+/* Copyright (c) 2016 mundialis GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * WMS-Time Slider
+ *
+ * Used to slide through all timestamps from a WMS-Time Layer. Timestamps are
+ * taken from the layer's getCapabilitites document when displayed as a list.
+ *
+ * Example usage:
+ *
+ * {
+ *      xtype: 'basigx-container-wmstimeslider',
+ *      url: 'http://example.de/geoserver/timeseries/wms',
+ *      layerNameInWMS: "timeseries",
+ *      layerNameInClient: 'timeseries1'
+ * }
+ *
+ * TODOs:
+ *   * Make type of timestamp on labels and tooltips configurable
+ *     (now it shows interval in days)
+ *
+ * @class BasiGX.view.container.WMSTimeSlider
+ */
+Ext.define("BasiGX.view.container.WMSTimeSlider",{
+    extend: "Ext.container.Container",
+    xtype: 'basigx-container-wmstimeslider',
+
+    width: '95%',
+
+    config: {
+        times: []
+    },
+
+    url: null,
+
+    layerNameInWMS: null,
+
+    layerNameInClient: null,
+
+    cls: 'timeSlider',
+
+    initComponent: function() {
+        var me = this;
+        var slidercontainer = this;
+        var params = Ext.apply({
+            service: 'WMS',
+            version: '1.3.0',
+            request: 'GetCapabilities'
+        });
+        Ext.Ajax.request({
+            url: slidercontainer.url,
+            method: 'GET',
+            params: params,
+            async: false,
+            success: function(response) {
+                var parser = new ol.format.WMSCapabilities();
+                var result;
+                var timelayer;
+                var timevalues;
+                try {
+                    result = parser.read(response.responseText);
+                } catch(ex) {
+                    Ext.Msg.alert("Error", "Could not parse GetCapabilites from layer");
+                    return;
+                }
+                Ext.each(result.Capability.Layer.Layer, function(layer) {
+                    if (layer.Name == slidercontainer.layerNameInWMS) {
+                        timelayer = layer;
+                    }
+                })
+                Ext.each(timelayer.Dimension, function(dimension) {
+                    if (dimension.name == "time") {
+                        timevalues = dimension.values;
+                    }
+                })
+
+                var WMStimes = timevalues.split(",");
+                slidercontainer.setTimes(WMStimes);
+
+            },
+            failure: function() {
+                Ext.Msg.alert("Error", "Could not reach WMS");
+            }
+
+        });
+
+        me.callParent(arguments);
+    },
+
+    layout: {
+        type: 'vbox',
+        align: 'stretch'
+    },
+
+    items: [
+            {
+                xtype: 'container',
+                name: 'labelcontainer',
+                layout: {
+                    type: 'hbox',
+                    align: 'stretch'
+                },
+                defaults: {
+                    xtype: 'container',
+                    flex: 1
+                },
+                items: [],
+                listeners: {
+                    boxready: {
+                        fn: function() {
+                            var me = this;
+                            me.up().setLabels();
+                        }
+                    }
+                }
+            },
+            {
+                xtype: 'slider',
+                name: 'timeslider',
+                tipText: function(thumb){
+                    var slider = Ext.ComponentQuery.query('timeseries-container-wmstimeslider')[0];
+                    var time = slider.getTimes()[thumb.value];
+                    return Ext.Date.format(new Date(time), 'Y-m-d');
+                },
+                listeners:{
+                    boxready: {
+                        fn: function(){
+                            var me = this;
+                            me.maxValue = me.up().getTimes().length-1;
+                        }
+                    },
+                    change: {
+                        fn: function(){
+                            var me = this;
+                            me.up().updateTime();
+                        }
+                    }
+                }
+
+            }
+    ],
+
+    setLabels: function() {
+        var me = this;
+
+        var labelcontainer;
+        Ext.each(me.items.items, function(item) {
+            if (item.name == "labelcontainer") {
+                labelcontainer = item;
+            }
+        });
+
+        //Do not add all labels but first, middle and last
+        var start = Ext.Date.format(new Date(me.getTimes()[0]), 'Y-m-d');
+        var middle = Ext.Date.format(new Date(me.getTimes()[Math.floor(me.getTimes().length/2)]), 'Y-m-d');
+        var end = Ext.Date.format(new Date(me.getTimes()[me.getTimes().length-1]), 'Y-m-d');
+
+        labelcontainer.add({
+            html: start
+        });
+        labelcontainer.add({
+            html: '<div style="text-align:center;">' + middle + '</div>'
+        });
+        labelcontainer.add({
+            html: '<div style="float:right;">' + end + '</div>'
+        });
+
+    },
+
+    updateTime: function() {
+        var me = this;
+        var timeslider;
+        Ext.each(me.items.items, function(item){
+            if (item.name == "timeslider") {
+                timeslider = item
+            }
+        })
+        var time = me.getTimes()[timeslider.getValue()];
+        var layer = BasiGX.util.Layer.getLayerByName(me.layerNameInClient);
+        layer.getSource().updateParams({TIME:time});
+    }
+
+});

--- a/src/view/container/WMSTimeSlider.js
+++ b/src/view/container/WMSTimeSlider.js
@@ -24,7 +24,7 @@
  * {
  *      xtype: 'basigx-container-wmstimeslider',
  *      url: 'http://example.de/geoserver/timeseries/wms',
- *      layerNameInWMS: "timeseries",
+ *      layerNameInWMS: 'timeseries',
  *      layerNameInClient: 'timeseries1'
  * }
  *
@@ -77,15 +77,15 @@ Ext.define("BasiGX.view.container.WMSTimeSlider",{
                     return;
                 }
                 Ext.each(result.Capability.Layer.Layer, function(layer) {
-                    if (layer.Name == slidercontainer.layerNameInWMS) {
+                    if (layer.Name === slidercontainer.layerNameInWMS) {
                         timelayer = layer;
                     }
-                })
+                });
                 Ext.each(timelayer.Dimension, function(dimension) {
-                    if (dimension.name == "time") {
+                    if (dimension.name === "time") {
                         timevalues = dimension.values;
                     }
-                })
+                });
 
                 var WMStimes = timevalues.split(",");
                 slidercontainer.setTimes(WMStimes);
@@ -131,7 +131,7 @@ Ext.define("BasiGX.view.container.WMSTimeSlider",{
                 xtype: 'slider',
                 name: 'timeslider',
                 tipText: function(thumb){
-                    var slider = Ext.ComponentQuery.query('timeseries-container-wmstimeslider')[0];
+                    var slider = Ext.ComponentQuery.query('basigx-container-wmstimeslider')[0];
                     var time = slider.getTimes()[thumb.value];
                     return Ext.Date.format(new Date(time), 'Y-m-d');
                 },
@@ -158,7 +158,7 @@ Ext.define("BasiGX.view.container.WMSTimeSlider",{
 
         var labelcontainer;
         Ext.each(me.items.items, function(item) {
-            if (item.name == "labelcontainer") {
+            if (item.name === "labelcontainer") {
                 labelcontainer = item;
             }
         });
@@ -184,10 +184,10 @@ Ext.define("BasiGX.view.container.WMSTimeSlider",{
         var me = this;
         var timeslider;
         Ext.each(me.items.items, function(item){
-            if (item.name == "timeslider") {
-                timeslider = item
+            if (item.name === "timeslider") {
+                timeslider = item;
             }
-        })
+        });
         var time = me.getTimes()[timeslider.getValue()];
         var layer = BasiGX.util.Layer.getLayerByName(me.layerNameInClient);
         layer.getSource().updateParams({TIME:time});

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -33,6 +33,7 @@
             'view/container/OverpassSearch.test.js',
             'view/container/Redlining.test.js',
             'view/container/WfsSearch.test.js',
+            'view/container/WMSTimeSlider.test.js',
             'view/form/AddWms.test.js',
             'view/form/CoordinateTransform.test.js',
             'view/form/CsvImport.test.js',

--- a/test/spec/view/container/WMSTimeSlider.test.js
+++ b/test/spec/view/container/WMSTimeSlider.test.js
@@ -1,0 +1,102 @@
+Ext.Loader.syncRequire(['BasiGX.view.container.WMSTimeSlider']);
+
+describe('BasiGX.view.container.WMSTimeSlider', function() {
+    var div;
+    var map;
+    var mapComponent;
+    var layer;
+    var slider;
+    var labelcontainer;
+    var timeslider;
+    beforeEach(function() {
+        div = document.createElement('div');
+        document.body.appendChild(div);
+        map = new ol.Map({
+            target: div,
+            view: new ol.View({
+                resolution: 7
+            })
+        });
+        mapComponent = Ext.create('GeoExt.component.Map', {
+            map: map
+        });
+        layer = new ol.layer.Tile({
+            name: 'test',
+            source: new ol.source.TileWMS({})
+        });
+        map.addLayer(layer);
+        slider = Ext.create('BasiGX.view.container.WMSTimeSlider', {
+            url: 'http://geoserver.mundialis.de/geoserver/timeseries/wms',
+            layerNameInWMS: 'soilmoisture',
+            layerNameInClient: 'test'
+        });
+        Ext.each(slider.items.items, function(item) {
+            if (item.name === "labelcontainer") {
+                labelcontainer = item;
+            }
+        });
+        Ext.each(slider.items.items, function(item) {
+            if (item.name === "timeslider") {
+                timeslider = item;
+            }
+        });
+    });
+    afterEach(function() {
+        slider.destroy();
+        layer = null;
+        map.setTarget(null);
+        map = null;
+        mapComponent.destroy();
+        labelcontainer = null;
+        timeslider = null;
+        document.body.removeChild(div);
+        div = null;
+    });
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.view.container.WMSTimeSlider).to.not.be(undefined);
+        });
+        it('can be instantiated', function(){
+            expect(slider).to.be.a(BasiGX.view.container.WMSTimeSlider);
+        });
+    });
+    describe('timestamps', function() {
+        it('has received timestamps', function(){
+            expect(slider.getTimes()).to.not.be(undefined);
+            expect(slider.getTimes()).to.be.an(Array);
+        });
+    });
+    describe('getLabels', function() {
+        it('has a label container', function(){
+            expect(labelcontainer).to.not.be(undefined);
+            expect(labelcontainer).to.be.a(Ext.container.Container);
+        });
+        it('has three label items', function(){
+            slider.setLabels();
+            expect(labelcontainer.items.items).to.be.an(Array);
+            expect(labelcontainer.items.items.length).to.be(3);
+        });
+        it('contains objects', function(){
+            Ext.each(labelcontainer.items.items, function(item) {
+                expect(item).to.be.an(Object);
+            });
+        });
+    });
+    describe('updateTime', function() {
+        it('has a slider container', function(){
+            expect(timeslider).to.not.be(undefined);
+            expect(timeslider).to.be.a(Ext.slider.Single);
+        });
+        it('choses the right time', function(){
+            slider.updateTime();
+            var slidertime = slider.getTimes()[timeslider.getValue()];
+            var thumbtime = slider.getTimes()[timeslider.thumbs[0].value];
+            var layertime = layer.getSource().getParams().TIME;
+            // "2016-04-11T00:00:00.000Z"
+            expect(layertime).to.match(
+              /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+/);
+            expect(slidertime).to.be(layertime);
+            expect(layertime).to.be(thumbtime);
+        });
+    });
+});


### PR DESCRIPTION
This slider takes a WMS-Time Layer and uses its timestamps to create itself. This makes it possible to slide through the different times from the layer.

The tests depend on an ajax request to a public WMS-time. If this foreign depency is not good practice it can be removed.
