### PR TITLE
Add the ability to add markup to enhance accessibility

### DIFF
--- a/src/plugin/AccessibleTitle.js
+++ b/src/plugin/AccessibleTitle.js
@@ -111,7 +111,7 @@ Ext.define('BasiGX.plugin.AccessibleTitle', {
         if (!headerDom) {
             return;
         }
-        me.addedHtmlHeader = Ext.DomHelper.append(headerDom, spec);
+        me.addedHtmlHeader = Ext.DomHelper.insertFirst(headerDom, spec);
     },
 
     /**

--- a/src/plugin/AccessibleTitle.js
+++ b/src/plugin/AccessibleTitle.js
@@ -133,7 +133,7 @@ Ext.define('BasiGX.plugin.AccessibleTitle', {
      */
     getHeaderParent: function(){
         var cmp = this.getCmp();
-        var cmpParts = [cmp.header, cmp.body];
+        var cmpParts = [cmp.header, cmp.body, cmp];
         var headerParent;
         Ext.each(cmpParts, function(part) {
             if(!headerParent && part && part.el && part.el.dom) {

--- a/src/plugin/AccessibleTitle.js
+++ b/src/plugin/AccessibleTitle.js
@@ -1,0 +1,175 @@
+/* Copyright (c) 2017-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * A plugin that adds structural (but hidden) markup to enhance the
+ * accessibility of an application.
+ *
+ * @class BasiGX.plugin.AccessibleTitle
+ */
+Ext.define('BasiGX.plugin.AccessibleTitle', {
+    extend: 'Ext.plugin.Abstract',
+
+    alias: 'plugin.a11ytitle',
+    pluginId: 'a11ytitle',
+
+    config: {
+        /**
+         * @cfg {Number} The level of the heading to add, e.g. `3` for a `<h3>`
+         *     that should be added.
+         */
+        a11yHeadingLevel: 2
+    },
+
+    privates: {
+        /**
+         * @type {HTMLElement} The header element, usually a `<h2>`-element.
+         *     The type varies depending on the #a11yHeadingLevel configuration.
+         */
+        addedHtmlHeader: null
+    },
+
+    /**
+     * Called when this plugin is initialized. Will receive the instance of
+     * `Ext.Component` that owns this plugin.
+     *
+     * @param {Ext.Component} cmp The component that owns the plugin.
+     */
+    init: function(cmp) {
+        var me = this;
+        cmp.on('afterrender', me.addA11yMarkup, me);
+        Ext.override(cmp, {
+            setTitle: function() {
+                var overridenReturnVal = this.callParent(arguments);
+                me.updateA11yMarkup();
+                return overridenReturnVal;
+            }
+        });
+        me.setCmp(cmp);
+    },
+
+    /**
+     * The destroy method is invoked by the owning component at the time it
+     * is being destroyed.
+     */
+    destroy: function() {
+        var me = this;
+        me.removeA11yMarkup();
+        me.setCmp(null);
+    },
+
+    /**
+     * The applier method which will update the created dom for the passed
+     * new #a11yHeadingLevel.
+     *
+     * @param {Number} newLevel The level of the heading, e.g. `4` for `<h4>`.
+     */
+    applyA11yHeadingLevel: function(newLevel) {
+        var me = this;
+        if (me.addedHtmlHeader) {
+            var spec = me.getHeaderSpec(newLevel);
+            me.addHtmlHeader(spec);
+        }
+        return newLevel;
+    },
+
+    /**
+     * Called after the owning component is rendered, this method will determine
+     * the heading level, an appropriate `Ext.DomHelper` specification and then
+     * actually add the HTML by calling #addHtmlHeader.
+     */
+    addA11yMarkup: function() {
+        var me = this;
+        var level = me.getA11yHeadingLevel();
+        var spec = me.getHeaderSpec(level);
+        me.addHtmlHeader(spec);
+    },
+
+    /**
+     * Adds the a11y header markup for the passed specification.
+     *
+     * @param {Object} spec The specification for the HTML to create.
+     */
+    addHtmlHeader: function(spec) {
+        var me = this;
+        if (me.addedHtmlHeader) {
+            me.removeA11yMarkup();
+        }
+        var headerDom = me.getHeaderParent();
+        if (!headerDom) {
+            return;
+        }
+        me.addedHtmlHeader = Ext.DomHelper.append(headerDom, spec);
+    },
+
+    /**
+     * Removes the added HTML, if any.
+     */
+    removeA11yMarkup: function() {
+        var me = this;
+        if (!me.addedHtmlHeader) {
+            return;
+        }
+        var parentNode = me.addedHtmlHeader.parentNode;
+        parentNode.removeChild(me.addedHtmlHeader);
+    },
+
+    /**
+     * Return the element into which we want to add our HTML.
+     *
+     * @return {HTMLElement} The element into which we will add our HTML.
+     */
+    getHeaderParent: function(){
+        var cmp = this.getCmp();
+        var cmpParts = [cmp.header, cmp.body];
+        var headerParent;
+        Ext.each(cmpParts, function(part) {
+            if(!headerParent && part && part.el && part.el.dom) {
+                headerParent = part.el.dom;
+            }
+        });
+        return headerParent;
+    },
+
+    /**
+     * Returns a specification to be used with `Ext.DomHelper`.
+     *
+     * @param {Number} newLevel The level of the heading, e.g. `4` for `<h4>`.
+     * @return {Object} An appropriate `Ext.DomHelper` specification for the
+     *     passed level.
+     */
+    getHeaderSpec: function(level) {
+        var me = this;
+        var cmp = me.getCmp();
+        var spec = {
+            tag: 'h' + level,
+            style: 'display: none;',
+            html: cmp.getTitle() // will be updated later, in updateA11yMarkup
+        };
+        return spec;
+    },
+
+    /**
+     * Update the HTML of our header whenever the title of the owning component
+     * changes.
+     */
+    updateA11yMarkup: function() {
+        var me = this;
+        var cmp = me.getCmp();
+        if (me.addedHtmlHeader && cmp.getTitle) {
+            Ext.get(me.addedHtmlHeader).setHtml(cmp.getTitle());
+        }
+    }
+});

--- a/src/view/panel/Accessible.js
+++ b/src/view/panel/Accessible.js
@@ -1,0 +1,33 @@
+/* Copyright (c) 2017-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * A base class for windows which will provide everything that the parent class
+ * `Ext.panel.Panel` has and additionally incorporates the plugin to add
+ * structural HTML for enhanced accessibility (`BasiGX.plugin.AccessibleTitle`).
+ *
+ * @class BasiGX.view.panel.Accessible
+ */
+Ext.define('BasiGX.view.panel.Accessible', {
+    alternateClassName: 'BasiGX.view.panel.A11y',
+    extend: 'Ext.panel.Panel',
+    requires: [
+        'BasiGX.plugin.AccessibleTitle'
+    ],
+    plugins: [{
+        ptype: 'a11ytitle',
+        a11yHeadingLevel: 3
+    }]
+});

--- a/src/view/window/Accessible.js
+++ b/src/view/window/Accessible.js
@@ -1,0 +1,30 @@
+/* Copyright (c) 2017-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * A base class for windows which will provide everything that the parent class
+ * `Ext.window.Window` has and additionally incorporates the plugin to add
+ * structural HTML for enhanced accessibility (`BasiGX.plugin.AccessibleTitle`).
+ *
+ * @class BasiGX.view.window.Accessible
+ */
+Ext.define('BasiGX.view.window.Accessible', {
+    alternateClassName: 'BasiGX.view.window.A11y',
+    extend: 'Ext.window.Window',
+    requires: [
+        'BasiGX.plugin.AccessibleTitle'
+    ],
+    plugins: ['a11ytitle']
+});

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -4,6 +4,7 @@
     var specPath = './spec/',
         dependencies = [
             'basics.test.js',
+            'plugin/AccessibleTitle.test.js',
             'plugin/Hover.test.js',
             'plugin/WfsCluster.test.js',
             'util/Accessibility.test.js',
@@ -45,12 +46,14 @@
             'view/form/Print.test.js',
             'view/grid/FeaturePropertyGrid.test.js',
             'view/grid/GazetteerGrid.test.js',
+            'view/panel/Accessible.test.js',
             'view/panel/Header.test.js',
             'view/panel/LayerSetChooser.test.js',
             'view/panel/LegendTree.test.js',
             'view/panel/MapContainer.test.js',
             'view/panel/Menu.test.js',
-            'view/view/LayerSet.test.js'
+            'view/view/LayerSet.test.js',
+            'view/window/Accessible.test.js'
         ],
         getScriptTag = global.TestUtil.getExternalScriptTag,
         dependencyCnt = dependencies.length,

--- a/test/spec/plugin/AccessibleTitle.test.js
+++ b/test/spec/plugin/AccessibleTitle.test.js
@@ -1,0 +1,102 @@
+Ext.Loader.syncRequire([
+    'BasiGX.plugin.AccessibleTitle',
+    'Ext.panel.Panel'
+]);
+
+describe('BasiGX.plugin.AccessibleTitle', function() {
+
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.plugin.AccessibleTitle).to.not.be(undefined);
+        });
+        it('can be instantiated', function(){
+            var plugin = Ext.create('BasiGX.plugin.AccessibleTitle');
+            expect(plugin).to.be.a(BasiGX.plugin.AccessibleTitle);
+            plugin.destroy();
+        });
+    });
+
+    describe('Adding the plugin to a panel', function() {
+        var cntH2Before = 0;
+        var cntH4Before = 0;
+        var panel = null;
+        var plugin = null;
+        beforeEach(function() {
+            cntH2Before = document.querySelectorAll('h2').length;
+            cntH4Before = document.querySelectorAll('h4').length;
+            panel = Ext.create('Ext.panel.Panel', {
+                plugins: ['a11ytitle'],
+                title: 'Humpty Foo',
+                renderTo: Ext.getBody()
+            });
+            plugin = panel.getPlugin('a11ytitle');
+        });
+        afterEach(function() {
+            if (panel && panel.destroy) {
+                panel.destroy();
+            }
+            panel = null;
+            plugin = null;
+            cntH2Before = 0;
+            cntH4Before = 0;
+        });
+
+        it('renders an h2-header', function() {
+            var cntH2After = document.querySelectorAll('h2').length;
+            expect(cntH2After).to.be(cntH2Before + 1);
+        });
+        it('sets the title into h2-header', function() {
+            var innerHtmlH2 = plugin.addedHtmlHeader.innerHTML;
+            expect(innerHtmlH2).to.be(panel.getTitle());
+        });
+        it('updates the HTML when panel title changes', function() {
+            var innerHtmlBefore = plugin.addedHtmlHeader.innerHTML;
+
+            panel.setTitle('Dumpty Bar');
+
+            var innerHtmlAfter = plugin.addedHtmlHeader.innerHTML;
+
+            expect(innerHtmlAfter).to.not.be(innerHtmlBefore);
+            expect(innerHtmlAfter).to.be('Dumpty Bar');
+        });
+        it('changes the level in the DOM (i.e. `4` becomes `h4`)', function() {
+            var cntH2After = document.querySelectorAll('h2').length;
+            expect(cntH2After).to.be(cntH2Before + 1);
+
+            plugin.setA11yHeadingLevel(4);
+
+            cntH2After = document.querySelectorAll('h2').length;
+            expect(cntH2After).to.be(cntH2Before);
+
+            var cntH4After = document.querySelectorAll('h4').length;
+            expect(cntH4After).to.be(cntH4Before + 1);
+        });
+        it('ensures the added HTML is invisible', function(){
+            var elem = Ext.get(plugin.addedHtmlHeader);
+            expect(elem.isVisible()).to.be(false);
+        });
+        it('removes added DOM elements when panel is destroyed', function() {
+            panel.destroy();
+            var cntH2After = document.querySelectorAll('h2').length;
+            expect(cntH2After).to.be(cntH2Before);
+        });
+        it('plugin contains a reference to the panel', function() {
+            expect(plugin.getCmp()).to.be(panel);
+        });
+        it('also works when panel has `header: false`', function() {
+            // setup
+            var panel2 = Ext.create('Ext.panel.Panel', {
+                plugins: ['a11ytitle'],
+                title: 'Will it blend?',
+                renderTo: Ext.getBody(),
+                header: false
+            });
+            var plugin2 = panel2.getPlugin('a11ytitle');
+
+            expect(plugin2.addedHtmlHeader.innerHTML).to.be('Will it blend?');
+
+            // teardown
+            panel2.destroy();
+        });
+    });
+});

