### PR TITLE
Fix value checks in the context of the SLD styler

### DIFF
--- a/src/util/SLD.js
+++ b/src/util/SLD.js
@@ -41,7 +41,7 @@ Ext.define('BasiGX.util.SLD', {
         ],
         DEFAULT_STROKE_OPACITY: '1',
         DEFAULT_STROKE_COLOR: '#000000',
-        DEFAULT_STROKE_WIDTH: '0',
+        DEFAULT_STROKE_WIDTH: '1',
 
         DEFAULT_FILL_COLOR: '#FF0000',
         DEFAULT_FILL_OPACITY: '1',

--- a/src/view/container/SLDStyler.js
+++ b/src/view/container/SLDStyler.js
@@ -700,6 +700,9 @@ Ext.define('BasiGX.view.container.SLDStyler', {
                         },
                         value: strokeWidth,
                         name: 'stroke-width',
+                        allowDecimals: true,
+                        decimalPrecision: 1,
+                        decimalSeparator: '.',
                         minValue: 0,
                         maxValue: 50,
                         listeners: listenerConfig
@@ -987,14 +990,22 @@ Ext.define('BasiGX.view.container.SLDStyler', {
 
         if (strokeWidthFs) {
             value = strokeWidthFs.getValue();
-            symbolizerObj.strokeWidth = value ? value.toString() :
-                BasiGX.util.SLD.DEFAULT_STROKE_WIDTH.toString();
+            if(Ext.isNumber(value)) {
+                symbolizerObj.strokeWidth = value.toString();
+            } else {
+                symbolizerObj.strokeWidth =
+                    BasiGX.util.SLD.DEFAULT_STROKE_WIDTH.toString();
+            }
         }
 
         if (!graphicTabActive && radiusFs) {
             value = radiusFs.getValue();
-            symbolizerObj.radius = value ? value.toString() :
-                BasiGX.util.SLD.DEFAULT_POINT_RADIUS.toString();
+            if(Ext.isNumber(value)) {
+                symbolizerObj.radius = value.toString();
+            } else {
+                symbolizerObj.radius =
+                    BasiGX.util.SLD.DEFAULT_POINT_RADIUS.toString();
+            }
         }
 
         if (graphicTabActive) {

--- a/src/view/container/SLDStyler.js
+++ b/src/view/container/SLDStyler.js
@@ -990,7 +990,7 @@ Ext.define('BasiGX.view.container.SLDStyler', {
 
         if (strokeWidthFs) {
             value = strokeWidthFs.getValue();
-            if(Ext.isNumber(value)) {
+            if (Ext.isNumber(value)) {
                 symbolizerObj.strokeWidth = value.toString();
             } else {
                 symbolizerObj.strokeWidth =
@@ -1000,7 +1000,7 @@ Ext.define('BasiGX.view.container.SLDStyler', {
 
         if (!graphicTabActive && radiusFs) {
             value = radiusFs.getValue();
-            if(Ext.isNumber(value)) {
+            if (Ext.isNumber(value)) {
                 symbolizerObj.radius = value.toString();
             } else {
                 symbolizerObj.radius =


### PR DESCRIPTION
This possibly (!) fixes some problems that occured when using the SLD styler classes (but may also introduce a bug in other projects that use the SLD styler when their code is not adapted!?)

`DEFAULT_STROKE_WIDTH` should have a default of `1` in my eyes as this is the default the GeoServer uses. Unfortunately there is some strange magic happening on the GeoServer side when updating a style with such a default value: GeoServer seems to remove default values like `<sld:CssParameter name="stroke-width">1</sld:CssParameter>` from the SLD. The next time the style is loaded in the SLD styler, the value from DEFAULT_STROKE_WIDTH would be used, which was wrong before this PR...

This also adds some defaults to the stroke width numberfield to support decimals.

Furthermore some conditional checks in `SLDStyler.js` have been enhanced. There were edge-cases, e.g. when a value has the value `0` where the previous logic did not work as expected.