### PR TITLE
Multiple enhancements of the AddWms form panel

### DIFF
--- a/examples/i18n/i18n.js
+++ b/examples/i18n/i18n.js
@@ -1,5 +1,14 @@
+Ext.require([
+    'BasiGX.view.component.Map',
+    'BasiGX.view.combo.Language',
+    'BasiGX.view.button.ZoomIn',
+    'BasiGX.view.button.ZoomOut',
+    'BasiGX.view.button.ZoomToExtent',
+    'BasiGX.view.button.Measure',
+    'BasiGX.view.button.AddWms'
+]);
 
-Ext.onReady(function(){
+Ext.onReady(function() {
 
     // enable tooltips
     Ext.tip.QuickTipManager.init();
@@ -15,7 +24,7 @@ Ext.onReady(function(){
             layout: 'fit',
             items: [{
                 xtype: 'basigx-component-map',
-                appContextPath: './resources/appContext.json',
+                appContextPath: './resources/appContext.json'
             }],
             tbar: [{
                 xtype: 'basigx-combo-language',
@@ -47,7 +56,7 @@ Ext.onReady(function(){
                 xtype: 'tbseparator'
             }, {
                 xtype: 'basigx-button-addwms'
-            }],
+            }]
         }]
     });
 

--- a/examples/i18n/index.html
+++ b/examples/i18n/index.html
@@ -21,26 +21,14 @@
     <script src="http://openlayers.org/en/v3.14.2/build/ol.js"></script>
     <script src="https://geoext.github.io/geoext3/master/GeoExt.js"></script>
 
-    <script src="../../src/util/Animate.js"></script>
-    <script src="../../src/util/Layer.js"></script>
-    <script src="../../src/util/Application.js"></script>
-    <script src="../../src/util/ConfigParser.js"></script>
-    <script src="../../src/util/MsgBox.js"></script>
-    <script src="../../src/util/Url.js"></script>
-
-    <script src="../../src/view/form/AddWms.js"></script>
-    <script src="../../src/view/component/Map.js"></script>
-
-    <script src="../../src/view/button/ZoomIn.js"></script>
-    <script src="../../src/view/button/ZoomOut.js"></script>
-    <script src="../../src/view/button/ZoomToExtent.js"></script>
-
-    <script src="../../src/view/button/AddWms.js"></script>
-    <script src="../../src/view/button/Measure.js"></script>
-
-    <script src="../../src/view/combo/Language.js"></script>
-
+    <script>
+    Ext.Loader.setConfig({
+        enabled: true,
+        paths: {
+            'BasiGX': '../../src'
+        }
+    });
+    </script>
     <script src="i18n.js"></script>
-
 </body>
 </html>

--- a/examples/i18n/resources/locale/app-locale-de.json
+++ b/examples/i18n/resources/locale/app-locale-de.json
@@ -195,10 +195,23 @@
                 "availableLayesFieldSetTitle": "Verfügbare Layer",
                 "resetBtnText": "Zurücksetzen",
                 "requestLayersBtnText": "Verfügbare Layer abfragen",
+                "checkAllLayersBtnText": "Alle auswählen",
+                "uncheckAllLayersBtnText": "Nichts auswählen",
                 "addCheckedLayersBtnText": "Ausgewählte Layer hinzufügen",
                 "errorIncompatibleWMS": "Der angefragte WMS ist nicht kompatibel zur Anwendung",
-                "errorRequestFailed": "Die angegebene URL konte nicht abgefragt werden",
-                "errorCouldntParseResponse": "Die erhaltene Antwort konnte nicht erfolgreich geparst werden"
+                "errorRequestFailed": "Die angegebene URL konnte nicht abgefragt werden",
+                "errorCouldntParseResponse": "Die erhaltene Antwort konnte nicht erfolgreich geparst werden",
+                "msgRequestTimedOut": "Die Anfrage wurde nicht schnell genug beantwortet und abgebrochen",
+                "msgServiceException": "Eine OGC ServiceException ist aufgetreten",
+                "msgCorsMisconfiguration": "HTTP access control (CORS) auf dem Zielserver vermutlich nicht korrekt konfiguriert",
+                "msgUnauthorized": "Der Client ist nicht gegenüber dem Zielserver authentifiziert",
+                "msgForbidden": "Der Client hat keinen Zugriff auf die angefragte Ressource",
+                "msgFileNotFound": "Die angefragte Ressource existiert nicht",
+                "msgTooManyRequests": "Der Client hat zu viele Anfragen gestellt",
+                "msgServiceUnavailable": "Der Server ist derzeit nicht verfügbar (zu viele Anfragen bzw. Wartungsmodus)",
+                "msgGatewayTimeOut": "Der Server fungierte als Gateway und das Originalziel hat zu langsam geantwortet",
+                "msgClientError": "Ein unspezifizierter Clientfehler ist aufgetreten",
+                "msgServerError": "Ein unspezifizierter Serverfehler ist aufgetreten"
             }
         }
     },
