### PR TITLE
Removes togglegroup from spatial operator buttons

### DIFF
--- a/src/view/button/SpatialOperatorDifference.js
+++ b/src/view/button/SpatialOperatorDifference.js
@@ -58,8 +58,6 @@ Ext.define('BasiGX.view.button.SpatialOperatorDifference', {
         showSelectMasterSlaveFeatureDialog: true
     },
 
-    toggleGroup: 'draw',
-
     handler: function() {
         // effectively disable the toggle functionality, behaves like
         // `enableToggle: false` but keeps the ability to be part

--- a/src/view/button/SpatialOperatorIntersect.js
+++ b/src/view/button/SpatialOperatorIntersect.js
@@ -75,8 +75,6 @@ Ext.define('BasiGX.view.button.SpatialOperatorIntersect', {
         tolerance: 0
     },
 
-    toggleGroup: 'draw',
-
     handler: function() {
         // effectively disable the toggle functionality, behaves like
         // `enableToggle: false` but keeps the ability to be part

--- a/src/view/button/SpatialOperatorUnion.js
+++ b/src/view/button/SpatialOperatorUnion.js
@@ -56,8 +56,6 @@ Ext.define('BasiGX.view.button.SpatialOperatorUnion', {
         maxAllowedFeaturesForOperation: 9999
     },
 
-    toggleGroup: 'draw',
-
     handler: function() {
         // effectively disable the toggle functionality, behaves like
         // `enableToggle: false` but keeps the ability to be part


### PR DESCRIPTION
Typically we will have a `toggleGroup` eg. `draw` making sure only one type of features can be digitized at one time. You'll also often have selection functionality in that same `toggleGroup` to avoid digitizing and selecting at the same time.

OTOH, having the spatial operator buttons in that `toggleGroup` makes no sense, since that will effectively remove the selection before having the chance to do the operation.

@terrestris/devs Please review.