### PR TITLE
Factor out digitize buttons

### DIFF
--- a/src/util/Demonstration.js
+++ b/src/util/Demonstration.js
@@ -121,7 +121,7 @@ Ext.define('BasiGX.util.Demonstration', {
             if (conf) {
                 Ext.iterate(conf, function(key, value) {
                     if (Ext.isDefined(
-                            window['BasiGX']['util']['Demonstration'][key])) {
+                        window['BasiGX']['util']['Demonstration'][key])) {
                         window['BasiGX']['util']['Demonstration'][key](
                             value, el, index, liveDemoConfig
                         );

--- a/src/util/SldOpenlayersConverter.js
+++ b/src/util/SldOpenlayersConverter.js
@@ -89,7 +89,7 @@ Ext.define('BasiGX.util.SldOpenlayersConverter', {
          */
         getSldNameFromSld: function(sldObj) {
             return sldObj.value.namedLayerOrUserLayer[0]
-                    .namedStyleOrUserStyle[0].name;
+                .namedStyleOrUserStyle[0].name;
         },
 
         /**
@@ -113,9 +113,9 @@ Ext.define('BasiGX.util.SldOpenlayersConverter', {
          */
         toSldString: function(sldObject) {
             if (sldObject.value.namedLayerOrUserLayer[0]
-                    .namedStyleOrUserStyle[0].isDefault) {
+                .namedStyleOrUserStyle[0].isDefault) {
                 delete sldObject.value.namedLayerOrUserLayer[0]
-                        .namedStyleOrUserStyle[0].isDefault;
+                    .namedStyleOrUserStyle[0].isDefault;
             }
             var util = BasiGX.util.SldOpenlayersConverter;
             return util.marshaller.marshalString(sldObject);
@@ -153,11 +153,11 @@ Ext.define('BasiGX.util.SldOpenlayersConverter', {
                 if (firstNamedLayerOrUserLayer.namedStyleOrUserStyle &&
                   firstNamedLayerOrUserLayer.namedStyleOrUserStyle[0] &&
                   firstNamedLayerOrUserLayer.namedStyleOrUserStyle[0]
-                        .featureTypeStyle &&
+                      .featureTypeStyle &&
                   firstNamedLayerOrUserLayer.namedStyleOrUserStyle[0]
-                        .featureTypeStyle[0] &&
+                      .featureTypeStyle[0] &&
                   firstNamedLayerOrUserLayer.namedStyleOrUserStyle[0]
-                        .featureTypeStyle[0].rule) {
+                      .featureTypeStyle[0].rule) {
                     return firstNamedLayerOrUserLayer.namedStyleOrUserStyle[0]
                         .featureTypeStyle[0].rule;
                 }
@@ -214,19 +214,19 @@ Ext.define('BasiGX.util.SldOpenlayersConverter', {
             switch (operator) {
                 case 'PropertyIsNull':
                     propertyName = filter.comparisonOps.value.propertyName
-                            .content[0];
+                        .content[0];
                     break;
                 case 'PropertyIsLike':
                     propertyName = filter.comparisonOps.value.propertyName
-                            .content[0];
+                        .content[0];
                     break;
                 case 'PropertyIsBetween':
                     propertyName = filter.comparisonOps.value.expression.value
-                            .content[0];
+                        .content[0];
                     break;
                 default:
                     propertyName = filter.comparisonOps.value.expression[0]
-                            .value.content[0];
+                        .value.content[0];
                     break;
             }
             return propertyName;
@@ -245,17 +245,17 @@ Ext.define('BasiGX.util.SldOpenlayersConverter', {
                     break;
                 case 'PropertyIsLike':
                     literalValues.push(
-                            filter.comparisonOps.value.literal.content[0]);
+                        filter.comparisonOps.value.literal.content[0]);
                     break;
                 case 'PropertyIsBetween':
                     literalValues.push(filter.comparisonOps.value.lowerBoundary
-                            .expression.value.content[0]);
+                        .expression.value.content[0]);
                     literalValues.push(filter.comparisonOps.value.upperBoundary
-                            .expression.value.content[0]);
+                        .expression.value.content[0]);
                     break;
                 default:
                     literalValues.push(filter.comparisonOps.value
-                            .expression[1].value.content[0]);
+                        .expression[1].value.content[0]);
                     break;
             }
             return literalValues;
@@ -340,11 +340,11 @@ Ext.define('BasiGX.util.SldOpenlayersConverter', {
             if ('fill' in mark) {
                 // find the correct cssParameter
                 var fillColor = sldUtil.getFirstCssParameterContentByName(
-                        mark.fill.cssParameter, 'fill'
-                    );
+                    mark.fill.cssParameter, 'fill'
+                );
                 var fillOpacity = sldUtil.getFirstCssParameterContentByName(
-                        mark.fill.cssParameter, 'fill-opacity'
-                    ) || sldUtil.DEFAULT_FILL_OPACITY;
+                    mark.fill.cssParameter, 'fill-opacity'
+                ) || sldUtil.DEFAULT_FILL_OPACITY;
 
                 fillColor = BasiGX.util.Color.hexToRgba(fillColor, fillOpacity);
                 fill = new ol.style.Fill({
@@ -363,17 +363,17 @@ Ext.define('BasiGX.util.SldOpenlayersConverter', {
             var stroke;
             if ('stroke' in mark) {
                 var strokeColor = sldUtil.getFirstCssParameterContentByName(
-                        mark.stroke.cssParameter, 'stroke'
-                    ) || sldUtil.DEFAULT_STROKE_COLOR;
+                    mark.stroke.cssParameter, 'stroke'
+                ) || sldUtil.DEFAULT_STROKE_COLOR;
                 var strokeWidth = sldUtil.getFirstCssParameterContentByName(
-                        mark.stroke.cssParameter, 'stroke-width'
-                    ) || sldUtil.DEFAULT_STROKE_WIDTH;
+                    mark.stroke.cssParameter, 'stroke-width'
+                ) || sldUtil.DEFAULT_STROKE_WIDTH;
                 var strokeOpacity = sldUtil.getFirstCssParameterContentByName(
-                        mark.stroke.cssParameter, 'stroke-opacity'
-                    ) || sldUtil.DEFAULT_STROKE_OPACITY;
+                    mark.stroke.cssParameter, 'stroke-opacity'
+                ) || sldUtil.DEFAULT_STROKE_OPACITY;
 
                 strokeColor = BasiGX.util.Color.hexToRgba(strokeColor,
-                        strokeOpacity);
+                    strokeOpacity);
                 stroke = new ol.style.Stroke({
                     color: strokeColor,
                     width: strokeWidth
@@ -494,8 +494,8 @@ Ext.define('BasiGX.util.SldOpenlayersConverter', {
             } else if ((/Graphic/).test(firstTypeName)) {
                 // … ol.style.Icon
                 var imageSrc = sldUtil.onlineResourceFromGraphic(
-                        firstGraphicOrMark
-                    );
+                    firstGraphicOrMark
+                );
                 style = new ol.style.Style({
                     image: new ol.style.Icon({
                         src: imageSrc,
@@ -625,16 +625,16 @@ Ext.define('BasiGX.util.SldOpenlayersConverter', {
             };
             if (olSymbolizer.getImage() instanceof ol.style.Circle) {
                 var fillColor = BasiGX.util.Color.rgbaToHex(
-                        olSymbolizer.getImage().getFill().getColor());
+                    olSymbolizer.getImage().getFill().getColor());
                 var fillOpacity = BasiGX.util.Color.rgbaAsArray(
-                        olSymbolizer.getImage().getFill().getColor())[4];
+                    olSymbolizer.getImage().getFill().getColor())[4];
                 var radius = olSymbolizer.getImage().getRadius().toString();
                 var strokeColor = BasiGX.util.Color.rgbaToHex(
-                        olSymbolizer.getImage().getStroke().getColor());
+                    olSymbolizer.getImage().getStroke().getColor());
                 var strokeWidth = olSymbolizer.getImage().getStroke()
-                        .getWidth().toString();
+                    .getWidth().toString();
                 var strokeOpacity = BasiGX.util.Color.rgbaAsArray(
-                        olSymbolizer.getImage().getStroke().getColor())[4];
+                    olSymbolizer.getImage().getStroke().getColor())[4];
 
                 sldSymbolizer.value.graphic.externalGraphicOrMark = [{
                     TYPE_NAME: 'SLD_1_0_0.Mark',
@@ -702,15 +702,15 @@ Ext.define('BasiGX.util.SldOpenlayersConverter', {
          */
         polygonSymbolizerToSld: function(olSymbolizer) {
             var fillColor = BasiGX.util.Color.rgbaToHex(
-                    olSymbolizer.getFill().getColor());
+                olSymbolizer.getFill().getColor());
             var fillOpacity = BasiGX.util.Color.rgbaAsArray(
-                    olSymbolizer.getFill().getColor())[4];
+                olSymbolizer.getFill().getColor())[4];
             var strokeColor = BasiGX.util.Color.rgbaToHex(
-                    olSymbolizer.getStroke().getColor());
+                olSymbolizer.getStroke().getColor());
             var strokeWidth = olSymbolizer.getStroke()
-                    .getWidth().toString();
+                .getWidth().toString();
             var strokeOpacity = BasiGX.util.Color.rgbaAsArray(
-                    olSymbolizer.getStroke().getColor())[4];
+                olSymbolizer.getStroke().getColor())[4];
 
             var sldSymbolizer = {
                 name: {
@@ -762,11 +762,11 @@ Ext.define('BasiGX.util.SldOpenlayersConverter', {
          */
         lineSymbolizerToSld: function(olSymbolizer) {
             var strokeColor = BasiGX.util.Color.rgbaToHex(
-                    olSymbolizer.getStroke().getColor());
+                olSymbolizer.getStroke().getColor());
             var strokeWidth = olSymbolizer.getStroke()
-                    .getWidth().toString();
+                .getWidth().toString();
             var strokeOpacity = BasiGX.util.Color.rgbaAsArray(
-                    olSymbolizer.getStroke().getColor())[4];
+                olSymbolizer.getStroke().getColor())[4];
 
             var sldSymbolizer = {
                 name: {
@@ -891,7 +891,7 @@ Ext.define('BasiGX.util.SldOpenlayersConverter', {
                                 value: {
                                     TYPE_NAME: 'Filter_1_0_0.LiteralType',
                                     content: [filterValues.literalNumberField1
-                                              .toString()]
+                                        .toString()]
                                 }
                             }
                         },
@@ -910,7 +910,7 @@ Ext.define('BasiGX.util.SldOpenlayersConverter', {
                                 value: {
                                     TYPE_NAME: 'Filter_1_0_0.LiteralType',
                                     content: [filterValues.literalNumberField2
-                                            .toString()]
+                                        .toString()]
                                 }
                             }
                         }
@@ -957,7 +957,7 @@ Ext.define('BasiGX.util.SldOpenlayersConverter', {
                         value: {
                             TYPE_NAME: 'Filter_1_0_0.LiteralType',
                             content: [filterValues
-                                    .literalNumberField2.toString()]
+                                .literalNumberField2.toString()]
                         }
                     };
                     break;

--- a/src/ux/ContextSensitiveHelp.js
+++ b/src/ux/ContextSensitiveHelp.js
@@ -188,7 +188,7 @@ Ext.define('BasiGX.ux.ContextSensitiveHelp', {
                 var doc = component.getViewModel().get('documentation');
                 if (!Ext.isEmpty(doc)) {
                     var exisitingWin = Ext.ComponentQuery.query(
-                            'window[name=contextsensitivehelp]')[0];
+                        'window[name=contextsensitivehelp]')[0];
                     if (exisitingWin) {
                         exisitingWin.setHtml(doc);
                         exisitingWin.setTitle(me.getViewModel().get('title'));

--- a/src/view/button/DigitizeLine.js
+++ b/src/view/button/DigitizeLine.js
@@ -1,0 +1,77 @@
+/* Copyright (c) 2017-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * Digitize Line Button
+ *
+ * @class BasiGX.view.button.DigitizeLine
+ */
+Ext.define('BasiGX.view.button.DigitizeLine', {
+    extend: 'BasiGX.view.button.Base',
+    xtype: 'basigx-button-digitize-line',
+
+    requires: [
+    ],
+
+    /**
+     *
+     */
+    viewModel: {
+        data: {
+            tooltip: 'Digitize a new line',
+            digitizeLineText: 'Digitize line'
+        }
+    },
+
+    /**
+     *
+     */
+    bind: {
+        text: '{digitizeLineText}'
+    },
+
+    config: {
+        layer: null,
+        map: null,
+        collection: null
+    },
+
+    name: 'drawLineBtn',
+    toggleGroup: 'draw',
+
+    listeners: {
+        toggle: function(btn, pressed) {
+            if (!this.drawLineInteraction) {
+                var cfg = {
+                    type: 'LineString'
+                };
+                if (this.getLayer()) {
+                    cfg.source = this.getLayer().getSource();
+                } else {
+                    cfg.features = this.getCollection();
+                }
+                this.drawLineInteraction = new ol.interaction.Draw(cfg);
+                this.getMap().addInteraction(this.drawLineInteraction);
+            }
+            if (pressed) {
+                this.drawLineInteraction.setActive(true);
+            } else {
+                this.drawLineInteraction.setActive(false);
+            }
+        }
+    }
+
+
+});

--- a/src/view/button/DigitizePoint.js
+++ b/src/view/button/DigitizePoint.js
@@ -1,0 +1,77 @@
+/* Copyright (c) 2017-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * Digitize Point Button
+ *
+ * @class BasiGX.view.button.DigitizePoint
+ */
+Ext.define('BasiGX.view.button.DigitizePoint', {
+    extend: 'BasiGX.view.button.Base',
+    xtype: 'basigx-button-digitize-point',
+
+    requires: [
+    ],
+
+    /**
+     *
+     */
+    viewModel: {
+        data: {
+            tooltip: 'Digitize a new point',
+            digitizePointText: 'Digitize point'
+        }
+    },
+
+    /**
+     *
+     */
+    bind: {
+        text: '{digitizePointText}'
+    },
+
+    config: {
+        layer: null,
+        map: null,
+        collection: null
+    },
+
+    name: 'drawPointBtn',
+    toggleGroup: 'draw',
+
+    listeners: {
+        toggle: function(btn, pressed) {
+            if (!this.drawPointInteraction) {
+                var cfg = {
+                    type: 'Point'
+                };
+                if (this.getLayer()) {
+                    cfg.source = this.getLayer().getSource();
+                } else {
+                    cfg.features = this.getCollection();
+                }
+                this.drawPointInteraction = new ol.interaction.Draw(cfg);
+                this.getMap().addInteraction(this.drawPointInteraction);
+            }
+            if (pressed) {
+                this.drawPointInteraction.setActive(true);
+            } else {
+                this.drawPointInteraction.setActive(false);
+            }
+        }
+    }
+
+
+});

--- a/src/view/button/DigitizePolygon.js
+++ b/src/view/button/DigitizePolygon.js
@@ -1,0 +1,77 @@
+/* Copyright (c) 2017-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * Digitize Polygon Button
+ *
+ * @class BasiGX.view.button.DigitizePolygon
+ */
+Ext.define('BasiGX.view.button.DigitizePolygon', {
+    extend: 'BasiGX.view.button.Base',
+    xtype: 'basigx-button-digitize-polygon',
+
+    requires: [
+    ],
+
+    /**
+     *
+     */
+    viewModel: {
+        data: {
+            tooltip: 'Digitize a new polygon',
+            digitizePolygonText: 'Digitize polygon'
+        }
+    },
+
+    /**
+     *
+     */
+    bind: {
+        text: '{digitizePolygonText}'
+    },
+
+    config: {
+        layer: null,
+        map: null,
+        collection: null
+    },
+
+    name: 'drawPolygonsBtn',
+    toggleGroup: 'draw',
+
+    listeners: {
+        toggle: function(btn, pressed) {
+            if (!this.drawPolygonInteraction) {
+                var cfg = {
+                    type: 'Polygon'
+                };
+                if (this.getLayer()) {
+                    cfg.source = this.getLayer().getSource();
+                } else {
+                    cfg.features = this.getCollection();
+                }
+                this.drawPolygonInteraction = new ol.interaction.Draw(cfg);
+                this.getMap().addInteraction(this.drawPolygonInteraction);
+            }
+            if (pressed) {
+                this.drawPolygonInteraction.setActive(true);
+            } else {
+                this.drawPolygonInteraction.setActive(false);
+            }
+        }
+    }
+
+
+});

--- a/src/view/container/Redlining.js
+++ b/src/view/container/Redlining.js
@@ -33,9 +33,6 @@ Ext.define('BasiGX.view.container.Redlining', {
      */
     viewModel: {
         data: {
-            drawPointsBtnText: 'Draw Points',
-            drawLinesBtnText: 'Draw Lines',
-            drawPolygonsBtnText: 'Draw Polygons',
             drawPostItBtnText: 'Draw Post-it',
             copyObjectBtnText: 'Copy Object',
             moveObjectBtnText: 'Move Object',
@@ -54,21 +51,6 @@ Ext.define('BasiGX.view.container.Redlining', {
                 'werden'
         }
     },
-
-    /**
-     *
-     */
-    drawPointInteraction: null,
-
-    /**
-     *
-     */
-    drawLineInteraction: null,
-
-    /**
-     *
-     */
-    drawPolygonInteraction: null,
 
     /**
      *
@@ -301,74 +283,17 @@ Ext.define('BasiGX.view.container.Redlining', {
     getRedlineItems: function() {
         var me = this;
         return [{
-            xtype: 'button',
-            bind: {
-                text: '{drawPointsBtnText}'
-            },
-            name: 'drawPointsBtn',
-            toggleGroup: 'draw',
-            listeners: {
-                toggle: function(btn, pressed) {
-                    if (!me.drawPointInteraction) {
-                        me.drawPointInteraction = new ol.interaction.Draw({
-                            features: me.redlineFeatures,
-                            type: 'Point'
-                        });
-                        me.map.addInteraction(me.drawPointInteraction);
-                    }
-                    if (pressed) {
-                        me.drawPointInteraction.setActive(true);
-                    } else {
-                        me.drawPointInteraction.setActive(false);
-                    }
-                }
-            }
+            xtype: 'basigx-button-digitize-point',
+            collection: me.redlineFeatures,
+            map: me.map
         }, {
-            xtype: 'button',
-            bind: {
-                text: '{drawLinesBtnText}'
-            },
-            name: 'drawLinesBtn',
-            toggleGroup: 'draw',
-            listeners: {
-                toggle: function(btn, pressed) {
-                    if (!me.drawLineInteraction) {
-                        me.drawLineInteraction = new ol.interaction.Draw({
-                            features: me.redlineFeatures,
-                            type: 'LineString'
-                        });
-                        me.map.addInteraction(me.drawLineInteraction);
-                    }
-                    if (pressed) {
-                        me.drawLineInteraction.setActive(true);
-                    } else {
-                        me.drawLineInteraction.setActive(false);
-                    }
-                }
-            }
+            xtype: 'basigx-button-digitize-line',
+            collection: me.redlineFeatures,
+            map: me.map
         }, {
-            xtype: 'button',
-            bind: {
-                text: '{drawPolygonsBtnText}'
-            },
-            name: 'drawPolygonsBtn',
-            toggleGroup: 'draw',
-            listeners: {
-                toggle: function(btn, pressed) {
-                    if (!me.drawPolygonInteraction) {
-                        me.drawPolygonInteraction = new ol.interaction.Draw({
-                            features: me.redlineFeatures,
-                            type: 'Polygon'
-                        });
-                        me.map.addInteraction(me.drawPolygonInteraction);
-                    }
-                    if (pressed) {
-                        me.drawPolygonInteraction.setActive(true);
-                    } else {
-                        me.drawPolygonInteraction.setActive(false);
-                    }
-                }
-            }
+            xtype: 'basigx-button-digitize-polygon',
+            collection: me.redlineFeatures,
+            map: me.map
         }, {
             xtype: 'button',
             bind: {

--- a/src/view/container/Redlining.js
+++ b/src/view/container/Redlining.js
@@ -23,6 +23,9 @@ Ext.define('BasiGX.view.container.Redlining', {
     xtype: 'basigx-container-redlining',
 
     requires: [
+        'BasiGX.view.button.DigitizePoint',
+        'BasiGX.view.button.DigitizeLine',
+        'BasiGX.view.button.DigitizePolygon',
         'BasiGX.view.container.RedlineStyler'
     ],
 

--- a/src/view/container/Redlining.js
+++ b/src/view/container/Redlining.js
@@ -343,36 +343,36 @@ Ext.define('BasiGX.view.container.Redlining', {
                     if (!me.copySelectInteraction) {
                         me.copySelectInteraction =
                            new ol.interaction.Select({
-                               condition: function(evt) {
-                                   return ol.events.condition.pointerMove(
-                                       evt) || ol.events.condition.
-                                       click(evt);
-                               },
-                               addCondition: function(evt) {
-                                   if (evt.type === 'click') {
-                                       var features = me.
-                                           copySelectInteraction.
-                                           getFeatures().getArray();
-                                       if (features[0]) {
-                                           var copyFeature = features[0].
-                                               clone();
-                                           var doneFn = function(
-                                               finalFeature) {
-                                               me.redlineFeatures.push(
-                                                   finalFeature);
-                                           };
-                                           BasiGX.util.Animate.moveFeature(
-                                               copyFeature, 500,
-                                               100,
-                                               me.getRedlineStyleFunction(),
-                                               doneFn);
+                                condition: function(evt) {
+                                    return ol.events.condition.pointerMove(
+                                        evt) || ol.events.condition.
+                                        click(evt);
+                                },
+                                addCondition: function(evt) {
+                                    if (evt.type === 'click') {
+                                        var features = me.
+                                            copySelectInteraction.
+                                            getFeatures().getArray();
+                                        if (features[0]) {
+                                            var copyFeature = features[0].
+                                                clone();
+                                            var doneFn = function(
+                                                finalFeature) {
+                                                me.redlineFeatures.push(
+                                                    finalFeature);
+                                            };
+                                            BasiGX.util.Animate.moveFeature(
+                                                copyFeature, 500,
+                                                100,
+                                                me.getRedlineStyleFunction(),
+                                                doneFn);
 
-                                           me.copySelectInteraction.
-                                               getFeatures().clear();
-                                       }
-                                   }
-                               }
-                           });
+                                            me.copySelectInteraction.
+                                                getFeatures().clear();
+                                        }
+                                    }
+                                }
+                            });
                         me.map.addInteraction(me.copySelectInteraction);
                     }
                     if (pressed) {
@@ -394,45 +394,45 @@ Ext.define('BasiGX.view.container.Redlining', {
                     if (!me.translateInteraction) {
                         me.translateSelectInteraction =
                            new ol.interaction.Select({
-                               condition: ol.events.condition.pointerMove,
-                               addCondition: function() {
-                                   var selectedFeatures =
+                                condition: ol.events.condition.pointerMove,
+                                addCondition: function() {
+                                    var selectedFeatures =
                                       me.translateSelectInteraction.
                                           getFeatures();
-                                   var firstFeature = selectedFeatures.
-                                       getArray()[0];
+                                    var firstFeature = selectedFeatures.
+                                        getArray()[0];
 
-                                   if (firstFeature) {
-                                       var redlineFeature = me.
-                                           getRedlineFeatureFromClone(
-                                               firstFeature);
+                                    if (firstFeature) {
+                                        var redlineFeature = me.
+                                            getRedlineFeatureFromClone(
+                                                firstFeature);
 
-                                       if (me.translateFeatureCollection.
-                                           getLength() === 0) {
-                                           me.translateFeatureCollection.
-                                               push(redlineFeature);
-                                       } else if (me.
-                                           translateFeatureCollection.
-                                           getLength() > 0 &&
+                                        if (me.translateFeatureCollection.
+                                            getLength() === 0) {
+                                            me.translateFeatureCollection.
+                                                push(redlineFeature);
+                                        } else if (me.
+                                            translateFeatureCollection.
+                                            getLength() > 0 &&
                                            redlineFeature !== me.
                                                translateFeatureCollection.
                                                getArray()[0]) {
-                                           me.
-                                               translateFeatureCollection.
-                                               clear();
-                                           me.
-                                               translateFeatureCollection.
-                                               push(redlineFeature);
-                                       }
-                                   }
-                               }
-                           });
+                                            me.
+                                                translateFeatureCollection.
+                                                clear();
+                                            me.
+                                                translateFeatureCollection.
+                                                push(redlineFeature);
+                                        }
+                                    }
+                                }
+                            });
                         me.map.addInteraction(me.translateSelectInteraction);
                         me.translateFeatureCollection = new ol.Collection();
                         me.translateInteraction =
                            new ol.interaction.Translate({
-                               features: me.translateFeatureCollection
-                           });
+                                features: me.translateFeatureCollection
+                            });
                         me.map.addInteraction(me.translateInteraction);
                     }
                     if (pressed) {
@@ -659,16 +659,16 @@ Ext.define('BasiGX.view.container.Redlining', {
                     if (text.length > me.postitTextMaxLength) {
                         BasiGX.confirm(me.getViewModel().get(
                             'postItInputTooLongText'), {
-                                fn: function(choice) {
-                                    if (choice === 'yes') {
-                                        text = me.stringDivider(text, 16, '\n');
-                                        me.setPostitStyleAndTextOnFeature(
-                                            text, feat);
-                                    } else {
-                                        me.handlePostitAdd(feat, text);
-                                    }
+                            fn: function(choice) {
+                                if (choice === 'yes') {
+                                    text = me.stringDivider(text, 16, '\n');
+                                    me.setPostitStyleAndTextOnFeature(
+                                        text, feat);
+                                } else {
+                                    me.handlePostitAdd(feat, text);
                                 }
                             }
+                        }
                         );
                     } else {
                         text = me.stringDivider(text, 16, '\n');
@@ -698,16 +698,16 @@ Ext.define('BasiGX.view.container.Redlining', {
                     if (text.length > me.postitTextMaxLength) {
                         BasiGX.confirm(me.getViewModel().get(
                             'postItInputTooLongText'), {
-                                fn: function(choice) {
-                                    if (choice === 'yes') {
-                                        text = me.stringDivider(text, 16, '\n');
-                                        me.setPostitStyleAndTextOnFeature(
-                                            text, feature);
-                                    } else {
-                                        me.modifyPostit(feature, text);
-                                    }
+                            fn: function(choice) {
+                                if (choice === 'yes') {
+                                    text = me.stringDivider(text, 16, '\n');
+                                    me.setPostitStyleAndTextOnFeature(
+                                        text, feature);
+                                } else {
+                                    me.modifyPostit(feature, text);
                                 }
                             }
+                        }
                         );
                     } else {
                         text = me.stringDivider(text, 16, '\n');

--- a/src/view/grid/FeatureGrid.js
+++ b/src/view/grid/FeatureGrid.js
@@ -176,7 +176,7 @@ Ext.define('BasiGX.view.grid.FeatureGrid', {
         });
         this.highlightLayer.set('name', 'highlight');
         var displayInLayerSwitcherKey = BasiGX.util.Layer
-                    .KEY_DISPLAY_IN_LAYERSWITCHER;
+            .KEY_DISPLAY_IN_LAYERSWITCHER;
         this.highlightLayer.set(displayInLayerSwitcherKey, false);
         map.getMap().addLayer(this.highlightLayer);
     },
@@ -197,10 +197,10 @@ Ext.define('BasiGX.view.grid.FeatureGrid', {
         });
         if (this.getLayer().getSource().getFeatures().length === 0) {
             this.addFeatureKey = this.getLayer().getSource().once('addfeature',
-            function() {
-                me.reconfigureStore(grid.getStore());
-                me.getLayer().getSource().unByKey(me.addFeatureKey);
-            });
+                function() {
+                    me.reconfigureStore(grid.getStore());
+                    me.getLayer().getSource().unByKey(me.addFeatureKey);
+                });
         }
     },
 

--- a/src/view/grid/GazetteerGrid.js
+++ b/src/view/grid/GazetteerGrid.js
@@ -94,7 +94,7 @@ Ext.define('BasiGX.view.grid.GazetteerGrid', {
         },
         iconCls: 'fa fa-refresh fa-2x'
     },
-        '->',
+    '->',
     {
         xtype: 'button',
         name: 'directionsbutton',

--- a/test/spec/view/button/DigitizeLine.test.js
+++ b/test/spec/view/button/DigitizeLine.test.js
@@ -1,0 +1,15 @@
+Ext.Loader.syncRequire(['BasiGX.view.button.DigitizeLine']);
+
+describe('BasiGX.view.button.DigitizeLine', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.view.button.DigitizeLine).to.not.be(undefined);
+        });
+        it('can be instantiated', function() {
+            var btn = Ext.create('BasiGX.view.button.DigitizeLine');
+            expect(btn).to.be.a(BasiGX.view.button.DigitizeLine);
+            // teardown
+            btn.destroy();
+        });
+    });
+});

--- a/test/spec/view/button/DigitizePoint.test.js
+++ b/test/spec/view/button/DigitizePoint.test.js
@@ -1,0 +1,15 @@
+Ext.Loader.syncRequire(['BasiGX.view.button.DigitizePoint']);
+
+describe('BasiGX.view.button.DigitizePoint', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.view.button.DigitizePoint).to.not.be(undefined);
+        });
+        it('can be instantiated', function() {
+            var btn = Ext.create('BasiGX.view.button.DigitizePoint');
+            expect(btn).to.be.a(BasiGX.view.button.DigitizePoint);
+            // teardown
+            btn.destroy();
+        });
+    });
+});

--- a/test/spec/view/button/DigitizePolygon.test.js
+++ b/test/spec/view/button/DigitizePolygon.test.js
@@ -1,0 +1,15 @@
+Ext.Loader.syncRequire(['BasiGX.view.button.DigitizePolygon']);
+
+describe('BasiGX.view.button.DigitizePolygon', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.view.button.DigitizePolygon).to.not.be(undefined);
+        });
+        it('can be instantiated', function() {
+            var btn = Ext.create('BasiGX.view.button.DigitizePolygon');
+            expect(btn).to.be.a(BasiGX.view.button.DigitizePolygon);
+            // teardown
+            btn.destroy();
+        });
+    });
+});


### PR DESCRIPTION
This factores out the digitizing buttons (line, point, polygon) from the redlining component. The buttons can be used seperately and standalone with either a layer or a ol.Collection as a configuration option.

This PR also includes linting fixes (atom only sees the correct .eslintrc if you open BasiGX as a separate project).

@terrestris/devs please review