### PR TITLE
Fix hover plugin

### DIFF
--- a/src/plugin/Hover.js
+++ b/src/plugin/Hover.js
@@ -326,9 +326,9 @@ Ext.define('BasiGX.plugin.Hover', {
                         me.showHoverFeature(layer, respFeatures, respProjection);
 
                         Ext.each(respFeatures, function(feature) {
+                            feature.set('layer', layer);
                             var featureStyle = me.highlightStyleFunction(
                                     feature, resolution, pixelValues);
-                            feature.set('layer', layer);
                             feature.setStyle(featureStyle);
                             hoverFeatures.push(feature);
                         });


### PR DESCRIPTION
Ensure the layer is set as reference to the hover feature before applying the highlight style function.