### PR TITLE
Add basic instanciation tests and cleanup during tests

### DIFF
--- a/src/view/button/Base.js
+++ b/src/view/button/Base.js
@@ -33,7 +33,10 @@ Ext.define('BasiGX.view.button.Base', {
         me.callParent(arguments);
         if (me.setTooltip) {
             var bind = me.config.bind;
-            bind.tooltip = me.getViewModel().get('tooltip');
+            var ttFromViewModel = me.getViewModel().get('tooltip');
+            if (ttFromViewModel) {
+                bind.tooltip = ttFromViewModel;
+            }
             me.setBind(bind);
         }
     }

--- a/test/spec/view/button/DigitizeCopyObject.test.js
+++ b/test/spec/view/button/DigitizeCopyObject.test.js
@@ -5,5 +5,12 @@ describe('BasiGX.view.button.DigitizeCopyObject', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.DigitizeCopyObject).to.not.be(undefined);
         });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('BasiGX.view.button.DigitizeCopyObject');
+            expect(inst).to.be.a(BasiGX.view.button.DigitizeCopyObject);
+            // teardown
+            inst.destroy();
+        });
     });
 });

--- a/test/spec/view/button/DigitizeDeleteObject.test.js
+++ b/test/spec/view/button/DigitizeDeleteObject.test.js
@@ -5,5 +5,12 @@ describe('BasiGX.view.button.DigitizeDeleteObject', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.DigitizeDeleteObject).to.not.be(undefined);
         });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('BasiGX.view.button.DigitizeDeleteObject');
+            expect(inst).to.be.a(BasiGX.view.button.DigitizeDeleteObject);
+            // teardown
+            inst.destroy();
+        });
     });
 });

--- a/test/spec/view/button/DigitizeModifyObject.test.js
+++ b/test/spec/view/button/DigitizeModifyObject.test.js
@@ -5,5 +5,12 @@ describe('BasiGX.view.button.DigitizeModifyObject', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.DigitizeModifyObject).to.not.be(undefined);
         });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('BasiGX.view.button.DigitizeModifyObject');
+            expect(inst).to.be.a(BasiGX.view.button.DigitizeModifyObject);
+            // teardown
+            inst.destroy();
+        });
     });
 });

--- a/test/spec/view/button/DigitizeMoveObject.test.js
+++ b/test/spec/view/button/DigitizeMoveObject.test.js
@@ -5,5 +5,12 @@ describe('BasiGX.view.button.DigitizeMoveObject', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.DigitizeMoveObject).to.not.be(undefined);
         });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('BasiGX.view.button.DigitizeMoveObject');
+            expect(inst).to.be.a(BasiGX.view.button.DigitizeMoveObject);
+            // teardown
+            inst.destroy();
+        });
     });
 });

--- a/test/spec/view/button/DigitizeOpenStyler.test.js
+++ b/test/spec/view/button/DigitizeOpenStyler.test.js
@@ -5,5 +5,12 @@ describe('BasiGX.view.button.DigitizeOpenStyler', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.DigitizeOpenStyler).to.not.be(undefined);
         });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('BasiGX.view.button.DigitizeOpenStyler');
+            expect(inst).to.be.a(BasiGX.view.button.DigitizeOpenStyler);
+            // teardown
+            inst.destroy();
+        });
     });
 });

--- a/test/spec/view/button/DigitizePostit.test.js
+++ b/test/spec/view/button/DigitizePostit.test.js
@@ -5,5 +5,12 @@ describe('BasiGX.view.button.DigitizePostit', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.DigitizePostit).to.not.be(undefined);
         });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('BasiGX.view.button.DigitizePostit');
+            expect(inst).to.be.a(BasiGX.view.button.DigitizePostit);
+            // teardown
+            inst.destroy();
+        });
     });
 });

--- a/test/spec/view/button/History.test.js
+++ b/test/spec/view/button/History.test.js
@@ -13,6 +13,14 @@ describe('BasiGX.view.button.History', function() {
         });
     });
 
+    afterEach(function() {
+        btn.destroy();
+        var parent = buttonDiv && buttonDiv.parentNode;
+        if(parent) {
+            parent.removeChild(buttonDiv);
+        }
+    });
+
     describe('Basics', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.History).to.not.be(undefined);

--- a/test/spec/view/button/MergeSelection.test.js
+++ b/test/spec/view/button/MergeSelection.test.js
@@ -5,5 +5,12 @@ describe('BasiGX.view.button.MergeSelection', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.MergeSelection).to.not.be(undefined);
         });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('BasiGX.view.button.MergeSelection');
+            expect(inst).to.be.a(BasiGX.view.button.MergeSelection);
+            // teardown
+            inst.destroy();
+        });
     });
 });

--- a/test/spec/view/button/SpatialOperatorBase.test.js
+++ b/test/spec/view/button/SpatialOperatorBase.test.js
@@ -5,5 +5,12 @@ describe('BasiGX.view.button.SpatialOperatorBase', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.SpatialOperatorBase).to.not.be(undefined);
         });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('BasiGX.view.button.SpatialOperatorBase');
+            expect(inst).to.be.a(BasiGX.view.button.SpatialOperatorBase);
+            // teardown
+            inst.destroy();
+        });
     });
 });

