### PR TITLE
Detect all word characters in the web project base name

### DIFF
--- a/src/util/Url.js
+++ b/src/util/Url.js
@@ -71,7 +71,7 @@ Ext.define('BasiGX.util.Url', {
             var loc = window.location;
             var url = loc.protocol + '//' + loc.host;
             var webProjectName = window.location.pathname.match(
-                /\/[A-Za-z\-]*\//
+                /^\/[\w\-]*\/?/
             )[0];
 
             return url + webProjectName;


### PR DESCRIPTION
This allows the detection of word characters (a-z, A-Z, 0-9, underscore) in the extraction of the web project base name out of `window.location.pathname`.