### PR TITLE
Make the CSRF parameter name also accessible

### DIFF
--- a/src/util/CSRF.js
+++ b/src/util/CSRF.js
@@ -15,47 +15,154 @@
  */
 /**
  *
- * CSRF Util
+ * CSRF Utility methods.
  *
- * Some methods to access the csrf-token information served by spring security
+ * Some methods to access the csrf-token information served by spring security.
+ *
+ * The methods herein assume a certain HTML structure, which is easiest achieved
+ * by including a markup like the following in your base HTML:
+ *
+ *     <meta name="_csrf" content="${_csrf.token}" />
+ *     <meta name="_csrf_header" content="${_csrf.headerName}" />
+ *     <meta name="_csrf_parameter_name" content="${_csrf.parameterName}" />
+ *
+ * All methods will warn if the structure in the DOM is not as expected.
  *
  * @class BasiGX.util.CSRF
  */
 Ext.define('BasiGX.util.CSRF', {
 
+    requires: [
+        'Ext.String',
+        'Ext.DomQuery'
+    ],
+
     statics: {
         /**
-        * Get the CSRF token value.
-        *
-        * @return {String} - the key value, e.g. "741a3b1-221f-4d1d-..."
-        */
+         * A utility method to get the `content` attribute of a `<meta>`-tag
+         * with the given name. Will issue a warning to the console if the
+         * tag cannot be found.
+         *
+         * @param {String} name The name of the `<meta>`-tag we look for.
+         * @return {String} The content attribute of the `<meta>`-tag, or the
+         *     empty string if the tag was not found.
+         * @private
+         */
+        getContentFromMetaTagByName: function(name) {
+            var selector = Ext.String.format('meta[name="{0}"]', name);
+            var element = Ext.DomQuery.select(selector)[0];
+            var content;
+            if (element) {
+                content = element.content || '';
+            } else {
+                var tpl = 'Failed to find tag <meta name="{0}" />. Is it ' +
+                    ' present in the page DOM?';
+                var msg = Ext.String.format(tpl, name);
+                Ext.log.warn(msg);
+                content = '';
+            }
+            return content;
+        },
+
+        /**
+         * Get the CSRF token value.
+         *
+         * In order for this method to produce reliable output, your base HTML
+         * page should contain a `<meta>`-tag in the `<head>` with name
+         * `_csrf`. The `content` attribute is best filled from Spring by
+         * using this variable: `${_csrf.token}`.
+         *
+         * @return {String} - the key value, e.g. "741a3b1-221f-4d1d-..." or the
+         *     empty string if the meta tag cannot be found.
+         */
         getValue: function() {
-            return Ext.DomQuery.select('meta[name=_csrf]')[0].content;
+            var metaName = '_csrf';
+            return BasiGX.util.CSRF.getContentFromMetaTagByName(metaName);
         },
 
         /**
-        * Get the CSRF token key.
-        *
-        * @return {String} - the key string, e.g. "X-CSRF-TOKEN"
-        */
+         * Get the CSRF token key. This can be used if you want to send CSRF
+         * tokens as header. If you want to send it using a form parameter, use
+         * the method #getParamName instead.
+         *
+         * In order for this method to produce reliable output, your base HTML
+         * page should contain a `<meta>`-tag in the `<head>` with name
+         * `_csrf_header`. The `content` attribute is best filled from Spring by
+         * using this variable: `${_csrf.headerName}`.
+         *
+         * @return {String} - the key string, e.g. "X-CSRF-TOKEN" ort the empty
+         *     string if the meta tag cannot be found.
+         */
         getKey: function() {
-            return Ext.DomQuery.select('meta[name=_csrf_header]')[0].content;
+            var metaName = '_csrf_header';
+            return BasiGX.util.CSRF.getContentFromMetaTagByName(metaName);
         },
 
         /**
-        * Get the full CSRF token object.
-        *
-        * @return {Object} header - the header containing the csrf key and value
-        */
-        getHeader: function() {
-            var me = this,
-                header = {},
-                headerName = me.getKey(),
-                headerVal = me.getValue();
+         * Get the name of the parameter to send when you want to pass CSRF
+         * tokens via a form. Alternatively you can use #getKey to get the name
+         * of the header to send for CSRF-protection.
+         *
+         * In order for this method to produce reliable output, your base HTML
+         * page should contain a `<meta>`-tag in the `<head>` with name
+         * `_csrf_parameter_name`. The `content` attribute is best filled from
+         * Spring by using this variable: `${_csrf.parameterName}`.
+         *
+         * @return {String} The name of the parameter to send when sending CSRF
+         *     tokens via forms, e.g. "_csrf" or the empty string if the meta
+         *     tag cannot be found.
+         */
+        getParamName: function() {
+            var metaName = '_csrf_parameter_name';
+            return BasiGX.util.CSRF.getContentFromMetaTagByName(metaName);
+        },
 
-            header[headerName] = headerVal;
+        /**
+         * Get the full CSRF token object. Can directly be used for AJAX queries
+         * e.g. by passing them as `header` config to `Ext.Ajax.request`.
+         *
+         * @return {Object} header - the header containing the CSRF key and
+         *     value or an empty object if any of the required meta fields
+         *     cannot be found.
+         */
+        getHeader: function() {
+            var me = BasiGX.util.CSRF;
+            var header = {};
+            var headerName = me.getKey();
+            var headerVal = me.getValue();
+
+            if (headerName && headerVal) {
+                header[headerName] = headerVal;
+            }
 
             return header;
+        },
+
+        /**
+         * Returns an `Ext.dom.Helper` specification for adding an
+         * `<input type="hidden">` that contains the relevant CSRF information.
+         *
+         * @return {Object} A specification for a correctly configured hidden
+         *     input field for sending the CSRF information or such a
+         *     specification without `name` and `value` if any of the required
+         *     meta fields cannot be found.
+         */
+        getDomHelperField: function() {
+            var me = BasiGX.util.CSRF;
+            var name = me.getParamName();
+            var value = me.getValue();
+            var field = {
+                tag: 'input',
+                type: 'hidden'
+            };
+            if (name && value) {
+                field = Ext.apply(field, {
+                    name: name,
+                    value: value
+                });
+            }
+            return field;
         }
+
     }
 });

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -10,6 +10,7 @@
             'util/Application.test.js',
             'util/ConfigParser.test.js',
             'util/Controller.test.js',
+            'util/CSRF.test.js',
             'util/Layer.test.js',
             'util/Map.test.js',
             'util/Object.test.js',

--- a/test/spec/util/CSRF.test.js
+++ b/test/spec/util/CSRF.test.js
@@ -1,0 +1,212 @@
+Ext.Loader.syncRequire(['BasiGX.util.CSRF']);
+
+describe('BasiGX.util.CSRF', function() {
+    var tokenValue = 'my-csrf-token-value';
+    var headerName = 'my-csrf-header-name';
+    var paramName = 'my-csrf-param-name';
+    var generated = [];
+    var removeGeneratedDom = function() {
+        Ext.each(generated, function(generatedElement) {
+            if(generatedElement && generatedElement.destroy) {
+                generatedElement.destroy();
+            }
+            generatedElement = null;
+        });
+        generated = [];
+    };
+    beforeEach(function() {
+        // mockup the expected DOM structure
+        var specs = [{
+            tag: 'meta',
+            name: '_csrf',
+            content: tokenValue
+        }, {
+            tag: 'meta',
+            name: '_csrf_header',
+            content: headerName
+        }, {
+            tag: 'meta',
+            name: '_csrf_parameter_name',
+            content: paramName
+        }];
+        Ext.each(specs, function(spec) {
+            generated.push(Ext.dom.Helper.append(
+                Ext.getHead(), spec, true
+            ));
+        });
+    });
+    afterEach(removeGeneratedDom);
+
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.util.CSRF).to.not.be(undefined);
+        });
+    });
+
+    describe('Static methods', function() {
+
+        describe('#getValue', function() {
+            it('is a defined function', function() {
+                expect(BasiGX.util.CSRF.getValue).to.be.ok();
+                expect(BasiGX.util.CSRF.getValue).to.be.a('function');
+            });
+            it('returns the CSRF token', function() {
+                var got = BasiGX.util.CSRF.getValue();
+                expect(got).to.be(tokenValue);
+            });
+            it('returns the empty string and warns if DOM is not as expected',
+                function() {
+                    // setup
+                    // cleanup manually, so the DOM does not have the meta tags
+                    removeGeneratedDom();
+                    var logSpy = sinon.spy(Ext.log, 'warn');
+
+                    var got = BasiGX.util.CSRF.getValue();
+
+                    expect(got).to.be('');
+                    expect(logSpy.called).to.be(true);
+                    expect(logSpy.callCount).to.be(1);
+
+                    // cleanup
+                    Ext.log.warn.restore();
+                }
+            );
+        });
+
+        describe('#getKey', function() {
+            it('is a defined function', function() {
+                expect(BasiGX.util.CSRF.getKey).to.be.ok();
+                expect(BasiGX.util.CSRF.getKey).to.be.a('function');
+            });
+            it('returns the CSRF header name', function() {
+                var got = BasiGX.util.CSRF.getKey();
+                expect(got).to.be(headerName);
+            });
+            it('returns the empty string and warns if DOM is not as expected',
+                function() {
+                    // setup
+                    // cleanup manually, so the DOM does not have the meta tags
+                    removeGeneratedDom();
+                    var logSpy = sinon.spy(Ext.log, 'warn');
+
+                    var got = BasiGX.util.CSRF.getKey();
+
+                    expect(got).to.be('');
+                    expect(logSpy.called).to.be(true);
+                    expect(logSpy.callCount).to.be(1);
+
+                    // cleanup
+                    Ext.log.warn.restore();
+                }
+            );
+        });
+
+        describe('#getParamName', function() {
+            it('is a defined function', function() {
+                expect(BasiGX.util.CSRF.getParamName).to.be.ok();
+                expect(BasiGX.util.CSRF.getParamName).to.be.a('function');
+            });
+            it('returns the CSRF parameter name', function() {
+                var got = BasiGX.util.CSRF.getParamName();
+                expect(got).to.be(paramName);
+            });
+            it('returns the empty string and warns if DOM is not as expected',
+                function() {
+                    // setup
+                    // cleanup manually, so the DOM does not have the meta tags
+                    removeGeneratedDom();
+                    var logSpy = sinon.spy(Ext.log, 'warn');
+
+                    var got = BasiGX.util.CSRF.getParamName();
+
+                    expect(got).to.be('');
+                    expect(logSpy.called).to.be(true);
+                    expect(logSpy.callCount).to.be(1);
+
+                    // cleanup
+                    Ext.log.warn.restore();
+                }
+            );
+        });
+
+        describe('#getHeader', function() {
+            it('is a defined function', function() {
+                expect(BasiGX.util.CSRF.getHeader).to.be.ok();
+                expect(BasiGX.util.CSRF.getHeader).to.be.a('function');
+            });
+            it('returns an object', function() {
+                var got = BasiGX.util.CSRF.getHeader();
+                expect(got).to.be.an('object');
+            });
+            it('has a member for the CSRF header name', function() {
+                var got = BasiGX.util.CSRF.getHeader();
+                expect(headerName in got).to.be(true);
+                expect(got[headerName]).to.be.ok();
+                expect(got[headerName]).to.be.a('string');
+            });
+            it('ensures the value at the key is the token', function() {
+                var got = BasiGX.util.CSRF.getHeader();
+                expect(got[headerName]).to.be(tokenValue);
+            });
+            it('returns an empty object and warns if DOM is not as expected',
+                function() {
+                    // setup
+                    // cleanup manually, so the DOM does not have the meta tags
+                    removeGeneratedDom();
+                    var logSpy = sinon.spy(Ext.log, 'warn');
+
+                    var got = BasiGX.util.CSRF.getHeader();
+
+                    expect(got).to.eql({});
+                    expect(logSpy.called).to.be(true);
+                    expect(logSpy.callCount).to.be(2); // name and value missing
+
+                    // cleanup
+                    Ext.log.warn.restore();
+                }
+            );
+        });
+
+        describe('#getDomHelperField', function() {
+            it('is a defined function', function() {
+                expect(BasiGX.util.CSRF.getDomHelperField).to.be.ok();
+                expect(BasiGX.util.CSRF.getDomHelperField).to.be.a('function');
+            });
+            it('returns an object', function() {
+                var got = BasiGX.util.CSRF.getDomHelperField();
+                expect(got).to.be.an('object');
+            });
+            it('returns a spec for a hidden input', function() {
+                var got = BasiGX.util.CSRF.getDomHelperField();
+                expect(got.tag).to.be('input');
+                expect(got.type).to.be('hidden');
+            });
+            it('ensures the name and value are set correctly', function() {
+                var got = BasiGX.util.CSRF.getDomHelperField();
+                expect(got.name).to.be(paramName);
+                expect(got.value).to.be(tokenValue);
+            });
+            it('returns hidden input wo/ name&value if DOM is not as expected',
+                function() {
+                    // setup
+                    // cleanup manually, so the DOM does not have the meta tags
+                    removeGeneratedDom();
+                    var logSpy = sinon.spy(Ext.log, 'warn');
+
+                    var got = BasiGX.util.CSRF.getDomHelperField();
+
+                    expect(got).to.eql({
+                        tag: 'input',
+                        type: 'hidden'
+                    });
+                    expect(logSpy.called).to.be(true);
+                    expect(logSpy.callCount).to.be(2); // name and value missing
+
+                    // cleanup
+                    Ext.log.warn.restore();
+                }
+            );
+        });
+
+    });
+});


### PR DESCRIPTION
This enhances the CSRF utility to provide two new methods:

* `getParamName` return the name of the CSRF parameter (provided the expected DOM structure exists)
* `getDomHelperField` returns a spec ready to be used with e.g. `Ext.dom.Helper` wjhich will result in an `<input type="hidden"> including the relvant CSRF information.

Please review.