--- a/test/spec/view/component/Map.test.js
+++ b/test/spec/view/component/Map.test.js
@@ -5,5 +5,12 @@ describe('BasiGX.view.component.Map', function() {
         it('is defined', function() {
             expect(BasiGX.view.component.Map).to.not.be(undefined);
         });
+
+        it('can be instantiated', function() {
+            var map = new ol.Map();
+            var inst = Ext.create('BasiGX.view.component.Map', {map: map});
+            expect(inst).to.be.a(BasiGX.view.component.Map);
+            inst.destroy();
+        });
     });
 });

--- a/test/spec/view/container/LayerSlider.test.js
+++ b/test/spec/view/container/LayerSlider.test.js
@@ -5,5 +5,14 @@ describe('BasiGX.view.container.LayerSlider', function() {
         it('is defined', function() {
             expect(BasiGX.view.container.LayerSlider).to.not.be(undefined);
         });
+
+        it('can be instantiated', function() {
+            var cfg = {
+                layerNames: ['a', 'b']
+            };
+            var inst = Ext.create('BasiGX.view.container.LayerSlider', cfg);
+            expect(inst).to.be.a(BasiGX.view.container.LayerSlider);
+            inst.destroy();
+        });
     });
 });

--- a/test/spec/view/list/FocusableTreeItem.test.js
+++ b/test/spec/view/list/FocusableTreeItem.test.js
@@ -11,39 +11,75 @@ describe('BasiGX.view.list.FocusableTreeItem', function() {
         it('can be instantiated', function() {
             var item = Ext.create('BasiGX.view.list.FocusableTreeItem');
             expect(item).to.be.a(BasiGX.view.list.FocusableTreeItem);
+            // teardown
+            item.destroy();
         });
     });
     describe('Usage inside of a treelist', function() {
-        var callback = sinon.spy();
-        var div = document.createElement('div');
-        document.body.appendChild(div);
-        var store = {
-            root: {
-                expanded: true,
-                children: [{
-                    text: 'humpty',
-                    leaf: true
-                }, {
-                    text: 'dumpty',
-                    leaf: true
-                }, {
-                    text: 'foobar',
-                    leaf: true
-                }]
-            }
+        var callback;
+        var treeList;
+        var div;
+        var item;
+        var target;
+
+        /**
+         * Returns a mock-event as it would have been created by an
+         * actual keydown.
+         *
+         * @param {Number} key The keyCode of the pressed key.
+         * @return {Ext.event.Event} The mocked-up event.
+         */
+        var makeEvt = function(key) {
+            return Ext.create('Ext.event.Event', {
+                type: 'keypress',
+                keyCode: key,
+                target: target
+            });
         };
-        var treeList = Ext.create('Ext.list.Tree', {
-            defaults: {
-                // This way our BasiGX class is used
-                xtype: 'focusable-tree-item'
-            },
-            store: store,
-            listeners: {
-                selectionchange: callback
-            },
-            renderTo: div
+
+        beforeEach(function() {
+            callback = sinon.spy();
+            div = document.createElement('div');
+            document.body.appendChild(div);
+            var store = {
+                root: {
+                    expanded: true,
+                    children: [{
+                        text: 'humpty',
+                        leaf: true
+                    }, {
+                        text: 'dumpty',
+                        leaf: true
+                    }, {
+                        text: 'foobar',
+                        leaf: true
+                    }]
+                }
+            };
+            treeList = Ext.create('Ext.list.Tree', {
+                defaults: {
+                    // This way our BasiGX class is used
+                    xtype: 'focusable-tree-item'
+                },
+                store: store,
+                listeners: {
+                    selectionchange: callback
+                },
+                renderTo: div
+            });
+            expect(treeList).to.be.a(Ext.list.Tree);
+
+            item = Ext.ComponentQuery.query('focusable-tree-item')[0];
+            expect(item).to.be.ok();
+            expect(item.onKeyPress).to.be.ok();
+            target = item.el.dom;
         });
-        expect(treeList).to.be.a(Ext.list.Tree);
+
+        afterEach(function() {
+            treeList.destroy();
+            div.parentNode.removeChild(div);
+            callback = null;
+        });
 
         it('renders `<li>` elements with `tabIndex` attribute', function() {
             var selector = 'li.x-focusable-tree-item[tabindex]';
@@ -53,29 +89,6 @@ describe('BasiGX.view.list.FocusableTreeItem', function() {
 
         describe('ensures treelist `selectionchange` event can be triggered',
             function() {
-                var item;
-                var target;
-
-                /**
-                 * Returns a mock-event as it would have been created by an
-                 * actual keydown.
-                 *
-                 * @param {Number} key The keyCode of the pressed key.
-                 * @return {Ext.event.Event} The mocked-up event.
-                 */
-                var makeEvt = function(key) {
-                    return Ext.create('Ext.event.Event', {
-                        type: 'keypress',
-                        keyCode: key,
-                        target: target
-                    });
-                };
-
-                item = Ext.ComponentQuery.query('focusable-tree-item')[0];
-                expect(item).to.be.ok();
-                expect(item.onKeyPress).to.be.ok();
-                target = item.el.dom;
-
                 it('is triggered on ENTER-key', function() {
                     var evtEnter = makeEvt(Ext.event.Event.ENTER);
 


### PR DESCRIPTION
This actually revealed one bug (unchecked setting of `tooltip` viewModel config, which would err out when destroying components). 

Several components would not properly cleanup behind them, so that visual artifacts remained in the karma debug page.

Please review.