@@ -412,8 +425,8 @@
         }
     },
     "Ext.form.field.VTypes": {
-        "emailText": "Dieses Feld sollte eine E-Mail-Adresse enthalten. Format: \"user@example.com\"",
-        "urlText": "Dieses Feld sollte eine URL enthalten. Format: \"http:\"www.example.com\"",
+        "emailText": "Dieses Feld sollte eine E-Mail-Adresse enthalten. Format: 'user@example.com'",
+        "urlText": "Dieses Feld sollte eine URL enthalten. Format: 'http:www.example.com'",
         "alphaText": "Dieses Feld darf nur Buchstaben enthalten und _",
         "alphanumText": "Dieses Feld darf nur Buchstaben und Zahlen enthalten und _"
     },

--- a/examples/i18n/resources/locale/app-locale-en.json
+++ b/examples/i18n/resources/locale/app-locale-en.json
@@ -194,11 +194,24 @@
                 "wmsVersionContainerFieldLabel": "Version",
                 "availableLayesFieldSetTitle": "Available layers",
                 "resetBtnText": "Reset",
-                "requestLayersBtnText": "Request available layers",
+                "requestLayersBtnText": "Query for available layers",
+                "checkAllLayersBtnText": "Select all",
+                "uncheckAllLayersBtnText": "Select none",
                 "addCheckedLayersBtnText": "Add selected layers",
-                "errorIncompatibleWMS": "The requested WMS is not compatible with this application",
-                "errorRequestFailed": "Could not reach the desired location",
-                "errorCouldntParseResponse": "Error while reading the response send by the server"
+                "errorIncompatibleWMS": "The queried WMS is not compatible to the application",
+                "errorRequestFailed": "Failed to retrieve entered URL",
+                "errorCouldntParseResponse": "Failed to parse the response",
+                "msgRequestTimedOut": "The response was not delivered in time and the request has been aborted",
+                "msgServiceException": "An OGC ServiceException occured",
+                "msgCorsMisconfiguration": "HTTP access control (CORS) at the target server probably misconfigured",
+                "msgUnauthorized": "The client is not authorized",
+                "msgForbidden": "The client does not have access to the resource",
+                "msgFileNotFound": "The resource could not be found",
+                "msgTooManyRequests": "The client has sent too many requests",
+                "msgServiceUnavailable": "The service is not available",
+                "msgGatewayTimeOut": "The server was acting as a gateway and the upstream server was too slow sending a response",
+                "msgClientError": "An unspecified client error occured",
+                "msgServerError": "An unspecified server error occured"
             }
         }
     },

--- a/src/view/form/AddWms.js
+++ b/src/view/form/AddWms.js
@@ -88,12 +88,12 @@ Ext.define('BasiGX.view.form.AddWms', {
 
         /**
          * Whether to add a `Uncheck all layers` button to the toolbar to
-         * interactthe with the layers of a GetCapabilities response.
+         * interact with the layers of a GetCapabilities response.
          */
         hasUncheckAllBtn: false,
 
         /**
-         * Whether to include sublayers when creting the list of available
+         * Whether to include sublayers when creating the list of available
          * layers.
          */
         includeSubLayer: false,
@@ -200,6 +200,7 @@ Ext.define('BasiGX.view.form.AddWms', {
                 },
                 layout: 'hbox',
                 items: [
+                    // TODO generate from #versionArray?
                     {
                         boxLabel: 'v1.1.1',
                         name: 'version',


### PR DESCRIPTION
This PR suggests some changes to the `AddWms` form:

* Rename the configuration `versionsWmsAutomatically` to `autoDetectVersion`
* Remove configuration `triedVersions`, and instead use an internal property as this should never be set from the user
* Change the `defaultUrl`s default value to be the https-variant
* Add configuration `useDefaultXhrHeader` (to be able to communicate with more actual WMS servers out there, see doc comments for details)
* Add configuration option `disableCaching` (Named as the `Ext.Ajax.request` configuration) to control whether the `_dc`-parameter shall be sent along when fetching the capabilities
* Better error handling:
  * OGC `ServiceExceptionReports` are reported with details
  * Timeouts  are detected and reported
  * Some very common http status codes get special error messages
  * CORS errors are also detected as good as possible
  * All error messages live in the `viewModel`

The first two bullet points make this PR backwards incompatible, so think twice before merging, client projects may need to be updated as follows:

  * When using the former configuration option `versionsWmsAutomatically`: Rename this option to `autoDetectVersion`
  * (Very unlikely) When using the former configuration option `triedVersions`: Remove this option.
