### PR TITLE
Fixed undefined variable in configparser

### DIFF
--- a/src/util/ConfigParser.js
+++ b/src/util/ConfigParser.js
@@ -842,7 +842,7 @@ Ext.define('BasiGX.util.ConfigParser', {
                         );
                         if (node.checked) {
                             group.set('visible', true);
-                            var nextParent = parent.get('parentFolder');
+                            var nextParent = group.get('parentFolder');
                             while (nextParent) {
                                 nextParent.set('visible', true);
                                 nextParent = nextParent.get('parentFolder');


### PR DESCRIPTION
`parent` was meant to be `group` in this case