### PR TITLE
set filter flag for legend store before layer was added to the map

### DIFF
--- a/src/view/button/Measure.js
+++ b/src/view/button/Measure.js
@@ -172,14 +172,13 @@ Ext.define("BasiGX.view.button.Measure", {
                     })
                 })
             });
+            // Set our internal flag to filter this layer out of the tree / legend
+            var noLayerSwitcherKey = BasiGX.util.Layer.KEY_DISPLAY_IN_LAYERSWITCHER;
+            me.measureVectorLayer.set(noLayerSwitcherKey, false);
             me.map.addLayer(me.measureVectorLayer);
         } else {
             me.measureVectorLayer = measureLayer;
         }
-
-        // Set our internal flag to filter this layer out of the tree / legend
-        var noLayerSwitcherKey = BasiGX.util.Layer.KEY_DISPLAY_IN_LAYERSWITCHER;
-        me.measureVectorLayer.set(noLayerSwitcherKey, false);
 
         var type = (me.measureType === 'line' ? 'MultiLineString' : 'MultiPolygon');
         me.drawAction = new ol.interaction.Draw({


### PR DESCRIPTION
`BasiGX.util.Layer.KEY_DISPLAY_IN_LAYERSWITCHER` flag should be set on the layer **before** this will be added to the map, otherwise the `measurelayer` appears in the layerTree.

Please review @terrestris/owners 