### PR TITLE
Add and use a button base class

### DIFF
--- a/src/view/button/AddWms.js
+++ b/src/view/button/AddWms.js
@@ -21,8 +21,8 @@
  *
  * @class BasiGX.view.button.AddWms
  */
-Ext.define("BasiGX.view.button.AddWms", {
-    extend: "Ext.Button",
+Ext.define('BasiGX.view.button.AddWms', {
+    extend: 'BasiGX.view.button.Base',
     xtype: 'basigx-button-addwms',
 
     requires: [
@@ -81,19 +81,6 @@ Ext.define("BasiGX.view.button.AddWms", {
             } else {
                 BasiGX.util.Animate.shake(win);
             }
-        }
-    },
-
-    /**
-     *
-     */
-    constructor: function(config) {
-        this.callParent([config]);
-
-        if (this.setTooltip) {
-            var bind = this.config.bind;
-            bind.tooltip = this.getViewModel().get('tooltip');
-            this.setBind(bind);
         }
     }
 });

--- a/src/view/button/Base.js
+++ b/src/view/button/Base.js
@@ -1,0 +1,40 @@
+/* Copyright (c) 2017-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * A base class for buttons.
+ *
+ * @class BasiGX.view.button.Base
+ */
+Ext.define('BasiGX.view.button.Base', {
+    extend: 'Ext.Button',
+    xtype: 'basigx-button-base',
+    viewModel: {
+        data: {}
+    },
+    bind: {},
+    /**
+     *
+     */
+    constructor: function() {
+        var me = this;
+        me.callParent(arguments);
+        if (me.setTooltip) {
+            var bind = me.config.bind;
+            bind.tooltip = me.getViewModel().get('tooltip');
+            me.setBind(bind);
+        }
+    }
+});

--- a/src/view/button/CoordinateTransform.js
+++ b/src/view/button/CoordinateTransform.js
@@ -21,8 +21,8 @@
  *
  * @class BasiGX.view.button.CoordinateTransform
  */
-Ext.define("BasiGX.view.button.CoordinateTransform", {
-    extend: "Ext.Button",
+Ext.define('BasiGX.view.button.CoordinateTransform', {
+    extend: 'BasiGX.view.button.Base',
     xtype: 'basigx-button-coordinatetransform',
 
     requires: [
@@ -82,19 +82,6 @@ Ext.define("BasiGX.view.button.CoordinateTransform", {
             } else {
                 BasiGX.util.Animate.shake(win);
             }
-        }
-    },
-
-    /**
-     *
-     */
-    constructor: function(config) {
-        this.callParent([config]);
-
-        if (this.setTooltip) {
-            var bind = this.config.bind;
-            bind.tooltip = this.getViewModel().get('tooltip');
-            this.setBind(bind);
         }
     }
 });

--- a/src/view/button/Help.js
+++ b/src/view/button/Help.js
@@ -20,8 +20,8 @@
  *
  * @class BasiGX.view.button.Help
  */
-Ext.define("BasiGX.view.button.Help", {
-    extend: "Ext.Button",
+Ext.define('BasiGX.view.button.Help', {
+    extend: 'BasiGX.view.button.Base',
     xtype: 'basigx-button-help',
 
     requires: [
@@ -61,19 +61,6 @@ Ext.define("BasiGX.view.button.Help", {
         handler: function(button){
             var help = Ext.create('BasiGX.ux.ContextSensitiveHelp');
             help.setContextHelp(button.getAdditonalHelpKeys());
-        }
-    },
-
-    /**
-     *
-     */
-    constructor: function(config) {
-        this.callParent([config]);
-
-        if (this.setTooltip) {
-            var bind = this.config.bind;
-            bind.tooltip = this.getViewModel().get('tooltip');
-            this.setBind(bind);
         }
     }
 });

--- a/src/view/button/Hsi.js
+++ b/src/view/button/Hsi.js
@@ -93,7 +93,7 @@ Ext.define('BasiGX.view.button.Hsi', {
             this.setPressed(this.buttonPressed);
         } else {
             this.setCls(this.buttonPressed ? this.getPressedCls() :
-                "basigx-map-tool-button");
+                'basigx-map-tool-button');
         }
         this.setControlStatus(this.buttonPressed);
     },

--- a/src/view/button/Hsi.js
+++ b/src/view/button/Hsi.js
@@ -20,8 +20,8 @@
  *
  * @class BasiGX.view.button.Hsi
  */
-Ext.define("BasiGX.view.button.Hsi", {
-    extend: "Ext.Button",
+Ext.define('BasiGX.view.button.Hsi', {
+    extend: 'BasiGX.view.button.Base',
     xtype: 'basigx-button-hsi',
     requires: [
         'Ext.app.ViewModel',
@@ -80,15 +80,8 @@ Ext.define("BasiGX.view.button.Hsi", {
     /**
      *
      */
-    constructor: function(config) {
-        this.callParent([config]);
-
-        if (this.setTooltip) {
-            var bind = this.config.bind;
-            bind.tooltip = this.getViewModel().get('tooltip');
-            this.setBind(bind);
-        }
-
+    constructor: function() {
+        this.callParent(arguments);
         this.toggleButton();
     },
 

--- a/src/view/button/Measure.js
+++ b/src/view/button/Measure.js
@@ -25,9 +25,9 @@ Ext.define('BasiGX.view.button.Measure', {
     xtype: 'basigx-button-measure',
 
     requires: [
-        "BasiGX.util.Layer",
-        "BasiGX.util.Map",
-        "Ext.app.ViewModel"
+        'BasiGX.util.Layer',
+        'BasiGX.util.Map',
+        'Ext.app.ViewModel'
     ],
 
    /**
@@ -230,11 +230,11 @@ Ext.define('BasiGX.view.button.Measure', {
     /**
      *
      */
-    constructor: function(config) {
+    constructor: function() {
         var me = this;
         var LayerUtil = BasiGX.util.Layer;
 
-        me.callParent([config]);
+        me.callParent(arguments);
 
         me.map = BasiGX.util.Map.getMapComponent().getMap();
 

--- a/src/view/button/Measure.js
+++ b/src/view/button/Measure.js
@@ -20,8 +20,8 @@
  *
  * @class BasiGX.view.button.Measure
  */
-Ext.define("BasiGX.view.button.Measure", {
-    extend: "Ext.Button",
+Ext.define('BasiGX.view.button.Measure', {
+    extend: 'BasiGX.view.button.Base',
     xtype: 'basigx-button-measure',
 
     requires: [

--- a/src/view/button/Permalink.js
+++ b/src/view/button/Permalink.js
@@ -20,8 +20,8 @@
  *
  * @class BasiGX.view.button.Permalink
  */
-Ext.define("BasiGX.view.button.Permalink", {
-    extend: "Ext.Button",
+Ext.define('BasiGX.view.button.Permalink', {
+    extend: 'BasiGX.view.button.Base',
     xtype: 'basigx-button-permalink',
 
     requires: [
@@ -62,19 +62,6 @@ Ext.define("BasiGX.view.button.Permalink", {
             } else {
                 BasiGX.util.Animate.shake(win);
             }
-        }
-    },
-
-    /**
-     *
-     */
-    constructor: function(config) {
-        this.callParent([config]);
-
-        if (this.setTooltip) {
-            var bind = this.config.bind;
-            bind.tooltip = this.getViewModel().get('tooltip');
-            this.setBind(bind);
         }
     }
 });

--- a/src/view/button/ToggleLegend.js
+++ b/src/view/button/ToggleLegend.js
@@ -20,8 +20,8 @@
  *
  * @class BasiGX.view.button.ToggleLegend
  */
-Ext.define("BasiGX.view.button.ToggleLegend", {
-    extend: "Ext.Button",
+Ext.define('BasiGX.view.button.ToggleLegend', {
+    extend: 'BasiGX.view.button.Base',
     xtype: 'basigx-button-togglelegend',
     requires: [
         'Ext.app.ViewModel',
@@ -72,19 +72,6 @@ Ext.define("BasiGX.view.button.ToggleLegend", {
                 }
                 button.blur();
             }
-        }
-    },
-
-    /**
-     *
-     */
-    constructor: function(config) {
-        this.callParent([config]);
-
-        if (this.setTooltip) {
-            var bind = this.config.bind;
-            bind.tooltip = this.getViewModel().get('tooltip');
-            this.setBind(bind);
         }
     }
 });

--- a/src/view/button/ZoomIn.js
+++ b/src/view/button/ZoomIn.js
@@ -20,8 +20,8 @@
  *
  * @class BasiGX.view.button.ZoomIn
  */
-Ext.define("BasiGX.view.button.ZoomIn", {
-    extend: "Ext.Button",
+Ext.define('BasiGX.view.button.ZoomIn', {
+    extend: 'BasiGX.view.button.Base',
     xtype: 'basigx-button-zoomin',
     requires: [
         'Ext.app.ViewModel',
@@ -77,19 +77,6 @@ Ext.define("BasiGX.view.button.ZoomIn", {
 
             olMap.beforeRender(zoom);
             olView.setResolution(olView.getResolution() / 2);
-        }
-    },
-
-    /**
-     *
-     */
-    constructor: function(config) {
-        this.callParent([config]);
-
-        if (this.setTooltip) {
-            var bind = this.config.bind;
-            bind.tooltip = this.getViewModel().get('tooltip');
-            this.setBind(bind);
         }
     }
 });

--- a/src/view/button/ZoomOut.js
+++ b/src/view/button/ZoomOut.js
@@ -20,8 +20,8 @@
  *
  * @class BasiGX.view.button.ZoomOut
  */
-Ext.define("BasiGX.view.button.ZoomOut", {
-    extend: "Ext.Button",
+Ext.define('BasiGX.view.button.ZoomOut', {
+    extend: 'BasiGX.view.button.Base',
     xtype: 'basigx-button-zoomout',
     requires: [
         'Ext.app.ViewModel',
@@ -77,19 +77,6 @@ Ext.define("BasiGX.view.button.ZoomOut", {
 
             olMap.beforeRender(zoom);
             olView.setResolution(olView.getResolution() * 2);
-        }
-    },
-
-    /**
-     *
-     */
-    constructor: function(config) {
-        this.callParent([config]);
-
-        if (this.setTooltip) {
-            var bind = this.config.bind;
-            bind.tooltip = this.getViewModel().get('tooltip');
-            this.setBind(bind);
         }
     }
 });

--- a/src/view/button/ZoomToExtent.js
+++ b/src/view/button/ZoomToExtent.js
@@ -20,8 +20,8 @@
  *
  * @class BasiGX.view.button.ZoomToExtent
  */
-Ext.define("BasiGX.view.button.ZoomToExtent", {
-    extend: "Ext.Button",
+Ext.define('BasiGX.view.button.ZoomToExtent', {
+    extend: 'BasiGX.view.button.Base',
     xtype: 'basigx-button-zoomtoextent',
 
     requires: [
@@ -103,14 +103,8 @@ Ext.define("BasiGX.view.button.ZoomToExtent", {
     /**
      *
      */
-    constructor: function(config) {
-        this.callParent([config]);
-
-        if (this.setTooltip) {
-            var bind = this.config.bind;
-            bind.tooltip = this.getViewModel().get('tooltip');
-            this.setBind(bind);
-        }
+    constructor: function() {
+        this.callParent(arguments);
 
         if(this.getZoom() && this.getResolution()){
             Ext.raise('No zoom and resolution set for Extent Button!' +

--- a/test/index.html
+++ b/test/index.html
@@ -5,10 +5,11 @@
     <title>BasiGX Testsuite</title>
     <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.19.1/ol.css" />
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
     <script src="./raf.polyfill.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.19.1/ol.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.0.1/ext-all.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.0.1/packages/ux/classic/ux.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/packages/ux/classic/ux.js"></script>
     <script src="https://geoext.github.io/geoext3/master/GeoExt.js"></script>
     <script src="../node_modules/expect.js/index.js"></script>
     <script src="../node_modules/sinon/pkg/sinon.js"></script>

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -21,6 +21,7 @@
             'ux/ContextSensitiveHelp.test.js',
             'ux/RowExpanderWithComponents.test.js',
             'view/button/AddWms.test.js',
+            'view/button/Base.test.js',
             'view/button/CoordinateTransform.test.js',
             'view/button/Help.test.js',
             'view/button/Hsi.test.js',

--- a/test/spec/view/button/AddWms.test.js
+++ b/test/spec/view/button/AddWms.test.js
@@ -5,5 +5,11 @@ describe('BasiGX.view.button.AddWms', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.AddWms).to.not.be(undefined);
         });
+        it('can be instantiated', function() {
+            var btn = Ext.create('BasiGX.view.button.AddWms');
+            expect(btn).to.be.a(BasiGX.view.button.AddWms);
+            // teardown
+            btn.destroy();
+        });
     });
 });

--- a/test/spec/view/button/Base.test.js
+++ b/test/spec/view/button/Base.test.js
@@ -1,0 +1,90 @@
+Ext.Loader.syncRequire(['BasiGX.view.button.Base']);
+
+describe('BasiGX.view.button.Base', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.view.button.Base).to.not.be(undefined);
+        });
+        it('can be instantiated', function() {
+            var btn = Ext.create('BasiGX.view.button.Base');
+            expect(btn).to.be.a(BasiGX.view.button.Base);
+        });
+    });
+    describe('Tooltip bound if possible (direct instantiation)', function() {
+        it('binds to tooltip if `setTooltip` exists', function() {
+            var btn = Ext.create('BasiGX.view.button.Base', {
+                viewModel: {
+                    data:{
+                        tooltip: 'My Tooltip'
+                    }
+                }
+            });
+            var bind = btn.getBind();
+            expect(bind).to.be.ok();
+            expect(bind.tooltip).to.be.ok();
+            // teardown
+            btn.destroy();
+        });
+        it('does not bind to tooltip if `setTooltip` is undefined', function() {
+            // This is the case for modern builds, e.g.
+            var origSetTooltip = BasiGX.view.button.Base.prototype.setTooltip;
+            BasiGX.view.button.Base.prototype.setTooltip = undefined;
+            var btn = Ext.create('BasiGX.view.button.Base', {
+                viewModel: {
+                    data:{
+                        tooltip: 'My Tooltip'
+                    }
+                }
+            });
+            var bind = btn.getBind();
+            expect(bind).to.be.ok();
+            expect(bind.tooltip).to.not.be.ok();
+            // teardown
+            BasiGX.view.button.Base.prototype.setTooltip = origSetTooltip;
+            btn.destroy();
+        });
+    });
+    describe('Tooltip bound if possible (subclass)', function() {
+        beforeEach(function() {
+            Ext.define('BasiGX.test.BaseButtonSubClass', {
+                extend: 'BasiGX.view.button.Base'
+            });
+        });
+        afterEach(function() {
+            Ext.undefine('BasiGX.test.BaseButtonSubClass');
+        });
+
+        it('binds to tooltip if `setTooltip` exists', function() {
+            var btn = Ext.create('BasiGX.test.BaseButtonSubClass', {
+                viewModel: {
+                    data:{
+                        tooltip: 'My Tooltip'
+                    }
+                }
+            });
+            var bind = btn.getBind();
+            expect(bind).to.be.ok();
+            expect(bind.tooltip).to.be.ok();
+            // teardown
+            btn.destroy();
+        });
+        it('does not bind to tooltip if `setTooltip` is undefined', function() {
+            // This is the case for modern builds, e.g.
+            var orig = BasiGX.test.BaseButtonSubClass.prototype.setTooltip;
+            BasiGX.test.BaseButtonSubClass.prototype.setTooltip = undefined;
+            var btn = Ext.create('BasiGX.test.BaseButtonSubClass', {
+                viewModel: {
+                    data:{
+                        tooltip: 'My Tooltip'
+                    }
+                }
+            });
+            var bind = btn.getBind();
+            expect(bind).to.be.ok();
+            expect(bind.tooltip).to.not.be.ok();
+            // teardown
+            BasiGX.test.BaseButtonSubClass.prototype.setTooltip = orig;
+            btn.destroy();
+        });
+    });
+});

--- a/test/spec/view/button/CoordinateTransform.test.js
+++ b/test/spec/view/button/CoordinateTransform.test.js
@@ -5,5 +5,11 @@ describe('BasiGX.view.button.CoordinateTransform', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.CoordinateTransform).to.not.be(undefined);
         });
+        it('can be instantiated', function() {
+            var btn = Ext.create('BasiGX.view.button.CoordinateTransform');
+            expect(btn).to.be.a(BasiGX.view.button.CoordinateTransform);
+            // teardown
+            btn.destroy();
+        });
     });
 });

--- a/test/spec/view/button/Help.test.js
+++ b/test/spec/view/button/Help.test.js
@@ -5,5 +5,11 @@ describe('BasiGX.view.button.Help', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.Help).to.not.be(undefined);
         });
+        it('can be instantiated', function() {
+            var btn = Ext.create('BasiGX.view.button.Help');
+            expect(btn).to.be.a(BasiGX.view.button.Help);
+            // teardown
+            btn.destroy();
+        });
     });
 });

--- a/test/spec/view/button/Hsi.test.js
+++ b/test/spec/view/button/Hsi.test.js
@@ -2,8 +2,39 @@ Ext.Loader.syncRequire(['BasiGX.view.button.Hsi']);
 
 describe('BasiGX.view.button.Hsi', function() {
     describe('Basics', function() {
+
+        var mapComponent;
+        var map;
+        var mapDiv;
+
+        beforeEach(function() {
+            mapDiv = document.createElement('div');
+            document.body.appendChild(mapDiv);
+
+            map = new ol.Map({target: mapDiv});
+            mapComponent = Ext.create('BasiGX.view.component.Map', {
+                map: map,
+                view: new ol.View({
+                    resolution: 7
+                })
+            });
+        });
+
+        afterEach(function() {
+            map.setTarget(null);
+            mapComponent.destroy();
+            document.body.removeChild(mapDiv);
+            mapDiv = null;
+        });
+
         it('is defined', function() {
             expect(BasiGX.view.button.Hsi).to.not.be(undefined);
+        });
+        it('can be instantiated', function() {
+            var btn = Ext.create('BasiGX.view.button.Hsi');
+            expect(btn).to.be.a(BasiGX.view.button.Hsi);
+            // teardown
+            btn.destroy();
         });
     });
 });

--- a/test/spec/view/button/LayerSetChooser.test.js
+++ b/test/spec/view/button/LayerSetChooser.test.js
@@ -1,9 +1,0 @@
-Ext.Loader.syncRequire(['BasiGX.util.Animate']);
-
-describe('BasiGX.util.Animate', function() {
-    describe('Basics', function() {
-        it('is defined', function() {
-            expect(BasiGX.util.Animate).to.not.be(undefined);
-        });
-    });
-});

--- a/test/spec/view/button/Measure.test.js
+++ b/test/spec/view/button/Measure.test.js
@@ -43,6 +43,12 @@ describe('BasiGX.view.button.Measure', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.Measure).to.not.be(undefined);
         });
+        it('can be instantiated', function() {
+            var myBtn = Ext.create('BasiGX.view.button.Measure');
+            expect(myBtn).to.be.a(BasiGX.view.button.Measure);
+            // teardown
+            myBtn.destroy();
+        });
     });
 
     describe('Static methods', function() {

--- a/test/spec/view/button/Permalink.test.js
+++ b/test/spec/view/button/Permalink.test.js
@@ -5,5 +5,11 @@ describe('BasiGX.view.button.Permalink', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.Permalink).to.not.be(undefined);
         });
+        it('can be instantiated', function() {
+            var btn = Ext.create('BasiGX.view.button.Permalink');
+            expect(btn).to.be.a(BasiGX.view.button.Permalink);
+            // teardown
+            btn.destroy();
+        });
     });
 });

--- a/test/spec/view/button/ToggleLegend.test.js
+++ b/test/spec/view/button/ToggleLegend.test.js
@@ -5,5 +5,11 @@ describe('BasiGX.view.button.ToggleLegend', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.ToggleLegend).to.not.be(undefined);
         });
+        it('can be instantiated', function() {
+            var btn = Ext.create('BasiGX.view.button.ToggleLegend');
+            expect(btn).to.be.a(BasiGX.view.button.ToggleLegend);
+            // teardown
+            btn.destroy();
+        });
     });
 });

--- a/test/spec/view/button/ZoomIn.test.js
+++ b/test/spec/view/button/ZoomIn.test.js
@@ -5,5 +5,11 @@ describe('BasiGX.view.button.ZoomIn', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.ZoomIn).to.not.be(undefined);
         });
+        it('can be instantiated', function() {
+            var btn = Ext.create('BasiGX.view.button.ZoomIn');
+            expect(btn).to.be.a(BasiGX.view.button.ZoomIn);
+            // teardown
+            btn.destroy();
+        });
     });
 });

