### PR TITLE
Always replace surrounding quotes when converting cql filters

### DIFF
--- a/src/util/WFS.js
+++ b/src/util/WFS.js
@@ -144,6 +144,10 @@ Ext.define('BasiGX.util.WFS', {
             var ogcFilterType;
             var closingTag;
 
+            // always replace surrounding quotes
+            value = value.replace(/(^['])/g, '');
+            value = value.replace(/([']$)/g, '');
+
             switch (operator) {
                 case '=':
                     ogcFilterType = 'PropertyIsEqualTo';


### PR DESCRIPTION
When converting CQL to OGC filter encoding filters one runs into problems when converting string literals (which need to be quoted in CQL but will not match if the quotes are included in the filter encoding variant). With this PR the util will always remove trailing and leading single quotes from all values.

@terrestris/devs Please review.