### PR TITLE
Be more cautious when addding a filter

### DIFF
--- a/src/view/panel/MapContainer.js
+++ b/src/view/panel/MapContainer.js
@@ -280,7 +280,7 @@ Ext.define("BasiGX.view.panel.MapContainer", {
                 var layer = rec.getOlLayer();
                 var util = BasiGX.util.Layer;
                 var showKey = util.KEY_DISPLAY_IN_LAYERSWITCHER;
-                if (layer.get(showKey) === false) {
+                if (layer && layer.get(showKey) === false) {
                     return false;
                 }
                 return true;


### PR DESCRIPTION
In an application I observed that the `layer` from `getOlLayer` might be `undefined` (I issued an unlikely but allowed `removeAll` on the store of the layer tree). 

We should guard against this when adding a filter to our legend panel.

Please review.