### PR TITLE
Fixes image location resolving on production builds

### DIFF
--- a/src/view/button/DigitizePostit.js
+++ b/src/view/button/DigitizePostit.js
@@ -136,8 +136,14 @@ Ext.define('BasiGX.view.button.DigitizePostit', {
             );
             var imageBaseSrc;
             if (classPath) {
-                imageBaseSrc = classPath.split(
-                    'src/view/button/DigitizePostit.js')[0];
+                if (classPath.indexOf('src/view/button/DigitizePostit.js') === -1) {
+                    // we're on a production build, so let's use the
+                    // image from the classic resource folder
+                    imageBaseSrc = 'classic/';
+                } else {
+                    imageBaseSrc = classPath.split(
+                        'src/view/button/DigitizePostit.js')[0];
+                }
             }
             return imageBaseSrc + 'resources/img/postit.png';
         }

--- a/src/view/button/DigitizePostit.js
+++ b/src/view/button/DigitizePostit.js
@@ -136,13 +136,13 @@ Ext.define('BasiGX.view.button.DigitizePostit', {
             );
             var imageBaseSrc;
             if (classPath) {
-                if (classPath.indexOf('src/view/button/DigitizePostit.js') === -1) {
+                var devPath = 'src/view/button/DigitizePostit.js';
+                if (classPath.indexOf(devPath) === -1) {
                     // we're on a production build, so let's use the
                     // image from the classic resource folder
                     imageBaseSrc = 'classic/';
                 } else {
-                    imageBaseSrc = classPath.split(
-                        'src/view/button/DigitizePostit.js')[0];
+                    imageBaseSrc = classPath.split(devPath)[0];
                 }
             }
             return imageBaseSrc + 'resources/img/postit.png';


### PR DESCRIPTION
This assumes the BasiGX `resources` folder is copied in the `app.json` to the right location with another entry under the `resources` section like this:

```json
        {
            "path": "lib/BasiGX/resources",
            "output": "resources"
        },
```

@terrestris/devs Please review.