### PR TITLE
Fixed mobilewindow appearance in production build

### DIFF
--- a/src/view/panel/MobileWindow.js
+++ b/src/view/panel/MobileWindow.js
@@ -79,7 +79,10 @@ Ext.define("BasiGX.view.panel.MobileWindow", {
                 '[0].hide();">' +
                 '</i>',
             height: 40,
-            docked: 'top'
+            docked: 'top',
+            style: {
+                'background-color': 'white'
+            }
         });
         me.add(headerPanel);
 


### PR DESCRIPTION
This minor styling change seems to be necessary in ExtJS 6.0.1 when doing a modern production build, as the headerpanel has a transparent background. As this is just a minor styling fix, i will merge this once travis is green