### PR TITLE
Document adding 'ux' as require for BasiGX setup

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,11 +21,12 @@ sencha package repo add GeoExt http://geoext.github.io/geoext3/cmd/pkgs
 sencha package repo add BasiGX http://terrestris.github.io/BasiGX/cmd/pkgs
 ```
 
-* Add the packages `GeoExt` & `BasiGX` to the requirements in `app.json`.
+* Add the packages `GeoExt`, `BasiGX` & `ux` to the requirements in `app.json`.
 ```json
     "requires": [
         "GeoExt",
-        "BasiGX"
+        "BasiGX",
+        "ux"
     ],
 ```
 


### PR DESCRIPTION
If you add `BasiGX` to your ExtJS application you need to add the `ux` package to your application as well. This adds the corresponding configuration snippet to the Readme file.