### PR TITLE
Add missing msg field for angle measurement

### DIFF
--- a/src/view/button/Measure.js
+++ b/src/view/button/Measure.js
@@ -40,6 +40,7 @@ Ext.define("BasiGX.view.button.Measure", {
            textangle: 'Winkel messen',
            continuePolygonMsg: 'Klicken zum Zeichnen der Fläche',
            continueLineMsg: 'Klicken zum Zeichnen der Strecke',
+           continueAngleMsg: 'Klicken zum Zeichnen des Winkels',
            clickToDrawText: 'Klicken zum Messen'
        }
     },


### PR DESCRIPTION
This PR adds a missing viewModel field declaration that is required (as a default value) to show the appropriate text when drawing an angle.