### PR TITLE
I18n viewmodel determination fix

### DIFF
--- a/src/view/combo/Language.js
+++ b/src/view/combo/Language.js
@@ -286,9 +286,11 @@ Ext.define('BasiGX.view.combo.Language', {
                     var viewModel = configurator.values.viewModel;
                     var type = viewModel.type;
                     // if the component has an own viewModel instance
-                    if (!Ext.isEmpty(type)) {
+                    if (!Ext.isEmpty(type) || Ext.isString(viewModel)) {
+                        var viewName = type || viewModel;
                         var viewClassName = Ext.ClassManager.getName(
-                                Ext.ClassManager.getByAlias('viewmodel.' + type));
+                                Ext.ClassManager
+                                    .getByAlias('viewmodel.' + viewName));
                         baseLocaleObj.override = viewClassName;
                         Ext.define(viewClassName, baseLocaleObj);
                     } else if (!Ext.isEmpty(viewModel)) {

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -26,6 +26,7 @@
             'view/button/ZoomIn.test.js',
             'view/button/ZoomOut.test.js',
             'view/button/ZoomToExtent.test.js',
+            'view/combo/Language.test.js',
             'view/combo/ScaleCombo.test.js',
             'view/component/Map.test.js',
             'view/container/LayerSlider.test.js',

--- a/test/spec/view/combo/Language.test.js
+++ b/test/spec/view/combo/Language.test.js
@@ -1,0 +1,41 @@
+Ext.Loader.syncRequire([
+    'BasiGX.view.combo.Language'
+]);
+
+describe('BasiGX.view.combo.Language', function() {
+    var combo;
+    beforeEach(function() {
+        combo = Ext.create('BasiGX.view.combo.Language', {
+        });
+    });
+    afterEach(function() {
+        combo.destroy();
+    });
+
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.view.combo.Language).to.not.be(undefined);
+        });
+        it('can be instantiated', function(){
+            expect(combo).to.be.a(BasiGX.view.combo.Language);
+        });
+    });
+    describe('default application language', function() {
+        it('found a default application language', function() {
+            expect(combo.getDefaultLanguage()).to.not.be(undefined);
+            expect(combo.getDefaultLanguage()).to.be.a('string');
+        });
+    });
+    describe('locale template url', function() {
+        it('found a template for locale url', function() {
+            expect(combo.getAppLocaleUrlTpl()).to.not.be(undefined);
+            expect(combo.getAppLocaleUrlTpl()).to.be.a('string');
+        });
+    });
+    describe('defaults', function() {
+        it('has some default languages', function(){
+            expect(combo.getLanguages()).to.not.be(undefined);
+            expect(combo.getLanguages()).to.be.an(Array);
+        });
+    });
+});


### PR DESCRIPTION
This PR introduces a small fix for right determination of `viewModel` class, if this was provided not as `type` object, but as `String`.
Also some basic tests were added (till now, there were any tests for `BasiGX.view.combo.Language` at all).

This check is very helpful particularly for classes, which have a "real" `viewModel` classes (not inline).

The bug was detected during momo-project development, the proposed fix was successfully tested with all existing affected classes.

Please review @terrestris/owners 
