### PR TITLE
Set fallback value for layer transparency property to `true`

### DIFF
--- a/src/util/ConfigParser.js
+++ b/src/util/ConfigParser.js
@@ -543,7 +543,7 @@ Ext.define('BasiGX.util.ConfigParser', {
                     attributions: attributions,
                     params: {
                         LAYERS: config.layers,
-                        TRANSPARENT: config.transparent || false,
+                        TRANSPARENT: config.transparent || true,
                         VERSION: config.version || '1.1.1'
                     }
                 };


### PR DESCRIPTION
Title says it all.

This mini change is important for print functionality among other things - non transparent layers will be covered by each other so only the topmost layer can be printed.

Please review @weskamm 