### PR TITLE
Add zIndex to HoverLayer

### DIFF
--- a/src/plugin/Hover.js
+++ b/src/plugin/Hover.js
@@ -223,7 +223,8 @@ Ext.define('BasiGX.plugin.Hover', {
             hoverVectorLayer = new ol.layer.Vector({
                 name: 'hoverVectorLayer',
                 source: me.getHoverVectorLayerSource(),
-                visible: true
+                visible: true,
+                zIndex: 1000
             });
             map.addLayer(hoverVectorLayer);
             me.setHoverVectorLayer(hoverVectorLayer);


### PR DESCRIPTION
This adds a zIndex to the Hoverlayer as it should be always on top.