### PR TITLE
WIP: Fix feature equality check

### DIFF
--- a/src/util/Digitize.js
+++ b/src/util/Digitize.js
@@ -31,7 +31,11 @@ Ext.define('BasiGX.util.Digitize', {
             Ext.each(collection.getArray(), function(feature) {
                 var featureWktString = wktParser.writeFeature(feature);
                 if (cloneWktString === featureWktString) {
-                    finalFeature = feature;
+                    var id1 = feature.getId();
+                    var id2 = clone.getId();
+                    if (id1 && id2 && id1 === id2 || !id1 || !id2) {
+                        finalFeature = feature;
+                    }
                     return false;
                 }
             });

--- a/src/view/button/DigitizeDeleteObject.js
+++ b/src/view/button/DigitizeDeleteObject.js
@@ -31,7 +31,7 @@ Ext.define('BasiGX.view.button.DigitizeDeleteObject', {
      */
     viewModel: {
         data: {
-            tooltip: 'Delete an objetct',
+            tooltip: 'Delete an object',
             deleteObjectBtnText: 'Delete Object'
         }
     },


### PR DESCRIPTION
Due to the checking for equal geometries many of the digitizing tools run into problems. This is an attempt to fix it.

* if both the clone and the original have an id set, it is used for comparison (thus ruling out false positives)