### PR TITLE
Support multiple merge target layers

### DIFF
--- a/src/util/Merge.js
+++ b/src/util/Merge.js
@@ -124,6 +124,7 @@ Ext.define('BasiGX.util.Merge', {
             Ext.each(toCopy, function(attribute) {
                 newFeature.set(attribute, feature.get(attribute));
             });
+            newFeature.setId('converted_' + feature.getId());
             return newFeature;
         }
 

--- a/src/view/button/MergeSelection.js
+++ b/src/view/button/MergeSelection.js
@@ -55,6 +55,7 @@ Ext.define('BasiGX.view.button.MergeSelection', {
      */
     config: {
         handler: function() {
+            var me = this;
             var grid;
             var parent = this.up('window');
             // support embedding the feature grid anywhere
@@ -69,7 +70,10 @@ Ext.define('BasiGX.view.button.MergeSelection', {
                 xtype: 'basigx-window-merge',
                 sourceLayer: this.getSourceLayer(),
                 targetLayer: targetLayer,
-                extraTargetLayers: this.getExtraTargetLayers()
+                extraTargetLayers: this.getExtraTargetLayers(),
+                mergedFeaturesFn: function(features) {
+                    me.getMergedFeaturesFn()(features);
+                }
             });
         },
         /**
@@ -85,6 +89,13 @@ Ext.define('BasiGX.view.button.MergeSelection', {
          * Optional extra target layers to put the features into.
          * @type {ol.layer.Vector[]}
          */
-        extraTargetLayers: null
+        extraTargetLayers: null,
+        /**
+         * Optional callback function to get notified once the features have
+         * been merged.
+         * @type {Function} which will receive the features that have been
+         * merged
+         */
+        mergedFeaturesFn: null
     }
 });

--- a/src/view/button/MergeSelection.js
+++ b/src/view/button/MergeSelection.js
@@ -72,7 +72,9 @@ Ext.define('BasiGX.view.button.MergeSelection', {
                 targetLayer: targetLayer,
                 extraTargetLayers: this.getExtraTargetLayers(),
                 mergedFeaturesFn: function(features) {
-                    me.getMergedFeaturesFn()(features);
+                    if (me.getMergedFeaturesFn()) {
+                        me.getMergedFeaturesFn()(features);
+                    }
                 }
             });
         },

--- a/src/view/button/MergeSelection.js
+++ b/src/view/button/MergeSelection.js
@@ -57,9 +57,7 @@ Ext.define('BasiGX.view.button.MergeSelection', {
         handler: function() {
             var grid;
             var parent = this.up('window');
-            // support embedding in window or panel
-            // This assumes the button is embedded in a buttongroup or similar
-            // panel, hence walking up two panels.
+            // support embedding the feature grid anywhere
             if (!parent && this.config.featureGridSelectorFn) {
                 grid = this.config.featureGridSelectorFn.call(this);
             } else {
@@ -70,7 +68,8 @@ Ext.define('BasiGX.view.button.MergeSelection', {
             Ext.create({
                 xtype: 'basigx-window-merge',
                 sourceLayer: this.getSourceLayer(),
-                targetLayer: targetLayer
+                targetLayer: targetLayer,
+                extraTargetLayers: this.getExtraTargetLayers()
             });
         },
         /**
@@ -78,6 +77,14 @@ Ext.define('BasiGX.view.button.MergeSelection', {
          * @type {ol.layer.Vector}
          */
         sourceLayer: null,
-        featureGridSelectorFn: null
+        /**
+         * A function to obtain the feature grid.
+         */
+        featureGridSelectorFn: null,
+        /**
+         * Optional extra target layers to put the features into.
+         * @type {ol.layer.Vector[]}
+         */
+        extraTargetLayers: null
     }
 });

--- a/src/view/window/MergeWindow.js
+++ b/src/view/window/MergeWindow.js
@@ -54,7 +54,12 @@ Ext.define('BasiGX.view.window.MergeWindow', {
          * The layer to merge to.
          * @type {ol.layer.Vector}
          */
-        targetLayer: null
+        targetLayer: null,
+        /**
+         * Optional extra layers to push the features into.
+         * @type {ol.layer.Vector[]}
+         */
+        extraTargetLayers: null
     },
 
     initComponent: function() {
@@ -125,11 +130,17 @@ Ext.define('BasiGX.view.window.MergeWindow', {
             var target = me.getTargetLayer().getSource();
             var mapping = Merge.extractMapping(win);
             var copy = Merge.extractToCopyAttributes(win);
+            var extraLayers = me.getExtraTargetLayers() || [];
+            var allFeatures = [];
 
             Ext.each(newFeatures, function(feature) {
                 var newFeature = Merge.convertFeature(feature, mapping, copy,
                     origSchema);
+                allFeatures.push(newFeature);
                 target.addFeature(newFeature);
+            });
+            Ext.each(extraLayers, function(layer) {
+                layer.getSource().addFeatures(allFeatures);
             });
 
             win.destroy();

--- a/src/view/window/MergeWindow.js
+++ b/src/view/window/MergeWindow.js
@@ -59,7 +59,14 @@ Ext.define('BasiGX.view.window.MergeWindow', {
          * Optional extra layers to push the features into.
          * @type {ol.layer.Vector[]}
          */
-        extraTargetLayers: null
+        extraTargetLayers: null,
+        /**
+         * Optional callback function to get notified once the features have
+         * been merged.
+         * @type {Function} which will receive the features that have been
+         * merged
+         */
+        mergedFeaturesFn: null
     },
 
     initComponent: function() {
@@ -142,6 +149,10 @@ Ext.define('BasiGX.view.window.MergeWindow', {
             Ext.each(extraLayers, function(layer) {
                 layer.getSource().addFeatures(allFeatures);
             });
+
+            if (me.getMergedFeaturesFn()) {
+                me.getMergedFeaturesFn()(allFeatures);
+            }
 
             win.destroy();
         };


### PR DESCRIPTION
Also sets an ID on cloned/merged features, else selection will not function properly on the grid nor in the map. Also adds a new config option `mergedFeaturesFn` to get notified once merge has commenced.

@terrestris/devs Please review.