### PR TITLE
Remove warning from sencha cmd wrt unescaped backslash

### DIFF
--- a/src/view/panel/LegendTree.js
+++ b/src/view/panel/LegendTree.js
@@ -285,7 +285,7 @@ Ext.define('BasiGX.view.panel.LegendTree', {
                 '.' + elemenIdAndCssClass + ' { ' +
                 ' background-color: ' + color + ';' +
                 ' background:linear-gradient(to right, white, ' + color + ');' +
-                ' filter: alpha(opacity=50)\10;' +//IE9 fallback
+                ' filter: alpha(opacity=50);' + // IE9 fallback
                 '}';
             Ext.util.CSS.createStyleSheet(css, elemenIdAndCssClass);
 


### PR DESCRIPTION
The syntax looks quite odd to me anyhow.

Please review.