### PR TITLE
Added skip map mode to print w/o extent selection & choosing template

### DIFF
--- a/src/view/form/Print.js
+++ b/src/view/form/Print.js
@@ -78,6 +78,11 @@ Ext.define('BasiGX.view.form.Print', {
         printExtentAlwaysCentered: true,
         printExtentMovable: false,
         printExtentScalable: false,
+        /**
+         * Option to be able to print without a map.
+         * @type {Boolean} if true, app selection and the extent rectangle are
+         * disabled.
+         */
         skipMapMode: false
     },
 
@@ -341,7 +346,7 @@ Ext.define('BasiGX.view.form.Print', {
             // TODO double check when rotated
             var featureBbox;
             if (fs.extentFeature) {
-                fs.extentFeature.getGeometry().getExtent();
+                featureBbox = fs.extentFeature.getGeometry().getExtent();
             }
             var dpi = fs.down('[name="dpi"]').getValue();
 

--- a/src/view/form/Print.js
+++ b/src/view/form/Print.js
@@ -77,7 +77,8 @@ Ext.define('BasiGX.view.form.Print', {
         store: null,
         printExtentAlwaysCentered: true,
         printExtentMovable: false,
-        printExtentScalable: false
+        printExtentScalable: false,
+        skipMapMode: false
     },
 
     borderColors: [
@@ -207,11 +208,14 @@ Ext.define('BasiGX.view.form.Print', {
             xtype: 'fieldcontainer',
             name: 'defaultFieldContainer',
             layout: 'form',
-            items: printAppComponent
+            items: printAppComponent,
+            hidden: this.config.skipMapMode
         });
 
-        me.on('afterrender', me.addExtentLayer, me);
-        me.on('afterrender', me.addExtentInteractions, me);
+        if (!this.config.skipMapMode) {
+            me.on('afterrender', me.addExtentLayer, me);
+            me.on('afterrender', me.addExtentInteractions, me);
+        }
 
         me.on('afterrender', me.addParentCollapseExpandListeners, me);
         me.on('beforeDestroy', me.cleanupPrintExtent, me);
@@ -335,7 +339,10 @@ Ext.define('BasiGX.view.form.Print', {
         Ext.each(fieldsets, function(fs) {
             var name = fs.name;
             // TODO double check when rotated
-            var featureBbox = fs.extentFeature.getGeometry().getExtent();
+            var featureBbox;
+            if (fs.extentFeature) {
+                fs.extentFeature.getGeometry().getExtent();
+            }
             var dpi = fs.down('[name="dpi"]').getValue();
 
             attributes[name] = {
@@ -894,9 +901,10 @@ Ext.define('BasiGX.view.form.Print', {
         }
         me._renderingClientExtents = true;
 
-        me.extentLayer.getSource().clear();
-
-        me.resetExtentInteraction();
+        if (me.extentLayer) {
+            me.extentLayer.getSource().clear();
+            me.resetExtentInteraction();
+        }
 
         var fieldsets = [];
         if (me && me.items) {
@@ -944,7 +952,9 @@ Ext.define('BasiGX.view.form.Print', {
         var me = this;
         var map = me.getMapComponent().getMap();
         me.cleanupTransformInteraction();
-        me.extentLayer.getSource().clear();
+        if (this.extentLayer) {
+            me.extentLayer.getSource().clear();
+        }
         map.un('moveend', me.renderAllClientInfos, me);
     },
 


### PR DESCRIPTION
This can be used for custom print requirements such as printing a 'normal' pdf without a map and a given template. It skips the app selection and disables the extent rectangle if the config option `skipMapMode` is set.

@terrestris/devs please review