### PR TITLE
Added postprocess step for config parser.

### DIFF
--- a/src/view/component/Map.js
+++ b/src/view/component/Map.js
@@ -156,6 +156,9 @@ Ext.define('BasiGX.view.component.Map', {
 
         me.addControls();
 
+        if (Ext.isFunction(BasiGX.util.ConfigParser.postprocessMap)) {
+            BasiGX.util.ConfigParser.postprocessMap(me.appContext);
+        }
     },
 
     addControls: function() {


### PR DESCRIPTION
Added a postprocess step in the map component. If the function
postprocessMap is defined in your overridden/custom ConfigParser, it
will be called once the component is created (via the call to
callParent).

Please review.