--- a/test/spec/view/panel/Accessible.test.js
+++ b/test/spec/view/panel/Accessible.test.js
@@ -1,0 +1,39 @@
+Ext.Loader.syncRequire([
+    'BasiGX.view.panel.Accessible'
+]);
+
+describe('BasiGX.view.panel.Accessible', function() {
+
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.view.panel.Accessible).to.not.be(undefined);
+        });
+        it('can be instantiated', function(){
+            var instance = Ext.create('BasiGX.view.panel.Accessible');
+            expect(instance).to.be.a(BasiGX.view.panel.Accessible);
+            instance.destroy();
+        });
+    });
+
+    describe('AccessibleTitle plugin', function() {
+        var instance = null;
+        var plugin = null;
+        beforeEach(function() {
+            instance = Ext.create('BasiGX.view.panel.Accessible');
+            plugin = instance.getPlugin('a11ytitle');
+        });
+        afterEach(function() {
+            instance.destroy();
+            instance = null;
+            plugin = null;
+        });
+
+        it('is configured with a plugin', function() {
+            expect(plugin).to.be.a(BasiGX.plugin.AccessibleTitle);
+        });
+        it('the plugin will add h3 elements', function() {
+            expect(plugin.getA11yHeadingLevel()).to.be(3);
+        });
+    });
+
+});

