### PR TITLE
Add a focusable tree item class

### DIFF
--- a/src/view/list/FocusableTreeItem.js
+++ b/src/view/list/FocusableTreeItem.js
@@ -1,0 +1,89 @@
+/* Copyright (c) 2017-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * `BasiGX.view.list.FocusableTreeItem`
+ *
+ * A class that can be used inside of `Ext.list.Tree` instances. This tree item
+ * class differs to its parent in two points:
+ *
+ * * `BasiGX.view.list.FocusableTreeItem` instances can be focused; by clicking
+ *   or by hitting the tab-key.
+ * * If a focused treeitem receives a `keypress`-event that originates from
+ *   either the space-bar or the the enter-key, the `selectionchange` event of
+ *   the parent `Ext.list.Tree` is fired with the focused item passed as new
+ *   selection
+ *
+ * @class BasiGX.view.list.FocusableTreeItem
+ */
+Ext.define('BasiGX.view.list.FocusableTreeItem', {
+    extend: 'Ext.list.TreeItem',
+    xtype: 'focusable-tree-item',
+
+    /**
+     * Changes the `element` specification to add the `tabIndex`-attribute to
+     * the topmost container, but only if it didn't have it already.
+     */
+    makeFocusableElement: function() {
+        var me = this;
+        var spec = me.element;
+        if(spec && Ext.isObject(spec)) {
+            if(!Ext.isDefined(spec.tabIndex) && !Ext.isDefined(spec.tabindex)) {
+                me.element.tabIndex = 0;
+            }
+        }
+    },
+
+    /**
+     * Registers our `keypress`-handler to eventually trigger `selectionchange`
+     * in the parent list.
+     */
+    bindFocusKeyPressHandler: function() {
+        var me = this;
+        me.getEl().on('keypress', me.onKeyPress, me);
+    },
+
+    /**
+     * Our handler for the `keypress`-event on a focused list item. Will check
+     * if the passed key was either the space-bar or the enter-key, and if so,
+     * it will trigger an appropriate `selectionchange`-event in the parent
+     * treelist.
+     *
+     * @param {Ext.event.Event} evt The `keypress`-event we detected, includes
+     *     the pressed key.
+     */
+    onKeyPress: function(evt) {
+        var me = this;
+        var enter = Ext.event.Event.ENTER;
+        var space = Ext.event.Event.SPACE;
+        var pressedKey = evt.getKey();
+        var list = me.up('treelist');
+        if (list && (pressedKey === enter || pressedKey === space)) {
+            list.fireEvent('selectionchange', list, me.getNode(), {});
+        }
+    },
+
+    /**
+     * The constructor of `BasiGX.view.list.FocusableTreeItem`. First makes the
+     * element focusable, and then registers a handler to handle `keypress`
+     * events on focused list items.
+     */
+    constructor: function () {
+        var me = this;
+        me.makeFocusableElement();
+        me.callParent(arguments);
+        me.bindFocusKeyPressHandler();
+    }
+});

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -47,6 +47,7 @@
             'view/form/Print.test.js',
             'view/grid/FeaturePropertyGrid.test.js',
             'view/grid/GazetteerGrid.test.js',
+            'view/list/FocusableTreeItem.test.js',
             'view/panel/Accessible.test.js',
             'view/panel/Header.test.js',
             'view/panel/LayerSetChooser.test.js',

