### PR TITLE
Update mocha to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
         },
         "abbrev": {
             "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
             "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
             "dev": true
         },
@@ -79,7 +78,6 @@
         },
         "adm-zip": {
             "version": "0.2.1",
-            "resolved": "http://registry.npmjs.org/adm-zip/-/adm-zip-0.2.1.tgz",
             "integrity": "sha1-6AHO3rW9mk6Y1pnFwPQjnicx3L8=",
             "dev": true
         },
@@ -170,7 +168,7 @@
         },
         "async": {
             "version": "1.5.2",
-            "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
             "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
             "dev": true
         },
@@ -227,9 +225,9 @@
             }
         },
         "browser-stdout": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
         "caller-path": {
@@ -323,7 +321,6 @@
         },
         "concat-map": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
@@ -390,7 +387,6 @@
         },
         "ctype": {
             "version": "0.5.3",
-            "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
             "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
             "dev": true,
             "optional": true
@@ -415,7 +411,6 @@
         },
         "deep-is": {
             "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
             "dev": true
         },
@@ -440,9 +435,9 @@
             "dev": true
         },
         "diff": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-            "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
             "dev": true
         },
         "doctrine": {
@@ -608,7 +603,6 @@
         },
         "esutils": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
@@ -901,13 +895,11 @@
         },
         "inherits": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
             "dev": true
         },
         "ini": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
             "integrity": "sha1-ToCMLOFExsF4iRjgNNZ5e8bPYoE=",
             "dev": true
         },
@@ -1098,7 +1090,6 @@
         },
         "json-stringify-safe": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
         },
@@ -1122,7 +1113,6 @@
         },
         "kew": {
             "version": "0.1.7",
-            "resolved": "http://registry.npmjs.org/kew/-/kew-0.1.7.tgz",
             "integrity": "sha1-CjKoF/8amzsSuMm6z0vE1nmvjnI=",
             "dev": true
         },
@@ -1168,7 +1158,6 @@
         },
         "mime": {
             "version": "1.2.11",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
             "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
             "dev": true
         },
@@ -1204,13 +1193,12 @@
         },
         "minimist": {
             "version": "1.2.0",
-            "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
             "dev": true
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "requires": {
@@ -1219,34 +1207,34 @@
             "dependencies": {
                 "minimist": {
                     "version": "0.0.8",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                     "dev": true
                 }
             }
         },
         "mocha": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.0.tgz",
-            "integrity": "sha512-ukB2dF+u4aeJjc6IGtPNnJXfeby5d4ZqySlIBT0OEyva/DrMjVm5HkQxKnHDLKEfEQBsEnwTg9HHhtPHJdTd8w==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
             "dev": true,
             "requires": {
-                "browser-stdout": "1.3.0",
-                "commander": "2.11.0",
+                "browser-stdout": "1.3.1",
+                "commander": "2.15.1",
                 "debug": "3.1.0",
-                "diff": "3.3.1",
+                "diff": "3.5.0",
                 "escape-string-regexp": "1.0.5",
                 "glob": "7.1.2",
-                "growl": "1.10.3",
+                "growl": "1.10.5",
                 "he": "1.1.1",
+                "minimatch": "3.0.4",
                 "mkdirp": "0.5.1",
-                "supports-color": "4.4.0"
+                "supports-color": "5.4.0"
             },
             "dependencies": {
                 "commander": {
-                    "version": "2.11.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+                    "version": "2.15.1",
+                    "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
                     "dev": true
                 },
                 "debug": {
@@ -1272,10 +1260,10 @@
                         "path-is-absolute": "^1.0.0"
                     }
                 },
-                "has-flag": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+                "growl": {
+                    "version": "1.10.5",
+                    "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+                    "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
                     "dev": true
                 },
                 "ms": {
@@ -1285,12 +1273,12 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-                    "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^2.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -1308,7 +1296,6 @@
         },
         "mocha-phantomjs-core": {
             "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/mocha-phantomjs-core/-/mocha-phantomjs-core-1.3.1.tgz",
             "integrity": "sha1-WGU4yNcfqN6QxBpGrMBIHB+4Phg=",
             "dev": true
         },
@@ -1332,7 +1319,6 @@
         },
         "ncp": {
             "version": "0.4.2",
-            "resolved": "http://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
             "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
             "dev": true
         },
