### PR TITLE
Do not check all external WMS by default

### DIFF
--- a/src/view/form/AddWms.js
+++ b/src/view/form/AddWms.js
@@ -95,7 +95,7 @@ Ext.define('BasiGX.view.form.AddWms', {
          * Whether layers shall start `checked` or `unchecked` in the available
          * layers fieldset.
          */
-        candidatesInitiallyChecked: true,
+        candidatesInitiallyChecked: false,
 
         /**
          * Whether to add a `Check all layers` button to the toolbar to interact


### PR DESCRIPTION
When using the AddWms functionality with a service that provides dozens of layers, they are all checked by default and it's very annoying to deselect all layers you dont want to add.

In my eyes, you most likely want to add a small number of layers, so the default should be false, i.e. you will first have to check the layers you want to add to your map.