### PR TITLE
Fixed the dataview layout of GraphicPool

### DIFF
--- a/sass/src/view/view/GraphicPool.scss
+++ b/sass/src/view/view/GraphicPool.scss
@@ -1,0 +1,13 @@
+.graphic-pool-view .thumb {
+    padding: 3px;
+}
+
+.graphic-pool-view .thumb-wrap {
+    /*height: 90px;*/
+    float: left;
+    margin: 4px;
+    margin-right: 0;
+    padding: 5px;
+    -webkit-transition: background-color 1s, border-color 0.5s;
+    transition: background-color 1s, border-color 0.5s;
+}

--- a/src/view/view/GraphicPool.js
+++ b/src/view/view/GraphicPool.js
@@ -45,9 +45,24 @@ Ext.define('BasiGX.view.view.GraphicPool', {
     border: false,
 
     /**
-     *
+     * shall the dataview be scrollable
      */
-    autoScroll: true,
+    scrollable: true,
+
+    /**
+     * the default height of the dataview
+     */
+    height: '100%',
+
+    /**
+     * the default width of the dataview
+     */
+    width: '100%',
+
+    /**
+     * the default class
+     */
+    cls: 'graphic-pool-view',
 
     /**
      * readonly


### PR DESCRIPTION
This PR makes the dataview of the graphicpool component 
  * scrollable
  * correctly aligned from left to right instead of top to bottom