@@ -1365,7 +1351,6 @@
         },
         "nopt": {
             "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "dev": true,
             "requires": {
@@ -1374,7 +1359,6 @@
         },
         "npmconf": {
             "version": "0.0.24",
-            "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-0.0.24.tgz",
             "integrity": "sha1-t4h1sIjMw8Cvo+zrPOMkSxtSOQw=",
             "dev": true,
             "requires": {
@@ -1390,19 +1374,16 @@
             "dependencies": {
                 "inherits": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
                     "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
                     "dev": true
                 },
                 "mkdirp": {
                     "version": "0.3.5",
-                    "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
                     "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
                     "dev": true
                 },
                 "nopt": {
                     "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
                     "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
                     "dev": true,
                     "requires": {
@@ -1411,7 +1392,6 @@
                 },
                 "once": {
                     "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz",
                     "integrity": "sha1-nbV0kzzLCMOnYU0VQDLAnqbzOec=",
                     "dev": true
                 },
@@ -1437,7 +1417,6 @@
         },
         "once": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
@@ -1455,7 +1434,6 @@
         },
         "optimist": {
             "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
@@ -1465,7 +1443,6 @@
             "dependencies": {
                 "minimist": {
                     "version": "0.0.10",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                     "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
                     "dev": true
                 },
@@ -1493,13 +1470,12 @@
         },
         "os-tmpdir": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
         "osenv": {
             "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
             "integrity": "sha1-zWrY3bKQkVrZ4idlV2Al1BHynLY=",
             "dev": true
         },
@@ -1511,7 +1487,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
@@ -1544,7 +1520,6 @@
         },
         "phantomjs": {
             "version": "1.9.7-15",
-            "resolved": "http://registry.npmjs.org/phantomjs/-/phantomjs-1.9.7-15.tgz",
             "integrity": "sha1-Czp85jBIaoO+kf9Ogy7uIOlxEVs=",
             "dev": true,
             "requires": {
@@ -1562,35 +1537,30 @@
             "dependencies": {
                 "asn1": {
                     "version": "0.1.11",
-                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                     "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
                     "dev": true,
                     "optional": true
                 },
                 "assert-plus": {
                     "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                     "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
                     "dev": true,
                     "optional": true
                 },
                 "async": {
                     "version": "0.9.2",
-                    "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
                     "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
                     "dev": true,
                     "optional": true
                 },
                 "aws-sign2": {
                     "version": "0.5.0",
-                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
                     "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
                     "dev": true,
                     "optional": true
                 },
                 "combined-stream": {
                     "version": "0.0.7",
-                    "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                     "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
                     "dev": true,
                     "optional": true,
@@ -1600,20 +1570,17 @@
                 },
                 "delayed-stream": {
                     "version": "0.0.5",
-                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                     "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
                     "dev": true,
                     "optional": true
                 },
                 "forever-agent": {
                     "version": "0.5.2",
-                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
                     "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=",
                     "dev": true
                 },
                 "form-data": {
                     "version": "0.1.4",
-                    "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
                     "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
                     "dev": true,
                     "optional": true,
@@ -1625,7 +1592,6 @@
                 },
                 "http-signature": {
                     "version": "0.10.1",
-                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                     "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
                     "dev": true,
                     "optional": true,
@@ -1637,7 +1603,6 @@
                 },
                 "mkdirp": {
                     "version": "0.3.5",
-                    "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
                     "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
                     "dev": true
                 },
@@ -1649,26 +1614,23 @@
                 },
                 "oauth-sign": {
                     "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
                     "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
                     "dev": true,
                     "optional": true
                 },
                 "progress": {
                     "version": "1.1.8",
-                    "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+                    "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
                     "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
                     "dev": true
                 },
                 "qs": {
                     "version": "0.6.6",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
                     "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc=",
                     "dev": true
                 },
                 "request": {
                     "version": "2.36.0",
-                    "resolved": "http://registry.npmjs.org/request/-/request-2.36.0.tgz",
                     "integrity": "sha1-KMbAQmLHuf/dIbklU3RRfubZQ/U=",
                     "dev": true,
                     "requires": {
@@ -1688,7 +1650,6 @@
                 },
                 "rimraf": {
                     "version": "2.2.8",
-                    "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
                     "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
                     "dev": true
                 },
@@ -1701,7 +1662,6 @@
                 },
                 "which": {
                     "version": "1.0.9",
-                    "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
                     "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
                     "dev": true
                 }
@@ -1736,7 +1696,6 @@
         },
         "prelude-ls": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
             "dev": true
         },
@@ -1748,7 +1707,6 @@
         },
         "proto-list": {
             "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
             "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
             "dev": true
         },
@@ -1806,7 +1764,6 @@
         },
         "request-progress": {
             "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
             "integrity": "sha1-ByHBBdipasayzossia4tXs/Pazo=",
             "dev": true,
             "requires": {
@@ -1815,7 +1772,7 @@
         },
         "require-uncached": {
             "version": "1.0.3",
-            "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
@@ -1825,7 +1782,6 @@
         },
         "resolve": {
             "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
             "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
             "dev": true
         },
@@ -1967,7 +1923,6 @@
         },
         "sprintf-js": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
@@ -2036,7 +1991,7 @@
         },
         "text-encoding": {
             "version": "0.6.4",
-            "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+            "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
             "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
             "dev": true
         },
@@ -2048,13 +2003,12 @@
         },
         "throttleit": {
             "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
             "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
             "dev": true
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },
@@ -2108,7 +2062,6 @@
         },
         "type-check": {
             "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
@@ -2184,7 +2137,6 @@
         },
         "wrappy": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "eslint": "5.9.0",
         "expect.js": "0.3.1",
         "istanbul": "0.4.5",
-        "mocha": "5.0.0",
+        "mocha": "5.2.0",
         "mocha-phantomjs": "4.1.0",
         "sinon": "7.1.1"
     }

--- a/src/view/combo/ScaleCombo.js
+++ b/src/view/combo/ScaleCombo.js
@@ -188,6 +188,9 @@ Ext.define('BasiGX.view.combo.ScaleCombo', {
         }
         var resolution = mapView.get(evt.key); // map.get('resolution')
         var store = this.getStore();
+        if (!store) {
+            return; // perhaps we've been destroyed already
+        }
 
         var matchInStore = (store.findExact('resolution', resolution) >= 0);
 


### PR DESCRIPTION
Updates mocha to the latest version. Also fixes a test which destroyed the `ScaleCombo` immediately after creating it. In case the tests run fast enough, this will fail since the combo will be destroyed before being fully initialized (it uses a delayed function in init).

Closes #326 

@terrestris/devs Please review.