### PR TITLE
Add and use a utility class to enhance accessibility

### DIFF
--- a/src/util/Accessibility.js
+++ b/src/util/Accessibility.js
@@ -1,0 +1,53 @@
+/* Copyright (c) 2017 terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * Accessibility Utility class
+ *
+ * Some methods to enhance the accessibility of an ExtJS application.
+ *
+ * @class BasiGX.util.Accessibility
+ */
+Ext.define('BasiGX.util.Accessibility', {
+    alternateClassName: 'BasiGX.util.A11y',
+    statics: {
+
+        /**
+         * Returns an `Ext.Element` for the top-level `<html>`-element.
+         *
+         * @return {Ext.Element} The `Ext.Element` wrapped around the
+         *     top-level `<html>`-element.
+         */
+        getHtmlElement: function() {
+            return Ext.get(Ext.DomQuery.select('html')[0]);
+        },
+
+        /**
+         * Sets the 'lang'-attribute of the top-level `<html>`-element to the
+         * passed value. This enables screenreaders to pronounce the content
+         * of a page better.
+         *
+         * @param {String} language The language to set. Should be an ISO 639-1
+         *     language code, e.g. `'en'` or `'de'`.
+         */
+        setHtmlLanguage: function(language) {
+            var htmlElem = BasiGX.util.Accessibility.getHtmlElement();
+            if (htmlElem) {
+                htmlElem.set({lang: language});
+            }
+        }
+
+    }
+});

--- a/src/view/combo/Language.js
+++ b/src/view/combo/Language.js
@@ -71,6 +71,7 @@ Ext.define('BasiGX.view.combo.Language', {
     extend: 'Ext.form.field.ComboBox',
     xtype: 'basigx-combo-language',
     requires: [
+        'BasiGX.util.Accessibility'
     ],
 
     viewModel: {
@@ -171,8 +172,9 @@ Ext.define('BasiGX.view.combo.Language', {
             change: me.onLanguageChange
         });
 
-        me.setValue(me.getDefaultLanguage());
-
+        var defaultLanguage = me.getDefaultLanguage();
+        me.setValue(defaultLanguage);
+        BasiGX.util.Accessibility.setHtmlLanguage(defaultLanguage);
     },
 
     /**
@@ -223,6 +225,7 @@ Ext.define('BasiGX.view.combo.Language', {
             } finally {
                 if (respObj) {
                     me.setAppLanguage(respObj);
+                    BasiGX.util.Accessibility.setHtmlLanguage(me.locale);
                     me.recreateSingletons();
                 }
             }

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -6,6 +6,7 @@
             'basics.test.js',
             'plugin/Hover.test.js',
             'plugin/WfsCluster.test.js',
+            'util/Accessibility.test.js',
             'util/Animate.test.js',
             'util/Application.test.js',
             'util/ConfigParser.test.js',

--- a/test/spec/util/Accessibility.test.js
+++ b/test/spec/util/Accessibility.test.js
@@ -1,0 +1,49 @@
+Ext.Loader.syncRequire(['BasiGX.util.Accessibility']);
+
+describe('BasiGX.util.Accessibility', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.util.Accessibility).to.not.be(undefined);
+        });
+        it('is aliased as BasiGX.util.A11y', function() {
+            expect(BasiGX.util.A11y).to.not.be(undefined);
+            expect(BasiGX.util.A11y).to.be(BasiGX.util.Accessibility);
+        });
+    });
+
+    describe('Static methods', function() {
+        var htmlElement = null;
+        beforeEach(function() {
+            htmlElement = document.querySelector('html');
+        });
+        afterEach(function() {
+            htmlElement.removeAttribute('lang');
+            htmlElement = null;
+        });
+
+        describe('#getHtmlElement', function() {
+            it('returns the <html>-element as Ext.Element', function() {
+                var got = BasiGX.util.Accessibility.getHtmlElement();
+                expect(got).to.be.ok();
+                expect(got).to.be.an(Ext.Element);
+                expect(got.dom).to.be.ok();
+                expect(got.dom).to.be(htmlElement);
+            });
+        });
+
+        describe('#setHtmlLanguage', function() {
+            it('sets the `lang`-attribute of the `<html>`-element', function() {
+                var fakeLanguage = 'snork-snork';
+                var before = htmlElement.getAttribute('lang');
+                expect(before).to.not.be(fakeLanguage);
+
+                BasiGX.util.Accessibility.setHtmlLanguage(fakeLanguage);
+
+                var after = htmlElement.getAttribute('lang');
+                expect(after).to.not.be(before);
+                expect(after).to.be(fakeLanguage);
+            });
+        });
+
+    });
+});

--- a/test/spec/view/combo/Language.test.js
+++ b/test/spec/view/combo/Language.test.js
@@ -26,6 +26,11 @@ describe('BasiGX.view.combo.Language', function() {
             expect(combo.getDefaultLanguage()).to.not.be(undefined);
             expect(combo.getDefaultLanguage()).to.be.a('string');
         });
+        it('sets the default language on the <html>-element', function() {
+            var htmlElement = document.querySelector('html');
+            var currentLang = htmlElement.getAttribute('lang');
+            expect(currentLang).to.be(combo.getDefaultLanguage());
+        });
     });
     describe('locale template url', function() {
         it('found a template for locale url', function() {
@@ -37,6 +42,43 @@ describe('BasiGX.view.combo.Language', function() {
         it('has some default languages', function(){
             expect(combo.getLanguages()).to.not.be(undefined);
             expect(combo.getLanguages()).to.be.an(Array);
+        });
+    });
+    describe('can change the language', function() {
+        var origExtLogInfo = null;
+        var htmlElement = null;
+        beforeEach(function() {
+            htmlElement = document.querySelector('html');
+            origExtLogInfo = Ext.Logger.info;
+            Ext.Logger.info = function(){}; // don't output logs when testing
+        });
+        afterEach(function() {
+            Ext.Logger.info = origExtLogInfo; // restore old log
+            origExtLogInfo = null;
+            htmlElement = null;
+        });
+        it('changes the lang-attribute of the html-element', function() {
+            var mockLocale = "humptydumpty";
+            // The followiing lines mockup a change in the language:
+            // 1) set the private locale property
+            combo.locale = mockLocale;
+            // 2) Mock up a successfull response object
+            var responseMock = {
+                responseText: "{}"
+            };
+            // 3) Save the language to compare against it later
+            var langBefore = htmlElement.getAttribute('lang');
+            // 4) emulate a succesfull callback, not optimal but better than
+            //    nothing
+            combo.onLoadAppLocaleSuccess.call(combo, responseMock);
+
+            var langAfter = htmlElement.getAttribute('lang');
+
+            expect(langAfter).to.not.be(langBefore);
+            expect(langAfter).to.be(mockLocale); // it's 'humptydumpty' now
+
+            // cleanup
+            htmlElement.setAttribute("lang", langBefore);
         });
     });
 });


### PR DESCRIPTION
This PR suggests to add a utilty class to enhance the accessibility.

As first step, the method `setHtmlLanguage` is added to set the `lang` attribute of the `<html>`-element, which is usefull e.g. for screenreaders.

Additionally the language combo is changed to call the `setHtmlLanguage` method whenever we know the language of the application or when it has changed.

When reviewing, please only consider ad26d0193cb6da3506ef28256434825b2eb32369 and 171cf19bda7a7669f5b06cf6b3ff75c3e8968e4c, the other commits (188eddf, 9639fd6 and 817d17c) will disappear here once  #135 is merged.

Please review.