### PR TITLE
Make the add wms window configurable

### DIFF
--- a/src/view/button/AddWms.js
+++ b/src/view/button/AddWms.js
@@ -74,7 +74,7 @@ Ext.define("BasiGX.view.button.AddWms", {
                     }]
                 };
 
-                var windowConfigToApply = this.getConfig('windowConfig');
+                var windowConfigToApply = this.getWindowConfig();
                 Ext.apply(windowConfig, windowConfigToApply);
 
                 Ext.create('Ext.window.Window', windowConfig).show();

--- a/src/view/button/AddWms.js
+++ b/src/view/button/AddWms.js
@@ -55,10 +55,15 @@ Ext.define("BasiGX.view.button.AddWms", {
      *
      */
     config: {
+        windowConfig: {
+            // can be used by subclasses to apply/merge
+            // additional/other values for the window
+        },
         handler: function(){
             var win = Ext.ComponentQuery.query('[name=add-wms-window]')[0];
             if(!win){
-                Ext.create('Ext.window.Window', {
+
+                var windowConfig = {
                     name: 'add-wms-window',
                     title: this.getViewModel().get('windowTitle'),
                     width: 500,
@@ -67,7 +72,12 @@ Ext.define("BasiGX.view.button.AddWms", {
                     items: [{
                         xtype: 'basigx-form-addwms'
                     }]
-                }).show();
+                };
+
+                var windowConfigToApply = this.getConfig('windowConfig');
+                Ext.apply(windowConfig, windowConfigToApply);
+
+                Ext.create('Ext.window.Window', windowConfig).show();
             } else {
                 BasiGX.util.Animate.shake(win);
             }


### PR DESCRIPTION
This makes the "Add WMS" window (optionally) configurable by passing values for the window in the `windowConfig` object that is introduced in this PR.

Existing applications do not need any adaptions (i.e. this code should work fine for them, too).