### PR TITLE
Make LayerSetChooser configurable with local config JSON

### DIFF
--- a/src/view/panel/LayerSetChooser.js
+++ b/src/view/panel/LayerSetChooser.js
@@ -84,6 +84,13 @@ Ext.define("BasiGX.view.panel.LayerSetChooser", {
     layerSetUrl: null,
 
     /**
+     * JSON-object to be passed to the automatically created
+     * 'basigx-view-layerset'.
+     * Only has an effect if this.items is empty.
+     */
+    layerSetData: null,
+
+    /**
      *
      */
     tpl: null,
@@ -115,10 +122,12 @@ Ext.define("BasiGX.view.panel.LayerSetChooser", {
     initComponent: function() {
 
         if(Ext.isEmpty(this.items)) {
+
             this.items = [{
                 xtype: 'basigx-view-layerset',
                 scrollable: true,
                 layerSetUrl: this.layerSetUrl,
+                layerSetData: this.layerSetData,
                 tpl: this.tpl
             }];
         }

--- a/src/view/view/LayerSet.js
+++ b/src/view/view/LayerSet.js
@@ -30,9 +30,16 @@ Ext.define("BasiGX.view.view.LayerSet", {
 
     /**
      * the url to request the layerset json-file.
-     * If this is null, a demo set will be shown
+     * If this is null, #layerSetData or a demo set will be shown
      */
     layerSetUrl: null,
+
+    /**
+     * The local JSON layerset configuration object.
+     * Only has an effect if #layerSetUrl is null.
+     * If this is null a demo set will be shown.
+     */
+    layerSetData: null,
 
     /**
      * the default path to request the images from
@@ -89,27 +96,31 @@ Ext.define("BasiGX.view.view.LayerSet", {
             store;
 
         if (Ext.isEmpty(me.layerSetUrl)) {
-            // setup demo content
+
+            // use given local data or demo data
+            var data = me.layerSetData || [
+                {
+                    "title": "Stadtkarte",
+                    "name": "stadtkarte",
+                    "thumb": me.demoThumb
+                },
+                {
+                    "title": "Verkehr",
+                    "name": "verkehr",
+                    "thumb": me.demoThumb
+                },
+                {
+                    "title": "Umwelt",
+                    "name": "umwelt",
+                    "thumb": me.demoThumb
+                }
+            ];
+
+            // setup local content
             store = Ext.create('Ext.data.Store', {
                 fields: ['name', 'thumb', 'url', 'type'],
                 sorters: 'type',
-                data: [
-                    {
-                        "title": "Stadtkarte",
-                        "name": "stadtkarte",
-                        "thumb": me.demoThumb
-                    },
-                    {
-                        "title": "Verkehr",
-                        "name": "verkehr",
-                        "thumb": me.demoThumb
-                    },
-                    {
-                        "title": "Umwelt",
-                        "name": "umwelt",
-                        "thumb": me.demoThumb
-                    }
-                ]
+                data: data
             });
 
         } else {


### PR DESCRIPTION
This introduces the possibilty to configure a ``BasiGX.view.panel.LayerSetChooser`` by a local config JSON-object, which is passed and interpreted to the underlying ``BasiGX.view.view.LayerSet``.