### PR TITLE
added hover revert feature order

### DIFF
--- a/src/plugin/Hover.js
+++ b/src/plugin/Hover.js
@@ -35,6 +35,14 @@ Ext.define('BasiGX.plugin.Hover', {
         LAYER_HOVERABLE_PROPERTY_NAME: 'hoverable',
 
         /**
+         * The property of a layer that holds a boolean value which indicates
+         * whether this layer features shall be reverted on hover tooltip.
+         *
+         * @type {String}
+         */
+        LAYER_HOVER_FEATURES_REVERT_NAME: 'hoverFeaturesRevert',
+
+        /**
          * The property of a layer that holds a string value which indicates,
          * which field of the layer shall be shown when hovering.
          *
@@ -300,6 +308,7 @@ Ext.define('BasiGX.plugin.Hover', {
         var mapView = map.getView();
         var pixel = evt.pixel;
         var hoverableProp = me.self.LAYER_HOVERABLE_PROPERTY_NAME;
+        var hoverFeaturesRevertProp = me.self.LAYER_HOVER_FEATURES_REVERT_NAME;
         var hoverLayers = [];
         var hoverFeatures = [];
 
@@ -310,6 +319,7 @@ Ext.define('BasiGX.plugin.Hover', {
             var resolution = mapView.getResolution();
             var projCode = mapView.getProjection().getCode();
             var hoverable = layer.get(hoverableProp);
+            var hoverFeaturesRevert = layer.get(hoverFeaturesRevertProp);
 
             // a layer will NOT be requested for hovering if there is a
             // "hoverable" property set to false. If this property is not set
@@ -346,6 +356,9 @@ Ext.define('BasiGX.plugin.Hover', {
                             feature.setStyle(featureStyle);
                             hoverFeatures.push(feature);
                         });
+                        if (hoverFeaturesRevert) {
+                            hoverFeatures.reverse();
+                        }
 
                         hoverLayers.push(layer);
 


### PR DESCRIPTION
Hallo terrestris,
da die Sortierreihenfolge bei getFeatureInfo() zwischen Geometriedarstellung und HoverInfo differiert, soll ein Layer die Möglichkeit besitzen die Sortierreihenfolge im HoverInfo-Fenster umkehren zu können. Dann stimmt die Reihenfolge im HoverInfo-Fenster mit der "Render-Reihenfolge" der Features überein.
Wäre super wenn Ihr die Änderung in die BasiGX übernehmen könntet.

Viele Grüße
Marco Pochert