### PR TITLE
Give the rowexpander plugin a pluginId

### DIFF
--- a/src/view/panel/LegendTree.js
+++ b/src/view/panel/LegendTree.js
@@ -106,7 +106,8 @@ Ext.define("BasiGX.view.panel.LegendTree", {
         me.plugins = [{
             ptype: 'rowexpanderwithcomponents',
             hideExpandColumn: true,
-            rowBodyCompTemplate: me.rowBodyCompTemplate
+            rowBodyCompTemplate: me.rowBodyCompTemplate,
+            pluginId: 'rowexpanderwithcomponents'
         }];
 
         // call parent


### PR DESCRIPTION
This way the plugin instance can be retrieved with code like

```js
    legendTree.getPlugin('rowexpanderwithcomponents');
```

Previously there was no way except for iterating over the return value
of `legendTree.getPlugins()`.