### PR TITLE
Hover plugin minor bugfixes

### DIFF
--- a/src/plugin/Hover.js
+++ b/src/plugin/Hover.js
@@ -414,7 +414,9 @@ Ext.define('BasiGX.plugin.Hover', {
 
         if (layers.length > 0 && features.length > 0) {
             map.getOverlays().forEach(function(o) {
-                map.removeOverlay(o);
+                if (o.get(overlayIdentifierKey) === overlayIdentifierVal) {
+                    map.removeOverlay(o);
+                }
             });
 
             var div = Ext.dom.Helper.createDom('<div>');

--- a/src/plugin/Hover.js
+++ b/src/plugin/Hover.js
@@ -67,7 +67,8 @@ Ext.define('BasiGX.plugin.Hover', {
         hoverVectorLayerSource: null,
         hoverVectorLayer: null,
         hoverVectorLayerInteraction: null,
-        dynamicHoverColor: false
+        dynamicHoverColor: false,
+        enableHoverSelection: true
     },
 
     /**
@@ -106,7 +107,10 @@ Ext.define('BasiGX.plugin.Hover', {
 
         me.addHoverVectorLayerSource();
         me.addHoverVectorLayer();
-        me.addHoverVectorLayerInteraction();
+
+        if (me.getEnableHoverSelection()) {
+            me.addHoverVectorLayerInteraction();
+        }
 
         me.setupMapEventListeners();
         this.setCmp(cmp);


### PR DESCRIPTION
Here we cover two minor issues regarding the `Hover` plugin:
* Introduce `enableHoverSelection` to control wether to allow click selection of a hovered feature.
* Only remove ol `Overlays` that are controlled by the plugin itself.