### PR TITLE
WIP:Always try to reload the graphic pool

### DIFF
--- a/src/view/panel/GraphicPool.js
+++ b/src/view/panel/GraphicPool.js
@@ -226,8 +226,21 @@ Ext.define('BasiGX.view.panel.GraphicPool', {
                         BasiGX.error(me.getViewModel().get('uploadErrorText'));
                     }
                 },
-                failure: function() {
-                    BasiGX.error(me.getViewModel().get('uploadErrorText'));
+                failure: function(form, action) {
+                    // for some reasons we come here even in case of success
+                    // (with HTTP Status 200 and a valid response)
+                    var response = action.response;
+                    // for another unknown reason,
+                    // we'll have to decode twice here!?
+                    var responseJson =
+                            Ext.decode(Ext.decode(response.responseText));
+
+                    if (response.status === 200 &&
+                            responseJson.success === true) {
+                        me.pictureView.getStore().load();
+                    } else {
+                        BasiGX.error(me.getViewModel().get('uploadErrorText'));
+                    }
                 }
             });
         }

--- a/src/view/view/GraphicPool.js
+++ b/src/view/view/GraphicPool.js
@@ -47,7 +47,7 @@ Ext.define('BasiGX.view.view.GraphicPool', {
     /**
      *
      */
-    autoScroll: true,
+    scrollable: true,
 
     /**
      * readonly


### PR DESCRIPTION
I tried using the `basigx-panel-graphicpool` component in a SHOGun2 based project (which is Multipart-Upload compatible, i.e. has an according `MultipartFilter ` (to handle CSRF) and a `CommonsMultipartResolver`)

At some point I recognized that the upload (using the graphic pool component) is working fine (HTTP status 200 with "JSON as string" success-response and text/html content type). Even though everything seems fine, i always end up in the `failure` function (changed within this PR).

The changes within this PR parse the response and try to handle it as a success (if that makes sense, i.e. HTTP Status 200 and a "valid" JSON).

I could not find a smarter solution, so this is marked as WIP. I think we should discuss this.