### PR TITLE
Fix empty grid

### DIFF
--- a/src/view/grid/FeatureGrid.js
+++ b/src/view/grid/FeatureGrid.js
@@ -195,6 +195,13 @@ Ext.define('BasiGX.view.grid.FeatureGrid', {
         grid.on('itemmouseleave', function() {
             me.highlightSource.clear();
         });
+        if (this.getLayer().getSource().getFeatures().length === 0) {
+            this.addFeatureKey = this.getLayer().getSource().once('addfeature',
+            function() {
+                me.reconfigureStore(grid.getStore());
+                me.getLayer().getSource().unByKey(me.addFeatureKey);
+            });
+        }
     },
 
     /**


### PR DESCRIPTION
If starting out with an empty layer, use the first added feature to
determine the attribute schema.

@weskamm please review
