### PR TITLE
Use https where appropriate

### DIFF
--- a/src/store/GazetteerSearch.js
+++ b/src/store/GazetteerSearch.js
@@ -34,7 +34,7 @@ Ext.define('BasiGX.store.GazetteerSearch', {
     _lastRequest: null,
 
     proxy: {
-        url: 'http://nominatim.openstreetmap.org',
+        url: 'https://nominatim.openstreetmap.org',
         method: 'GET',
         type: 'ajax',
         extraParams: {

--- a/src/view/component/Map.js
+++ b/src/view/component/Map.js
@@ -73,7 +73,7 @@ Ext.define('BasiGX.view.component.Map', {
                     {
                         'name': 'OSM WMS',
                         'type': 'TileWMS',
-                        'url': 'http://ows.terrestris.de/osm/service?',
+                        'url': 'https://ows.terrestris.de/osm/service?',
                         'layers': 'OSM-WMS',
                         'topic': false
                     }

--- a/src/view/container/NominatimSearch.js
+++ b/src/view/container/NominatimSearch.js
@@ -59,7 +59,7 @@ Ext.define('BasiGX.view.container.NominatimSearch', {
         /**
          * The URL to the nominatim service
          */
-        nominatimUrl: 'http://nominatim.openstreetmap.org',
+        nominatimUrl: 'https://nominatim.openstreetmap.org',
 
         /**
          *

--- a/src/view/panel/MapContainer.js
+++ b/src/view/panel/MapContainer.js
@@ -109,7 +109,7 @@ Ext.define('BasiGX.view.panel.MapContainer', {
             layers: [
                 new ol.layer.Tile({
                     source: new ol.source.TileWMS({
-                        url: 'http://ows.terrestris.de/osm/service?',
+                        url: 'https://ows.terrestris.de/osm/service?',
                         params: {'layers': 'OSM-WMS', 'TILED': true}
                     })
                 })


### PR DESCRIPTION
This changes 4 URLs (twice nominatim and twice the terrestris WMS) to use `https` instead of `http`.

Please review.