--- a/test/spec/view/button/ZoomOut.test.js
+++ b/test/spec/view/button/ZoomOut.test.js
@@ -5,5 +5,11 @@ describe('BasiGX.view.button.ZoomOut', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.ZoomOut).to.not.be(undefined);
         });
+        it('can be instantiated', function() {
+            var btn = Ext.create('BasiGX.view.button.ZoomOut');
+            expect(btn).to.be.a(BasiGX.view.button.ZoomOut);
+            // teardown
+            btn.destroy();
+        });
     });
 });

--- a/test/spec/view/button/ZoomToExtent.test.js
+++ b/test/spec/view/button/ZoomToExtent.test.js
@@ -5,5 +5,11 @@ describe('BasiGX.view.button.ZoomToExtent', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.ZoomToExtent).to.not.be(undefined);
         });
+        it('can be instantiated', function() {
+            var btn = Ext.create('BasiGX.view.button.ZoomToExtent');
+            expect(btn).to.be.a(BasiGX.view.button.ZoomToExtent);
+            // teardown
+            btn.destroy();
+        });
     });
 });


### PR DESCRIPTION
This PR suggests to add a common base class for the buttons which allows us to stop copy and paste the constructor part where we have special logic wrt to `setTooltip`.

@annarieger likes it already :smile: but I'd like to as @dnlkoch to look into this as well (in the project he currently working on…)
