### PR TITLE
Update animate util

### DIFF
--- a/src/util/Animate.js
+++ b/src/util/Animate.js
@@ -61,9 +61,26 @@ Ext.define('BasiGX.util.Animate', {
              // radius will be 5 at start and 30 at end.
              var radius = ol.easing.easeOut(elapsedRatio) * 25 + 5;
              var opacity = ol.easing.easeOut(1 - elapsedRatio);
+             var flashStyle;
 
-             var flashStyle = new ol.style.Style({
-                 image: new ol.style.Circle({
+             if (vectorContext.setStyle && vectorContext.drawGeometry) {
+                 // for ol3 versions from v3.15.0
+                 flashStyle = new ol.style.Style({
+                     image: new ol.style.Circle({
+                         radius: radius,
+                         snapToPixel: false,
+                         stroke: new ol.style.Stroke({
+                             color: 'rgba(255, 0, 0, ' + opacity + ')',
+                             width: 4,
+                             opacity: opacity
+                         })
+                     })
+                 });
+                 vectorContext.setStyle(flashStyle);
+                 vectorContext.drawGeometry(flashGeom, null);
+             } else {
+                 // for ol3 versions older v3.15.0
+                 flashStyle = new ol.style.Circle({
                      radius: radius,
                      snapToPixel: false,
                      stroke: new ol.style.Stroke({
@@ -71,11 +88,11 @@ Ext.define('BasiGX.util.Animate', {
                          width: 4,
                          opacity: opacity
                      })
-                 })
-             });
+                 });
+                 vectorContext.setImageStyle(flashStyle);
+                 vectorContext.drawPointGeometry(flashGeom, null);
+             }
 
-             vectorContext.setStyle(flashStyle);
-             vectorContext.drawGeometry(flashGeom, null);
              if (elapsed > duration) {
                ol.Observable.unByKey(listenerKey);
                return;

--- a/src/util/Animate.js
+++ b/src/util/Animate.js
@@ -62,18 +62,20 @@ Ext.define('BasiGX.util.Animate', {
              var radius = ol.easing.easeOut(elapsedRatio) * 25 + 5;
              var opacity = ol.easing.easeOut(1 - elapsedRatio);
 
-             var flashStyle = new ol.style.Circle({
-               radius: radius,
-               snapToPixel: false,
-               stroke: new ol.style.Stroke({
-                 color: 'rgba(255, 0, 0, ' + opacity + ')',
-                 width: 4,
-                 opacity: opacity
-               })
+             var flashStyle = new ol.style.Style({
+                 image: new ol.style.Circle({
+                     radius: radius,
+                     snapToPixel: false,
+                     stroke: new ol.style.Stroke({
+                         color: 'rgba(255, 0, 0, ' + opacity + ')',
+                         width: 4,
+                         opacity: opacity
+                     })
+                 })
              });
 
-             vectorContext.setImageStyle(flashStyle);
-             vectorContext.drawPointGeometry(flashGeom, null);
+             vectorContext.setStyle(flashStyle);
+             vectorContext.drawGeometry(flashGeom, null);
              if (elapsed > duration) {
                ol.Observable.unByKey(listenerKey);
                return;


### PR DESCRIPTION
This PR updates the animate util as it uses the ol3 methods on the vector context which changed in v3.15.0 (https://github.com/openlayers/ol3/releases/tag/v3.15.0).

It can be still used with older versions.