### PR TITLE
Add and use a utility for map/mapComponent setup

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -10,7 +10,9 @@
 
         "Ext": false,
         "GeoExt": false,
-        "ol": false
+        "ol": false,
+
+        "TestUtil": false
     },
     "rules": {
         "comma-dangle": 2,

--- a/test/spec/plugin/Hover.test.js
+++ b/test/spec/plugin/Hover.test.js
@@ -1,4 +1,4 @@
-Ext.Loader.syncRequire(['BasiGX.plugin.Hover', 'BasiGX.view.component.Map']);
+Ext.Loader.syncRequire(['BasiGX.plugin.Hover']);
 
 describe('BasiGX.plugin.Hover', function() {
 
@@ -6,27 +6,27 @@ describe('BasiGX.plugin.Hover', function() {
         it('is defined', function() {
             expect(BasiGX.plugin.Hover).to.not.be(undefined);
         });
-        it('can be instantiated', function(){
+        it('can be instantiated', function() {
             var plugin = Ext.create('BasiGX.plugin.Hover');
             expect(plugin).to.be.a(BasiGX.plugin.Hover);
         });
     });
 
     describe('Static properties', function() {
-        describe('they are defined for the base plugin', function(){
-            it('works for #HOVER_OVERLAY_IDENTIFIER_KEY', function(){
+        describe('they are defined for the base plugin', function() {
+            it('works for #HOVER_OVERLAY_IDENTIFIER_KEY', function() {
                 var prop = BasiGX.plugin.Hover.HOVER_OVERLAY_IDENTIFIER_KEY;
                 expect(prop).to.not.be(undefined);
             });
-            it('works for #HOVER_OVERLAY_IDENTIFIER_VALUE', function(){
+            it('works for #HOVER_OVERLAY_IDENTIFIER_VALUE', function() {
                 var prop = BasiGX.plugin.Hover.HOVER_OVERLAY_IDENTIFIER_VALUE;
                 expect(prop).to.not.be(undefined);
             });
-            it('works for #LAYER_HOVERABLE_PROPERTY_NAME', function(){
+            it('works for #LAYER_HOVERABLE_PROPERTY_NAME', function() {
                 var prop = BasiGX.plugin.Hover.LAYER_HOVERABLE_PROPERTY_NAME;
                 expect(prop).to.not.be(undefined);
             });
-            it('works for #LAYER_HOVERFIELD_PROPERTY_NAME', function(){
+            it('works for #LAYER_HOVERFIELD_PROPERTY_NAME', function() {
                 var prop = BasiGX.plugin.Hover.LAYER_HOVERFIELD_PROPERTY_NAME;
                 expect(prop).to.not.be(undefined);
             });
@@ -34,7 +34,7 @@ describe('BasiGX.plugin.Hover', function() {
         describe('they are inherited for subclasses', function() {
             var ParentClass = BasiGX.plugin.Hover;
             var ExtendedClass = null;
-            beforeEach(function(){
+            beforeEach(function() {
                 ExtendedClass = Ext.define('TestExtendHover', {
                     extend: 'BasiGX.plugin.Hover',
                     alias: 'plugin.test-extend-hover',
@@ -45,25 +45,25 @@ describe('BasiGX.plugin.Hover', function() {
                 Ext.undefine('TestExtendHover');
                 ExtendedClass = null;
             });
-            it('works for #HOVER_OVERLAY_IDENTIFIER_KEY', function(){
+            it('works for #HOVER_OVERLAY_IDENTIFIER_KEY', function() {
                 var originalProp = ParentClass.HOVER_OVERLAY_IDENTIFIER_KEY;
                 var prop = ExtendedClass.HOVER_OVERLAY_IDENTIFIER_KEY;
                 expect(prop).to.not.be(undefined);
                 expect(prop).to.be(originalProp);
             });
-            it('works for #HOVER_OVERLAY_IDENTIFIER_VALUE', function(){
+            it('works for #HOVER_OVERLAY_IDENTIFIER_VALUE', function() {
                 var originalProp = ParentClass.HOVER_OVERLAY_IDENTIFIER_VALUE;
                 var prop = ExtendedClass.HOVER_OVERLAY_IDENTIFIER_VALUE;
                 expect(prop).to.not.be(undefined);
                 expect(prop).to.be(originalProp);
             });
-            it('works for #LAYER_HOVERABLE_PROPERTY_NAME', function(){
+            it('works for #LAYER_HOVERABLE_PROPERTY_NAME', function() {
                 var originalProp = ParentClass.LAYER_HOVERABLE_PROPERTY_NAME;
                 var prop = ExtendedClass.LAYER_HOVERABLE_PROPERTY_NAME;
                 expect(prop).to.not.be(undefined);
                 expect(prop).to.be(originalProp);
             });
-            it('works for #LAYER_HOVERFIELD_PROPERTY_NAME', function(){
+            it('works for #LAYER_HOVERFIELD_PROPERTY_NAME', function() {
                 var originalProp = ParentClass.LAYER_HOVERFIELD_PROPERTY_NAME;
                 var prop = ExtendedClass.LAYER_HOVERFIELD_PROPERTY_NAME;
                 expect(prop).to.not.be(undefined);
@@ -73,7 +73,7 @@ describe('BasiGX.plugin.Hover', function() {
         describe('they can be overridden for subclasses', function() {
             var ParentClass = BasiGX.plugin.Hover;
             var ExtendedClass = null;
-            beforeEach(function(){
+            beforeEach(function() {
                 ExtendedClass = Ext.define('TestExtendHover', {
                     extend: 'BasiGX.plugin.Hover',
                     alias: 'plugin.test-extend-hover',
@@ -90,28 +90,28 @@ describe('BasiGX.plugin.Hover', function() {
                 Ext.undefine('TestExtendHover');
                 ExtendedClass = null;
             });
-            it('works for #HOVER_OVERLAY_IDENTIFIER_KEY', function(){
+            it('works for #HOVER_OVERLAY_IDENTIFIER_KEY', function() {
                 var originalProp = ParentClass.HOVER_OVERLAY_IDENTIFIER_KEY;
                 var prop = ExtendedClass.HOVER_OVERLAY_IDENTIFIER_KEY;
                 expect(prop).to.not.be(undefined);
                 expect(prop).to.not.be(originalProp);
                 expect(prop).to.be('a');
             });
-            it('works for #HOVER_OVERLAY_IDENTIFIER_VALUE', function(){
+            it('works for #HOVER_OVERLAY_IDENTIFIER_VALUE', function() {
                 var originalProp = ParentClass.HOVER_OVERLAY_IDENTIFIER_VALUE;
                 var prop = ExtendedClass.HOVER_OVERLAY_IDENTIFIER_VALUE;
                 expect(prop).to.not.be(undefined);
                 expect(prop).to.not.be(originalProp);
                 expect(prop).to.be('b');
             });
-            it('works for #LAYER_HOVERABLE_PROPERTY_NAME', function(){
+            it('works for #LAYER_HOVERABLE_PROPERTY_NAME', function() {
                 var originalProp = ParentClass.LAYER_HOVERABLE_PROPERTY_NAME;
                 var prop = ExtendedClass.LAYER_HOVERABLE_PROPERTY_NAME;
                 expect(prop).to.not.be(undefined);
                 expect(prop).to.not.be(originalProp);
                 expect(prop).to.be('c');
             });
-            it('works for #LAYER_HOVERFIELD_PROPERTY_NAME', function(){
+            it('works for #LAYER_HOVERFIELD_PROPERTY_NAME', function() {
                 var originalProp = ParentClass.LAYER_HOVERFIELD_PROPERTY_NAME;
                 var prop = ExtendedClass.LAYER_HOVERFIELD_PROPERTY_NAME;
                 expect(prop).to.not.be(undefined);
@@ -124,20 +124,16 @@ describe('BasiGX.plugin.Hover', function() {
     describe('Usage as plugin for BasiGX.view.component.Map', function() {
         var plugin;
         var mapComponent;
-        var div;
+        var testObjs;
         beforeEach(function() {
-            div = document.createElement('div');
-            document.body.appendChild(div);
-            mapComponent = Ext.create('BasiGX.view.component.Map', {
-                plugins: ['hover'],
-                map: new ol.Map({target: div})
+            testObjs = TestUtil.setupTestObjects({
+                mapComponentOpts: {plugins: ['hover']}
             });
+            mapComponent = testObjs.mapComponent;
             plugin = mapComponent.getPlugin('hover');
         });
         afterEach(function() {
-            mapComponent.destroy();
-            document.body.removeChild(div);
-            div = null;
+            TestUtil.teardownTestObjects(testObjs);
         });
         it('creates an instance by pluginId', function() {
             expect(plugin).to.be.a(BasiGX.plugin.Hover);
@@ -147,26 +143,22 @@ describe('BasiGX.plugin.Hover', function() {
         });
     });
 
-    describe('Configuration options', function(){
-        var div;
+    describe('Configuration options', function() {
         var plugin;
         var mapComponent;
+        var testObjs;
         beforeEach(function() {
-            div = document.createElement('div');
-            document.body.appendChild(div);
-            mapComponent = Ext.create('BasiGX.view.component.Map', {
-                plugins: ['hover'],
-                map: new ol.Map({target: div})
+            testObjs = TestUtil.setupTestObjects({
+                mapComponentOpts: {plugins: ['hover']}
             });
+            mapComponent = testObjs.mapComponent;
             plugin = mapComponent.getPlugin('hover');
         });
         afterEach(function() {
-            mapComponent.destroy();
-            document.body.removeChild(div);
-            div = null;
+            TestUtil.teardownTestObjects(testObjs);
         });
 
-        describe('sane defaults', function(){
+        describe('sane defaults', function() {
             it('has pointerRest set to true', function() {
                 expect(plugin.getPointerRest()).to.be(true);
             });
@@ -195,22 +187,20 @@ describe('BasiGX.plugin.Hover', function() {
                 );
             });
         });
-        describe('defaults are changeable', function(){
+        describe('defaults are changeable', function() {
             var mapComponentConfigured;
             var pluginConfigured;
             var source;
             var layer;
             var interaction;
-            var div2;
+            var testObjs2;
 
             beforeEach(function() {
-                div2 = document.createElement('div');
-                document.body.appendChild(div2);
                 source = new ol.source.Vector();
                 layer = new ol.layer.Vector();
                 interaction = new ol.interaction.Select();
-                mapComponentConfigured = Ext.create(
-                    'BasiGX.view.component.Map', {
+                testObjs2 = TestUtil.setupTestObjects({
+                    mapComponentOpts: {
                         plugins: {
                             ptype:'hover',
                             pointerRest: false,
@@ -220,16 +210,14 @@ describe('BasiGX.plugin.Hover', function() {
                             hoverVectorLayerSource: source,
                             hoverVectorLayer: layer,
                             hoverVectorLayerInteraction: interaction
-                        },
-                        map: new ol.Map({target: div2})
+                        }
                     }
-                );
+                });
+                mapComponentConfigured = testObjs2.mapComponent;
                 pluginConfigured = mapComponentConfigured.getPlugin('hover');
             });
-            afterEach(function(){
-                mapComponentConfigured.destroy();
-                document.body.removeChild(div2);
-                div2 = null;
+            afterEach(function() {
+                TestUtil.teardownTestObjects(testObjs2);
             });
 
             it('has pointerRest set to false', function() {
@@ -264,70 +252,56 @@ describe('BasiGX.plugin.Hover', function() {
                 );
             });
         });
-        describe("Configurable selectEventOrigin", function(){
-            it("is 'collection' by default", function(){
-                // setup
-                var mapComp = Ext.create("BasiGX.view.component.Map", {
-                    plugins: {
-                        ptype: "hover"
-                    },
-                    map: new ol.Map({target: div})
-                });
-                var hoverPlugin = mapComp.getPlugin("hover");
-
+        describe("Configurable selectEventOrigin", function() {
+            it("is 'collection' by default", function() {
                 // test
-                expect(hoverPlugin.selectEventOrigin).to.be("collection");
-
-                // teardown
-                mapComp.destroy();
-                mapComp = null;
+                expect(plugin.selectEventOrigin).to.be("collection");
             });
-            it("can be set to 'interaction'", function(){
-                // setup
-                var mapComp = Ext.create("BasiGX.view.component.Map", {
-                    plugins: {
-                        ptype: "hover",
-                        selectEventOrigin: "interaction"
-                    },
-                    map: new ol.Map({target: div})
+            it("can be set to 'interaction'", function() {
+                var testObjs2 = TestUtil.setupTestObjects({
+                    mapComponentOpts: {
+                        plugins: {
+                            ptype: "hover",
+                            selectEventOrigin: "interaction"
+                        }
+                    }
                 });
-                var hoverPlugin = mapComp.getPlugin("hover");
+                var hoverPlugin = testObjs2.mapComponent.getPlugin("hover");
 
                 // test
                 expect(hoverPlugin.selectEventOrigin).to.be("interaction");
 
                 // teardown
-                mapComp.destroy();
-                mapComp = null;
+                TestUtil.teardownTestObjects(testObjs2);
             });
-            it("defaults to 'collection' on unexpected values", function(){
+            it("defaults to 'collection' on unexpected values", function() {
                 // setup
-                var mapComp = Ext.create("BasiGX.view.component.Map", {
-                    plugins: {
-                        ptype: "hover",
-                        selectEventOrigin: "humpty-dumpty"
-                    },
-                    map: new ol.Map({target: div})
+                var testObjs2 = TestUtil.setupTestObjects({
+                    mapComponentOpts: {
+                        plugins: {
+                            ptype: "hover",
+                            selectEventOrigin: "humpty-dumpty"
+                        }
+                    }
                 });
-                var hoverPlugin = mapComp.getPlugin("hover");
+                var hoverPlugin = testObjs2.mapComponent.getPlugin("hover");
 
-                // test
                 // actually uses the default:
                 expect(hoverPlugin.selectEventOrigin).to.be("collection");
 
                 // teardown
-                mapComp.destroy();
-                mapComp = null;
+                TestUtil.teardownTestObjects(testObjs2);
             });
             it("warns with hints when defaulting to 'collection'", function() {
                 // setup
                 var loggerSpy = sinon.spy(Ext.log, "warn");
-                var mapComp = Ext.create("BasiGX.view.component.Map", {
-                    plugins: {
-                        ptype: "hover",
-                        selectEventOrigin: "humpty-dumpty"
-                    },
-                    map: new ol.Map({target: div})
+                var testObjs2 = TestUtil.setupTestObjects({
+                    mapComponentOpts: {
+                        plugins: {
+                            ptype: "hover",
+                            selectEventOrigin: "humpty-dumpty"
+                        }
+                    }
                 });
 
                 // test
@@ -338,8 +312,7 @@ describe('BasiGX.plugin.Hover', function() {
 
                 // teardown
                 Ext.log.warn.restore();
-                mapComp.destroy();
-                mapComp = null;
+                TestUtil.teardownTestObjects(testObjs2);
             });
         });
     });

--- a/test/spec/plugin/WfsCluster.test.js
+++ b/test/spec/plugin/WfsCluster.test.js
@@ -13,33 +13,31 @@ describe('BasiGX.plugin.WfsCluster', function() {
     describe('Usage as plugin for BasiGX.view.component.Map', function() {
         var plugin;
         var mapComponent;
-        var div;
         var clusterLayerConf;
         var layer;
+        var testObjs;
         beforeEach(function() {
-            div = document.createElement('div');
-            document.body.appendChild(div);
+            testObjs = TestUtil.setupTestObjects({
+                mapOpts: {
+                    projection: 'EPSG:3857'
+                },
+                mapComponentOpts: {
+                    plugins: ['wfscluster']
+                }
+            });
             clusterLayerConf = {
                 type: 'WFSCluster',
                 layers: 'test',
                 url: 'http://test.com'
             };
-            mapComponent = Ext.create('BasiGX.view.component.Map', {
-                plugins: ['wfscluster'],
-                map: new ol.Map({
-                    target: div,
-                    projection: 'EPSG:3857'
-                })
-            });
-            BasiGX.util.ConfigParser.map = mapComponent.getMap();
+            mapComponent = testObjs.mapComponent;
+            BasiGX.util.ConfigParser.map = testObjs.map;
             layer = BasiGX.util.ConfigParser.createLayer(clusterLayerConf);
-            mapComponent.getMap().addLayer(layer);
+            testObjs.map.addLayer(layer);
             plugin = mapComponent.getPlugin('wfscluster');
         });
         afterEach(function() {
-            mapComponent.destroy();
-            document.body.removeChild(div);
-            div = null;
+            TestUtil.teardownTestObjects(testObjs);
         });
         it('creates an instance by pluginId', function() {
             expect(plugin).to.be.a(BasiGX.plugin.WfsCluster);
@@ -70,17 +68,14 @@ describe('BasiGX.plugin.WfsCluster', function() {
             expect(loadCount).to.not.be(0);
         });
 
-        //TODO: find a way to trigger the moveend event, setCenter wont work
-//        it('registers and calls a moveend listener on map', function() {
-//            var loadCount = 0;
-//
-//            plugin.loadClusterFeatures = function() {
-//                loadCount++;
-//            };
-//            plugin.setUpClusterLayers(mapComponent);
-//            mapComponent.getMap().getView().setCenter([22,3]);
-//            expect(loadCount).to.not.be(0);
-//
-//        });
+        it('registers and calls a moveend listener on map', function() {
+            var loadCount = 0;
+            plugin.loadClusterFeatures = function() {
+                loadCount++;
+            };
+            plugin.setUpClusterLayers(mapComponent);
+            testObjs.map.dispatchEvent('moveend');
+            expect(loadCount).to.not.be(0);
+        });
     });
 });

--- a/test/spec/util/Animate.test.js
+++ b/test/spec/util/Animate.test.js
@@ -7,25 +7,19 @@ describe('BasiGX.util.Animate', function() {
         });
     });
     describe('Usage of static Methods', function() {
-        var div;
-        var mapComponent;
+        var btnDiv;
+        var testObjs;
         beforeEach(function() {
-            div = document.createElement('div');
-            document.body.appendChild(div);
-            mapComponent = Ext.create('BasiGX.view.component.Map', {
-                map: new ol.Map({
-                    target: div
-                })
-            });
+            btnDiv = TestUtil.setupTestDiv();
+            testObjs = TestUtil.setupTestObjects();
         });
         afterEach(function() {
-            document.body.removeChild(div);
-            div = null;
-            mapComponent.destroy();
+            TestUtil.teardownTestDiv(btnDiv);
+            TestUtil.teardownTestObjects(testObjs);
         });
 
         it('does not throw on shake method call', function() {
-            var component = Ext.create('Ext.button.Button', {renderTo: div});
+            var component = Ext.create('Ext.button.Button', {renderTo: btnDiv});
             expect(BasiGX.util.Animate.shake).withArgs(component, 100, 100).
                 to.not.throwException();
         });

--- a/test/spec/util/Application.test.js
+++ b/test/spec/util/Application.test.js
@@ -7,24 +7,14 @@ describe('BasiGX.util.Application', function() {
         });
     });
     describe('Usage of static Methods', function() {
-        var div;
         var mapComponent;
+        var testObjs;
         beforeEach(function() {
-            div = document.createElement('div');
-            document.body.appendChild(div);
-            mapComponent = Ext.create('BasiGX.view.component.Map', {
-                map: new ol.Map({
-                    target: div,
-                    view: new ol.View({
-                        center: [0, 0]
-                    })
-                })
-            });
+            testObjs = TestUtil.setupTestObjects();
+            mapComponent = testObjs.mapComponent;
         });
         afterEach(function() {
-            document.body.removeChild(div);
-            div = null;
-            mapComponent.destroy();
+            TestUtil.teardownTestObjects(testObjs);
         });
 
         it('does not throw on getAppContext call', function() {

--- a/test/spec/util/ConfigParser.test.js
+++ b/test/spec/util/ConfigParser.test.js
@@ -153,8 +153,7 @@ describe('BasiGX.util.ConfigParser', function() {
             }
         };
         beforeEach(function() {
-            div = document.createElement('div');
-            document.body.appendChild(div);
+            div = TestUtil.setupTestDiv();
             map = BasiGX.util.ConfigParser.setupMap(appContext);
             layer = BasiGX.util.ConfigParser.createLayer({
                 name: "OSM WMS Farbig",
@@ -176,8 +175,8 @@ describe('BasiGX.util.ConfigParser', function() {
             });
         });
         afterEach(function() {
-            document.body.removeChild(div);
-            div = null;
+            TestUtil.teardownTestDiv(div);
+            map.setTarget(null);
             map = null;
             layer = null;
         });

--- a/test/spec/util/Layer.test.js
+++ b/test/spec/util/Layer.test.js
@@ -2,44 +2,27 @@ Ext.Loader.syncRequire(['BasiGX.util.Layer']);
 
 describe('BasiGX.util.Layer', function() {
 
-    var div;
     var layer;
     var namedLayer;
     var map;
-    var mapComponent;
+    var testObjs;
 
     beforeEach(function() {
-        div = document.createElement('div');
-        div.style.position = "absolute";
-        div.style.top = "0";
-        div.style.left = "-1000px";
-        div.style.width = "512px";
-        div.style.height = "256px";
-        document.body.appendChild(div);
-
         layer = new ol.layer.Base({
             humpty: 'dumpty'
         });
         namedLayer = new ol.layer.Base({
             name: 'Some layername'
         });
-
-        map = new ol.Map({
-            layers: [layer, namedLayer],
-            view: new ol.View({
-                center: [0, 0],
-                zoom: 2
-            })
+        testObjs = TestUtil.setupTestObjects({
+            mapOpts: {
+                layers: [layer, namedLayer]
+            }
         });
-
-        mapComponent = Ext.create('GeoExt.component.Map', {
-            map: map
-        });
+        map = testObjs.map;
     });
     afterEach(function() {
-        mapComponent.destroy();
-        document.body.removeChild(div);
-        div = null;
+        TestUtil.teardownTestObjects(testObjs);
     });
 
     function addLayerWithKeyVal(key, val) {

--- a/test/spec/view/button/Hsi.test.js
+++ b/test/spec/view/button/Hsi.test.js
@@ -2,29 +2,12 @@ Ext.Loader.syncRequire(['BasiGX.view.button.Hsi']);
 
 describe('BasiGX.view.button.Hsi', function() {
     describe('Basics', function() {
-
-        var mapComponent;
-        var map;
-        var mapDiv;
-
+        var testObjs;
         beforeEach(function() {
-            mapDiv = document.createElement('div');
-            document.body.appendChild(mapDiv);
-
-            map = new ol.Map({target: mapDiv});
-            mapComponent = Ext.create('BasiGX.view.component.Map', {
-                map: map,
-                view: new ol.View({
-                    resolution: 7
-                })
-            });
+            testObjs = TestUtil.setupTestObjects();
         });
-
         afterEach(function() {
-            map.setTarget(null);
-            mapComponent.destroy();
-            document.body.removeChild(mapDiv);
-            mapDiv = null;
+            TestUtil.teardownTestObjects(testObjs);
         });
 
         it('is defined', function() {

--- a/test/spec/view/button/Measure.test.js
+++ b/test/spec/view/button/Measure.test.js
@@ -3,40 +3,23 @@ Ext.Loader.syncRequire(['BasiGX.view.button.Measure']);
 describe('BasiGX.view.button.Measure', function() {
 
     var btn;
-    var mapComponent;
-    var map;
-    var mapDiv;
     var buttonDiv;
+    var testObjs;
 
     beforeEach(function() {
-        mapDiv = document.createElement('div');
-        document.body.appendChild(mapDiv);
-        buttonDiv = document.createElement('div');
-        document.body.appendChild(buttonDiv);
-
-        map = new ol.Map({target: mapDiv});
-        mapComponent = Ext.create('BasiGX.view.component.Map', {
-            map: map,
-            view: new ol.View({
-                resolution: 7
-            })
-        });
+        testObjs = TestUtil.setupTestObjects();
+        buttonDiv = TestUtil.setupTestDiv();
         btn = Ext.create('BasiGX.view.button.Measure', {
             renderTo: buttonDiv
         });
     });
 
     afterEach(function() {
-        map.setTarget(null);
-        mapComponent.destroy();
-        document.body.removeChild(mapDiv);
-        mapDiv = null;
+        TestUtil.teardownTestObjects(testObjs);
         if (btn) {
             btn.destroy();
         }
-        document.body.removeChild(buttonDiv);
-        buttonDiv = null;
-        btn = null;
+        TestUtil.teardownTestDiv(buttonDiv);
     });
 
     describe('Basics', function() {
@@ -85,7 +68,7 @@ describe('BasiGX.view.button.Measure', function() {
         it('is autoconfigured with a map', function() {
             expect(btn.map).to.be.ok();
             expect(btn.map).to.be.a(ol.Map);
-            expect(btn.map).to.be(map);
+            expect(btn.map).to.be(testObjs.map);
         });
 
         it('automatically adds a vector layer', function() {

--- a/test/spec/view/combo/ScaleCombo.test.js
+++ b/test/spec/view/combo/ScaleCombo.test.js
@@ -1,43 +1,25 @@
-Ext.Loader.syncRequire([
-    'BasiGX.view.combo.ScaleCombo',
-    'GeoExt.component.Map'
-]);
+Ext.Loader.syncRequire(['BasiGX.view.combo.ScaleCombo']);
 
 describe('BasiGX.view.combo.ScaleCombo', function() {
-    var div;
-    var componentDiv;
     var map;
     var combo;
-    var mapComponent;
+    var testObjs;
     beforeEach(function() {
-        div = document.createElement('div');
-        document.body.appendChild(div);
-        componentDiv = document.createElement('div');
-        document.body.appendChild(componentDiv);
-
-        map = new ol.Map({
-            target: div,
-            view: new ol.View({
-                resolution: 7
-            })
+        testObjs = TestUtil.setupTestObjects({
+            mapOpts: {
+                view: new ol.View({
+                    resolution: 7
+                })
+            }
         });
-        mapComponent = Ext.create('GeoExt.component.Map', {
-            map: map,
-            renderTo: componentDiv
-        });
+        map = testObjs.map;
         combo = Ext.create('BasiGX.view.combo.ScaleCombo', {
             map: map
         });
     });
     afterEach(function() {
         combo.destroy();
-        mapComponent.destroy();
-        map.setTarget(null);
-        map = null;
-        document.body.removeChild(div);
-        div = null;
-        document.body.removeChild(componentDiv);
-        componentDiv = null;
+        TestUtil.teardownTestObjects(testObjs);
     });
 
     describe('Basics', function() {
@@ -51,7 +33,7 @@ describe('BasiGX.view.combo.ScaleCombo', function() {
     describe('autodetects map if not set', function() {
         it('works on an autodetected map if none configured', function() {
             var combo2 = Ext.create('BasiGX.view.combo.ScaleCombo');
-            expect(combo2.map).to.be(map);
+            expect(combo2.map).to.be(testObjs.map);
             combo2.destroy();
         });
     });

--- a/test/spec/view/container/Redlining.test.js
+++ b/test/spec/view/container/Redlining.test.js
@@ -2,30 +2,14 @@ Ext.Loader.syncRequire(['BasiGX.view.container.Redlining']);
 
 describe('BasiGX.view.container.Redlining', function() {
     var redliningContainer;
-    var map;
-    var mapComponent;
-    var div;
+    var testObjs;
     beforeEach(function() {
-        div = document.createElement('div');
-        document.body.appendChild(div);
-        map = new ol.Map({
-            target: div,
-            view: new ol.View({
-                resolution: 7
-            })
-        });
-        mapComponent = Ext.create('GeoExt.component.Map', {
-            map: map
-        });
+        testObjs = TestUtil.setupTestObjects();
         redliningContainer = Ext.create('BasiGX.view.container.Redlining');
     });
     afterEach(function() {
         redliningContainer.destroy();
-        mapComponent.destroy();
-        map.setTarget(null);
-        map = null;
-        document.body.removeChild(div);
-        div = null;
+        TestUtil.teardownTestObjects(testObjs);
     });
 
     describe('Basics', function() {

--- a/test/test-helper-functions.js
+++ b/test/test-helper-functions.js
@@ -1,4 +1,6 @@
-// This file is taken from GeoExt3
+// This file was originally taken from GeoExt3, and has been modified
+// to include more helpers, like #ensureMapComponentAvailable, #setupTestObjects
+// and some more.
 (function(global){
     /**
      * A helper method that'll return a HTML script tag for loading
@@ -22,7 +24,149 @@
         return '<scr' + 'ipt>' + code + '</scr' + 'ipt>';
     }
 
+    /**
+     * Ensures that the `BasiGX.view.component.Map` is available for
+     * instantiation by calling `Ext.Loader.syncRequire` if needed.
+     *
+     * @private
+     */
+    function ensureMapComponentAvailable() {
+        if(!BasiGX || !BasiGX.view || !BasiGX.view.component ||
+            !BasiGX.view.component.Map) {
+            Ext.Loader.syncRequire(['BasiGX.view.component.Map']);
+        }
+    }
+
+    /**
+     * A utility function that creates and adds a `<div>` to the `<body>` of the
+     * document. The div is positioned absolutely off the screen and configured
+     * with fixed dimensions to never be visible to the user (e.g. when the
+     * test suite is viewed in a browser).
+     *
+     * Use this method in `beforeEach` if you need a `<div>` (e.g. to render
+     * ExtJS components with their `renderTo` configuration).
+     *
+     * The created `<div>` is returned, so that it can easily be used in
+     * `afterEach`-calls to cleanup. Most of the time you'll be using the helper
+     * function #teardownTestDiv in such a case.
+     *
+     * @return {HTMLDivElement} The created `<div>`.
+     */
+    function setupTestDiv() {
+        var div = document.createElement('div');
+        div.style.position = 'absolute';
+        div.style.top = 0;
+        div.style.left = -500;
+        div.style.width = 256;
+        div.style.height = 128;
+        document.body.appendChild(div);
+        return div;
+    }
+
+    /**
+     * A utility function that removes the passed `div` from the document and
+     * nullifies it.
+     *
+     * Use this method (e.g. in `afterEach`-calls) to cleanup any divs that you
+     * have setup earlier (often by calling #setupTestDiv).
+     *
+     * @param {HTMLDivElement} div The `<div>` you want to remove.
+     */
+    function teardownTestDiv(div) {
+        if(!div) {
+            return;
+        }
+        var parent = div.parentNode;
+        if(parent) {
+            parent.removeChild(div);
+        }
+        div = null;
+    }
+
+    /**
+     * A utility function to create several objects that our tests need every
+     * now and then. Will return an object that provides the created components
+     * and HTML elements.
+     *
+     * Use this method (e.g. in `beforeEach` calls) to have easy access to an
+     * `ol.Map` and a `BasiGX.view.component.Map`. In order to teardown all
+     * created objects, use #teardownTestObjects.
+     *
+     * The created objects can be configured by passing in an `opts` object,
+     * where the key `mapOpts` is an object with configs for the `ol.Map`, and
+     * the key `mapComponentOpts` is an object with configs for the
+     * `BasiGX.view.component.Map`.
+     *
+     * @param {Object} opts The options for the objects to create. Optional.
+     * @param {Object} opts.mapOpts The options for the `ol.Map` constructor.
+     *     Optional.
+     * @param {Object} opts.mapComponentOpts The options for the map component
+     *     constructor. Optional.
+     * @return {Object} An object with the following keys: `map`, `mapDiv`,
+     *     `mapComponent` and `mapComponentDiv`. `map` will hold the `ol.Map`
+     *     instance, `mapDiv` will hold the `<div>` of the `map`, `mapComponent`
+     *     will hold the `BasiGX.view.component.Map` that is configured with the
+     *     `map` and `mapComponentDiv` will hold the `<div>` of the craeted
+     *     `mapComponent`. Usually you'll only interact with the components, not
+     *     with the `<div>`s.
+     */
+    function setupTestObjects(opts) {
+        ensureMapComponentAvailable();
+
+        var options = opts || {};
+        var mapOpts = options.mapOpts || {};
+        var mapComponentOpts = options.mapComponentOpts || {};
+
+        var mapDiv = setupTestDiv();
+        var mapComponentDiv = setupTestDiv();
+
+        var view = new ol.View({
+            center: [0, 0]
+        });
+        var map = new ol.Map(Ext.apply({target: mapDiv, view: view}, mapOpts));
+        var mapComponent = Ext.create('BasiGX.view.component.Map', Ext.apply({
+            map: map,
+            renderTo: mapComponentDiv
+        }, mapComponentOpts));
+
+        return {
+            map: map,
+            mapComponent: mapComponent,
+            mapDiv: mapDiv,
+            mapComponentDiv: mapComponentDiv
+        };
+    }
+
+    /**
+     * A utility method to clean up test objects when they are no longer needed.
+     * This is the companion method for #setupTestObjects; If you pass in the
+     * object that was created using #setupTestObjects, all created elements
+     * will properly be cleaned up.
+     *
+     * Usually you'll call this method inside of e.g. `afterEach`.
+     *
+     * @param {Object} createdObjs The object holding the objects created by
+     *     the method #setupTestObjects.
+     */
+    function teardownTestObjects(createdObjs) {
+        if(!createdObjs) {
+            return;
+        }
+        if(createdObjs.mapComponent && createdObjs.mapComponent.destroy) {
+            createdObjs.mapComponent.destroy();
+        }
+        if(createdObjs.map && createdObjs.map.setTarget) {
+            createdObjs.map.setTarget(null);
+        }
+        teardownTestDiv(createdObjs.mapComponentDiv);
+        teardownTestDiv(createdObjs.mapDiv);
+    }
+
     global.TestUtil = {
+        setupTestDiv: setupTestDiv,
+        teardownTestDiv: teardownTestDiv,
+        setupTestObjects: setupTestObjects,
+        teardownTestObjects: teardownTestObjects,
         getExternalScriptTag: getExternalScriptTag,
         getInlineScriptTag: getInlineScriptTag
     };


### PR DESCRIPTION
This PR suggestss to add and use some utility methods to ensure a testable setup exists with an `ol.Map` and an `BasiGX.view.component.Map`. This methdos are added:

* `ensureMapComponentAvailable()` only used internally
* `setupTestDiv()` and `teardownTestDiv()` for creating and destroying of `<div>` elements
* `setupTestObjects()` and `teardownTestObjects()` for creating and destroying of `ol.Map` and an `BasiGX.view.component.Map` instances.

For details see the changes in `test/test-helper-functions.js`.

With this in, our tests become way more readable and also we always properly cleanup after ourselves without all the clutter in each specific test file. I hope that writing tests is now easier and might even make fun.

Also included are minor stylistic changes and a previously commented out test that could now be uncommented (and passes).

Please review.