### PR TITLE
Use commandline flags to make the testsuite less fragile

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "output": "${package.dir}/build",
     "scripts": {
         "pretest": "npm run lint-js",
-        "test": "mocha-phantomjs --ssl-protocol=any --ignore-ssl-errors=true test/index.html",
+        "test": "mocha-phantomjs --ignore-resource-errors --ssl-protocol=any --ignore-ssl-errors=true --local-to-remote-url-access=true test/index.html",
         "lint-js": "eslint -c .eslintrc src/ && eslint -c test/.eslintrc test/",
-        "save-coverage": "mocha-phantomjs --ssl-protocol=any --ignore-ssl-errors=true --hooks ./test/phantom_hooks.js test/index.html",
+        "save-coverage": "mocha-phantomjs --ignore-resource-errors --ssl-protocol=any --ignore-ssl-errors=true --local-to-remote-url-access=true --hooks ./test/phantom_hooks.js test/index.html",
         "clean-coverage": "rm -rf src_instrumented src_old coverage",
         "ci-coverage": "npm run clean-coverage && istanbul instrument src -o src_instrumented && mv src src_old && mv src_instrumented src && istanbul cover npm run save-coverage && mv src src_instrumented && mv src_old src && istanbul report --root ./coverage lcovonly && cat ./coverage/lcov.info | coveralls",
         "html-coverage": "npm run clean-coverage && istanbul instrument src -o src_instrumented && mv src src_old && mv src_instrumented src && istanbul cover npm run save-coverage && mv src src_instrumented && mv src_old src && istanbul report --root ./coverage html"


### PR DESCRIPTION
This changes our npm script for testing to pass the following flags:

* `--ignore-resource-errors`, [docs](https://github.com/nathanboktae/mocha-phantomjs-core#ignoreresourceerrors)
* `--local-to-remote-url-access=true`, [docs](http://phantomjs.org/api/command-line.html)

Please review.