--- a/test/spec/view/list/FocusableTreeItem.test.js
+++ b/test/spec/view/list/FocusableTreeItem.test.js
@@ -1,0 +1,138 @@
+Ext.Loader.syncRequire([
+    'BasiGX.view.list.FocusableTreeItem',
+    'Ext.list.Tree'
+]);
+
+describe('BasiGX.view.list.FocusableTreeItem', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.view.list.FocusableTreeItem).to.not.be(undefined);
+        });
+        it('can be instantiated', function() {
+            var item = Ext.create('BasiGX.view.list.FocusableTreeItem');
+            expect(item).to.be.a(BasiGX.view.list.FocusableTreeItem);
+            // teardown
+            item.destroy();
+        });
+    });
+    describe('Usage inside of a treelist', function() {
+        var store;
+        var treeList;
+        var callback;
+        var div;
+        beforeEach(function() {
+            callback = sinon.spy();
+            div = document.createElement('div');
+            document.body.appendChild(div);
+            store = {
+                root: {
+                    expanded: true,
+                    children: [{
+                        text: 'humpty',
+                        leaf: true
+                    }, {
+                        text: 'dumpty',
+                        leaf: true
+                    }, {
+                        text: 'foobar',
+                        leaf: true
+                    }]
+                }
+            };
+            treeList = Ext.create('Ext.list.Tree', {
+                defaults: {
+                    // This way our BasiGX class is used
+                    xtype: 'focusable-tree-item'
+                },
+                store: store,
+                listeners: {
+                    selectionchange: callback
+                },
+                renderTo: div
+            });
+            expect(treeList).to.be.a(Ext.list.Tree);
+        });
+        afterEach(function() {
+            treeList.destroy();
+            store = null;
+            div.parentNode.removeChild(div);
+            div = null;
+        });
+
+        it('renders `<li>` elements with `tabIndex` attribute', function() {
+            var selector = 'li.x-focusable-tree-item[tabindex]';
+            var lis = document.querySelectorAll(selector);
+            expect(lis).to.have.length(3);
+        });
+
+        describe('ensures treelist `selectionchange` event can be triggered',
+            function() {
+                var item;
+                var target;
+
+                /**
+                 * Returns a mock-event as it would have been created by an
+                 * actual keydown.
+                 *
+                 * @param {Number} key The keyCode of the pressed key.
+                 * @return {Ext.event.Event} The mocked-up event.
+                 */
+                var makeEvt = function(key) {
+                    return Ext.create('Ext.event.Event', {
+                        type: 'keypress',
+                        keyCode: key,
+                        target: target
+                    });
+                };
+
+                beforeEach(function() {
+                    item = Ext.ComponentQuery.query('focusable-tree-item')[0];
+                    expect(item).to.be.ok();
+                    expect(item.onKeyPress).to.be.ok();
+                    target = item.el.dom;
+                });
+
+                it('is triggered on ENTER-key', function() {
+                    var evtEnter = makeEvt(Ext.event.Event.ENTER);
+
+                    var cntBefore = callback.callCount;
+
+                    // call into the keyPress method directly
+                    item.onKeyPress(evtEnter);
+
+                    expect(callback.callCount).to.be(cntBefore + 1);
+
+                    var call = callback.getCall(callback.callCount - 1);
+                    expect(call.args[0]).to.be(treeList);
+                    expect(call.args[1]).to.be(item.getNode());
+                });
+
+                it('is triggered on SPACE-key', function() {
+                    var evtSpace = makeEvt(Ext.event.Event.SPACE);
+
+                    var cntBefore = callback.callCount;
+
+                    // call into the keyPress method directly
+                    item.onKeyPress(evtSpace);
+
+                    expect(callback.callCount).to.be(cntBefore + 1);
+
+                    var call = callback.getCall(callback.callCount - 1);
+                    expect(call.args[0]).to.be(treeList);
+                    expect(call.args[1]).to.be(item.getNode());
+                });
+
+                it('is not triggered on A-key', function() {
+                    var evtA = makeEvt(Ext.event.Event.A);
+
+                    var cntBefore = callback.callCount;
+
+                    // call into the keyPress method directly
+                    item.onKeyPress(evtA);
+
+                    expect(callback.callCount).to.be(cntBefore); // not called
+                });
+            }
+        );
+    });
+});


### PR DESCRIPTION
This PR suggests to add a class that can be used inside of `Ext.list.Tree` instances. This tree item class differs to its parent in two points:

* `BasiGX.view.list.FocusableTreeItem` instances can be focused; by clicking or by hitting the tab-key.
* If a focused treeitem receives a `keypress`-event that originates from either the space-bar or the the enter-key, the `selectionchange` event of the parent `Ext.list.Tree` is fired with the focused item passed as new selection.

Please review.