### PR TITLE
replaces MapQuest layer source

### DIFF
--- a/src/view/panel/MapContainer.js
+++ b/src/view/panel/MapContainer.js
@@ -102,7 +102,7 @@ Ext.define("BasiGX.view.panel.MapContainer", {
             layers: [
                 new ol.layer.Tile({
                       source: new ol.source.TileWMS({
-                          url:"htto://ows.terrestris.de/ows?",
+                          url:"http://ows.terrestris.de/osm/service?",
                           params:{"layers": "OSM-WMS","TILED":true}
                       })
                 })

--- a/src/view/panel/MapContainer.js
+++ b/src/view/panel/MapContainer.js
@@ -101,7 +101,10 @@ Ext.define("BasiGX.view.panel.MapContainer", {
             hidden: true,
             layers: [
                 new ol.layer.Tile({
-                    source: new ol.source.MapQuest({layer: 'sat'})
+                      source: new ol.source.TileWMS({
+                          url:"htto://ows.terrestris.de/ows?",
+                          params:{"layers": "OSM-WMS","TILED":true}
+                      })
                 })
             ]
         },


### PR DESCRIPTION
In ol 3.17.0 the source MapQuest was removed. See https://github.com/openlayers/ol3/releases/tag/v3.17.0 . So it would be better to use a different source in the overviewmap.