### PR TITLE
Fixup tests

### DIFF
--- a/test/spec/view/button/SpatialOperatorDifference.test.js
+++ b/test/spec/view/button/SpatialOperatorDifference.test.js
@@ -1,4 +1,7 @@
 Ext.Loader.syncRequire(['BasiGX.view.button.SpatialOperatorDifference']);
+// fixup for methods that invoke `Ext.window.MessageBox` which will lead
+// to failing tests
+BasiGX.util.MsgBox.error = Ext.emptyFn;
 
 describe('BasiGX.view.button.SpatialOperatorDifference', function() {
     describe('Basics', function() {

--- a/test/spec/view/button/SpatialOperatorIntersect.test.js
+++ b/test/spec/view/button/SpatialOperatorIntersect.test.js
@@ -1,4 +1,7 @@
 Ext.Loader.syncRequire(['BasiGX.view.button.SpatialOperatorIntersect']);
+// fixup for methods that invoke `Ext.window.MessageBox` which will lead
+// to failing tests
+BasiGX.util.MsgBox.error = Ext.emptyFn;
 
 describe('BasiGX.view.button.SpatialOperatorIntersect', function() {
     describe('Basics', function() {

--- a/test/spec/view/button/SpatialOperatorUnion.test.js
+++ b/test/spec/view/button/SpatialOperatorUnion.test.js
@@ -1,4 +1,7 @@
 Ext.Loader.syncRequire(['BasiGX.view.button.SpatialOperatorUnion']);
+// fixup for methods that invoke `Ext.window.MessageBox` which will lead
+// to failing tests
+BasiGX.util.MsgBox.error = Ext.emptyFn;
 
 describe('BasiGX.view.button.SpatialOperatorUnion', function() {
     describe('Basics', function() {


### PR DESCRIPTION
This fixes latest added tests which invoke an `Ext.window.MessageBox`.
While tests will run in browser without this, tests with mocha-phantomjs will fail ..