--- a/test/spec/view/window/Accessible.test.js
+++ b/test/spec/view/window/Accessible.test.js
@@ -1,0 +1,39 @@
+Ext.Loader.syncRequire([
+    'BasiGX.view.window.Accessible'
+]);
+
+describe('BasiGX.view.window.Accessible', function() {
+
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.view.window.Accessible).to.not.be(undefined);
+        });
+        it('can be instantiated', function(){
+            var instance = Ext.create('BasiGX.view.window.Accessible');
+            expect(instance).to.be.a(BasiGX.view.window.Accessible);
+            instance.destroy();
+        });
+    });
+
+    describe('AccessibleTitle plugin', function() {
+        var instance = null;
+        var plugin = null;
+        beforeEach(function() {
+            instance = Ext.create('BasiGX.view.window.Accessible');
+            plugin = instance.getPlugin('a11ytitle');
+        });
+        afterEach(function() {
+            instance.destroy();
+            instance = null;
+            plugin = null;
+        });
+
+        it('is configured with a plugin', function() {
+            expect(plugin).to.be.a(BasiGX.plugin.AccessibleTitle);
+        });
+        it('the plugin will add h2 elements', function() {
+            expect(plugin.getA11yHeadingLevel()).to.be(2);
+        });
+    });
+
+});


### PR DESCRIPTION
This adds three components that will enhance the accessibility of apps created using them:

* A plugin to add the title of a component as hidden header (e.g. in a `<h2>`-tag): `BasiGX.plugin.AccessibleTitle`
  * That plugin will either render to the `header` or the `body` element of its target
  * The plugin also overides the `setTitle` method to update the hidden HTML accordingly when the title changes.
* Two base classes that use this plugin:
  * `BasiGX.view.panel.Accessible`: will render their `title` into a `<h3>`
  * `BasiGX.view.window.Accessible`: will render their `title` into a `<h2>`
  * Both the panel and the window class do this even when configured with `header: false`
  * A follow up PR might make the panel- class the base class for all our BasiGX panels

Please review.