### PR TITLE
Fix timinig issue for copy button.

### DIFF
--- a/src/view/form/Permalink.js
+++ b/src/view/form/Permalink.js
@@ -73,9 +73,18 @@ Ext.define('BasiGX.view.form.Permalink', {
             textfield.setValue(permalink);
         }
     }, {
-        hidden: !BasiGX.util.CopyClipboard.copyToClipboardSupported,
         bind: {
             text: '{copyToClipboardBtnText}'
+        },
+        listeners: {
+            boxready: function(btn) {
+                btn.setHidden(
+                        !BasiGX.util.CopyClipboard.copyToClipboardSupported);
+            },
+            initialize: function(btn) {
+                btn.setHidden(
+                        !BasiGX.util.CopyClipboard.copyToClipboardSupported);
+            }
         },
         handler: function(btn) {
             var textfield = btn.up('form').down('textfield');


### PR DESCRIPTION
This fixes a timing related bug in the Permalink form.

As the util is required asynchronous it might happen that `BasiGX.util.CopyClipboard` is not loaded when we try to call `BasiGX.util.CopyClipboard.copyToClipboardSupported` to set the hidden property.

This PR introduces a listener driven solution.

Plz review