### PR TITLE
Style enhancements

### DIFF
--- a/src/util/Color.js
+++ b/src/util/Color.js
@@ -67,6 +67,9 @@ Ext.define('BasiGX.util.Color', {
          *     // hex is now: "#ff0000"
          */
         rgbaToHex: function(rgba){
+            if (!rgba) {
+                return '';
+            }
             var regex = new RegExp("^rgba?[\\s+]?\\([\\s+]?(\\d+)[\\s+]?," +
                 "[\\s+]?(\\d+)[\\s+]?,[\\s+]?(\\d+)[\\s+]?", "i");
             rgba = rgba.match(regex);
@@ -74,6 +77,27 @@ Ext.define('BasiGX.util.Color', {
                 ("0" + parseInt(rgba[1],10).toString(16)).slice(-2) +
                 ("0" + parseInt(rgba[2],10).toString(16)).slice(-2) +
                 ("0" + parseInt(rgba[3],10).toString(16)).slice(-2) : '';
+        },
+
+        /**
+         * Method converts a rgba color string into an hex8 color string.
+         *
+         * Example:
+         *     var hex = BasiGX.util.Color.rgbaToHex("rgba(255,0,0,0)");
+         *     // hex is now: "#ff000000"
+         */
+        rgbaToHex8: function(rgba) {
+            if (!rgba) {
+                return '';
+            }
+            var regex = new RegExp("^rgba?[\\s+]?\\([\\s+]?(\\d+)[\\s+]?," +
+                "[\\s+]?(\\d+)[\\s+]?,[\\s+]?(\\d+)[\\s+]?,[\\s+]?(\\d+(?:\\.\\d+|))[\\s+]?", "i");
+            rgba = rgba.match(regex);
+            return (rgba && rgba.length === 5) ? "#" +
+                ("0" + parseInt(rgba[1],10).toString(16)).slice(-2) +
+                ("0" + parseInt(rgba[2],10).toString(16)).slice(-2) +
+                ("0" + parseInt(rgba[3],10).toString(16)).slice(-2) +
+                ("0" + Math.round(parseFloat(rgba[4]) * 255).toString(16)).slice(-2) : '';
         }
     }
 });

--- a/src/view/container/RedlineStyler.js
+++ b/src/view/container/RedlineStyler.js
@@ -632,6 +632,7 @@ Ext.define("BasiGX.view.container.RedlineStyler", {
             oldImage.getStroke().getWidth) {
             fallBackStrokeWidth = oldImage.getStroke().getWidth();
         }
+
         var style = new ol.style.Style({
             image: pointStyle.radius || pointStyle.fillcolor ||
             pointStyle.fillopacity || pointStyle.strokewidth ||
@@ -648,8 +649,10 @@ Ext.define("BasiGX.view.container.RedlineStyler", {
                     width: pointStyle.strokewidth ? pointStyle.strokewidth :
                         fallBackStrokeWidth
                 })
-            }) : oldImage
+            }) : oldImage,
+            text: oldStyle.getText() || new ol.style.Text()
         });
+
         return style;
     },
 
@@ -664,7 +667,8 @@ Ext.define("BasiGX.view.container.RedlineStyler", {
                     oldStyle.getStroke().getColor(),
                 width: lineStyle.strokewidth ? lineStyle.strokewidth :
                     oldStyle.getStroke().getWidth()
-            }) : oldStyle.getStroke()
+            }) : oldStyle.getStroke(),
+            text: oldStyle.getText() || new ol.style.Text()
         });
         return style;
     },
@@ -684,7 +688,8 @@ Ext.define("BasiGX.view.container.RedlineStyler", {
                     oldStyle.getStroke().getColor(),
                 width: polygonStyle.strokewidth ? polygonStyle.strokewidth :
                     oldStyle.getStroke().getWidth()
-            }) : oldStyle.getStroke()
+            }) : oldStyle.getStroke(),
+            text: oldStyle.getText() || new ol.style.Text()
         });
         return style;
     },


### PR DESCRIPTION
In this PR you'll find:
* A new method `rgbaToHex8()` to convert a RGBA color string into an hex8 color string.
* A default (and empty) `ol.Style.Text` object in any redlining style.