### PR TITLE
Allow to uncheck text symbolizer in sld styler

### DIFF
--- a/src/util/SLD.js
+++ b/src/util/SLD.js
@@ -341,7 +341,7 @@ Ext.define('BasiGX.util.SLD', {
          *
          * @return {Object} sldObject The updated SLD object.
          * @param {String} ruleName The name of the rule that should be updated.
-         * @param {Object} sldObj The sldObj to update, containing the rule.
+         * @param {Object} sldObject The sldObj to update, containing the rule.
          */
         removeTextSymbolizerFromRule: function(ruleName, sldObject) {
             var rules = BasiGX.util.SLD.rulesFromSldObject(sldObject);

--- a/src/util/SLD.js
+++ b/src/util/SLD.js
@@ -337,6 +337,39 @@ Ext.define('BasiGX.util.SLD', {
         },
 
         /**
+         * Method removes the point symbolizer for a given rule and sldObject
+         *
+         * @return {Object} sldObject The updated SLD object.
+         * @param {String} ruleName The name of the rule that should be updated.
+         * @param {Object} sldObj The sldObj to update, containing the rule.
+         */
+        removeTextSymbolizerFromRule: function(ruleName, sldObject) {
+            var rules = BasiGX.util.SLD.rulesFromSldObject(sldObject);
+            if (!rules) {
+                rules = [];
+            }
+            var ruleMatchIdx;
+            Ext.each(rules, function(currentRule, index) {
+                if (currentRule.name === ruleName) {
+                    ruleMatchIdx = index;
+                    return false;
+                }
+            });
+            if (Ext.isNumeric(ruleMatchIdx)) {
+                // remove the existing TextSymbolizer
+                var symbolizerIndex;
+                Ext.each(rules[ruleMatchIdx].symbolizer, function(s, idx) {
+                    if (s.value.TYPE_NAME === 'SLD_1_0_0.TextSymbolizer') {
+                        symbolizerIndex = idx;
+                        return false;
+                    }
+                });
+                rules[ruleMatchIdx].symbolizer.splice(symbolizerIndex, 1);
+            }
+            return sldObject;
+        },
+
+        /**
          * Method converts a stroke object in Jsonix syntax into a simplified
          * object
          *

--- a/src/view/container/SLDStyler.js
+++ b/src/view/container/SLDStyler.js
@@ -1556,66 +1556,72 @@ Ext.define('BasiGX.view.container.SLDStyler', {
         }
 
         if (textFs) {
-            symbolizerObj.labelAttribute = textFs.down(
-                'combo[name=labelattribute]').getValue() ||
-                BasiGX.util.SLD.DEFAULT_LABEL_ATTRIBUTE;
-            symbolizerObj.fontSize = textFs.down('numberfield[name=fontsize]')
-                .getValue().toString() || BasiGX.util.SLD.DEFAULT_FONTSIZE;
-            symbolizerObj.fontFamily = textFs.down('combo[name=fontfamily]')
-                .getValue() || BasiGX.util.SLD.DEFAULT_FONT_FAMILY;
-            symbolizerObj.fontWeight = textFs.down('combo[name=fontweight]')
-                .getValue() || BasiGX.util.SLD.DEFAULT_FONT_WEIGHT;
-            symbolizerObj.fontStyle = textFs.down('combo[name=fontstyle]')
-                .getValue() || BasiGX.util.SLD.DEFAULT_FONT_STYLE;
-            symbolizerObj.fontFillColor = BasiGX.util.SLD.
-                DEFAULT_FONT_FILLCOLOR;
-            symbolizerObj.fontFillOpacity = 0;
+            if (textFs.checkboxCmp.checked) { 
+                // Set text symbolizer only if the checkbox "text style" is checked
+                symbolizerObj.labelAttribute = textFs.down(
+                    'combo[name=labelattribute]').getValue() ||
+                    BasiGX.util.SLD.DEFAULT_LABEL_ATTRIBUTE;
+                symbolizerObj.fontSize = textFs.down('numberfield[name=fontsize]')
+                    .getValue().toString() || BasiGX.util.SLD.DEFAULT_FONTSIZE;
+                symbolizerObj.fontFamily = textFs.down('combo[name=fontfamily]')
+                    .getValue() || BasiGX.util.SLD.DEFAULT_FONT_FAMILY;
+                symbolizerObj.fontWeight = textFs.down('combo[name=fontweight]')
+                    .getValue() || BasiGX.util.SLD.DEFAULT_FONT_WEIGHT;
+                symbolizerObj.fontStyle = textFs.down('combo[name=fontstyle]')
+                    .getValue() || BasiGX.util.SLD.DEFAULT_FONT_STYLE;
+                symbolizerObj.fontFillColor = BasiGX.util.SLD.
+                    DEFAULT_FONT_FILLCOLOR;
+                symbolizerObj.fontFillOpacity = 0;
+    
+                var textFillFs = textFs.down('colorbutton[name=fill]');
+                if (textFillFs) {
+                    symbolizerObj.fontFillColor = '#' + textFillFs.getValue().
+                        substring(0, 6);
+                    symbolizerObj.fontFillOpacity = BasiGX.util.Color.rgbaAsArray(
+                        BasiGX.util.Color.hex8ToRgba(textFillFs.getValue()))[4];
+                }
+    
+                if (this.getMode() === 'line') {
+                    symbolizerObj.perpendicularOffset = textFs.down(
+                        'numberfield[name=perpendicularoffset]')
+                        .getValue().toString() || BasiGX.util.SLD.
+                            DEFAULT_LABEL_PERPENDICULAROFFSET;
+                    symbolizerObj.labelFollowLine = textFs.down(
+                        'checkbox[name=followlinelabel]')
+                        .getValue().toString() || BasiGX.util.SLD.
+                            DEFAULT_LABEL_FOLLOW_LINE;
+                } else {
+                    symbolizerObj.labelAnchorPointX = textFs.down(
+                        'numberfield[name=labelanchorpointx]')
+                        .getValue().toString() || BasiGX.util.SLD.
+                            DEFAULT_LABEL_ANCHORPOINTX;
+                    symbolizerObj.labelAnchorPointY = textFs.down(
+                        'numberfield[name=labelanchorpointy]')
+                        .getValue().toString() || BasiGX.util.SLD.
+                            DEFAULT_LABEL_ANCHORPOINTY;
+                    symbolizerObj.labelDisplacementX = textFs.down(
+                        'numberfield[name=labeldisplacementx]')
+                        .getValue().toString() || BasiGX.util.SLD.
+                            DEFAULT_LABEL_DISPLACEMENTX;
+                    symbolizerObj.labelDisplacementY = textFs.down(
+                        'numberfield[name=labeldisplacementy]')
+                        .getValue().toString() || BasiGX.util.SLD.
+                            DEFAULT_LABEL_DISPLACEMENTY;
+                    symbolizerObj.labelRotation = textFs.down(
+                        'numberfield[name=labelrotation]')
+                        .getValue().toString() || BasiGX.util.SLD.
+                            DEFAULT_LABEL_ROTATION;
+                }
 
-            var textFillFs = textFs.down('colorbutton[name=fill]');
-            if (textFillFs) {
-                symbolizerObj.fontFillColor = '#' + textFillFs.getValue().
-                    substring(0, 6);
-                symbolizerObj.fontFillOpacity = BasiGX.util.Color.rgbaAsArray(
-                    BasiGX.util.Color.hex8ToRgba(textFillFs.getValue()))[4];
-            }
-
-            if (this.getMode() === 'line') {
-                symbolizerObj.perpendicularOffset = textFs.down(
-                    'numberfield[name=perpendicularoffset]')
-                    .getValue().toString() || BasiGX.util.SLD.
-                    DEFAULT_LABEL_PERPENDICULAROFFSET;
-                symbolizerObj.labelFollowLine = textFs.down(
-                    'checkbox[name=followlinelabel]')
-                    .getValue().toString() || BasiGX.util.SLD.
-                    DEFAULT_LABEL_FOLLOW_LINE;
+                sldObj = BasiGX.util.SLD.setTextSymbolizerInRule(
+                    symbolizerObj,
+                    me.getRuleName(),
+                    sldObj
+                );
             } else {
-                symbolizerObj.labelAnchorPointX = textFs.down(
-                    'numberfield[name=labelanchorpointx]')
-                    .getValue().toString() || BasiGX.util.SLD.
-                    DEFAULT_LABEL_ANCHORPOINTX;
-                symbolizerObj.labelAnchorPointY = textFs.down(
-                    'numberfield[name=labelanchorpointy]')
-                    .getValue().toString() || BasiGX.util.SLD.
-                    DEFAULT_LABEL_ANCHORPOINTY;
-                symbolizerObj.labelDisplacementX = textFs.down(
-                    'numberfield[name=labeldisplacementx]')
-                    .getValue().toString() || BasiGX.util.SLD.
-                    DEFAULT_LABEL_DISPLACEMENTX;
-                symbolizerObj.labelDisplacementY = textFs.down(
-                    'numberfield[name=labeldisplacementy]')
-                    .getValue().toString() || BasiGX.util.SLD.
-                    DEFAULT_LABEL_DISPLACEMENTY;
-                symbolizerObj.labelRotation = textFs.down(
-                    'numberfield[name=labelrotation]')
-                    .getValue().toString() || BasiGX.util.SLD.
-                    DEFAULT_LABEL_ROTATION;
+                // If the checkbox "text style" is unchecked, remove the text symbolizer from sldObj
+                sldObj = BasiGX.util.SLD.removeTextSymbolizerFromRule(me.getRuleName(), sldObj);
             }
-
-            sldObj = BasiGX.util.SLD.setTextSymbolizerInRule(
-                symbolizerObj,
-                me.getRuleName(),
-                sldObj
-            );
         }
 
         var sld = BasiGX.util.SLD.toSldString(sldObj);

--- a/src/view/container/SLDStyler.js
+++ b/src/view/container/SLDStyler.js
@@ -1095,6 +1095,10 @@ Ext.define('BasiGX.view.container.SLDStyler', {
         });
         var fs = {
             xtype: 'fieldset',
+            checkboxToggle: true,
+            checkbox: {
+                listeners: listenerConfig
+            },
             height: '100%',
             bind: {
                 title: '{textStyleFieldSetTitle}'

--- a/src/view/container/SLDStyler.js
+++ b/src/view/container/SLDStyler.js
@@ -1556,61 +1556,67 @@ Ext.define('BasiGX.view.container.SLDStyler', {
         }
 
         if (textFs) {
-            if (textFs.checkboxCmp.checked) { 
-                // Set text symbolizer only if the checkbox "text style" is checked
+            if (textFs.checkboxCmp.checked) {
+                // Set text symbolizer only if the checkbox "text style"
+                // is checked
                 symbolizerObj.labelAttribute = textFs.down(
                     'combo[name=labelattribute]').getValue() ||
                     BasiGX.util.SLD.DEFAULT_LABEL_ATTRIBUTE;
-                symbolizerObj.fontSize = textFs.down('numberfield[name=fontsize]')
-                    .getValue().toString() || BasiGX.util.SLD.DEFAULT_FONTSIZE;
-                symbolizerObj.fontFamily = textFs.down('combo[name=fontfamily]')
-                    .getValue() || BasiGX.util.SLD.DEFAULT_FONT_FAMILY;
-                symbolizerObj.fontWeight = textFs.down('combo[name=fontweight]')
-                    .getValue() || BasiGX.util.SLD.DEFAULT_FONT_WEIGHT;
-                symbolizerObj.fontStyle = textFs.down('combo[name=fontstyle]')
-                    .getValue() || BasiGX.util.SLD.DEFAULT_FONT_STYLE;
+                symbolizerObj.fontSize = textFs.down(
+                    'numberfield[name=fontsize]').getValue().toString() ||
+                    BasiGX.util.SLD.DEFAULT_FONTSIZE;
+                symbolizerObj.fontFamily = textFs.down(
+                    'combo[name=fontfamily]').getValue() ||
+                    BasiGX.util.SLD.DEFAULT_FONT_FAMILY;
+                symbolizerObj.fontWeight = textFs.down(
+                    'combo[name=fontweight]').getValue() ||
+                    BasiGX.util.SLD.DEFAULT_FONT_WEIGHT;
+                symbolizerObj.fontStyle = textFs.down(
+                    'combo[name=fontstyle]').getValue() ||
+                    BasiGX.util.SLD.DEFAULT_FONT_STYLE;
                 symbolizerObj.fontFillColor = BasiGX.util.SLD.
                     DEFAULT_FONT_FILLCOLOR;
                 symbolizerObj.fontFillOpacity = 0;
-    
+
                 var textFillFs = textFs.down('colorbutton[name=fill]');
                 if (textFillFs) {
-                    symbolizerObj.fontFillColor = '#' + textFillFs.getValue().
-                        substring(0, 6);
-                    symbolizerObj.fontFillOpacity = BasiGX.util.Color.rgbaAsArray(
-                        BasiGX.util.Color.hex8ToRgba(textFillFs.getValue()))[4];
+                    symbolizerObj.fontFillColor = '#' + textFillFs.getValue()
+                        .substring(0, 6);
+                    symbolizerObj.fontFillOpacity = BasiGX.util.Color
+                        .rgbaAsArray(BasiGX.util.Color.hex8ToRgba(textFillFs
+                            .getValue()))[4];
                 }
-    
+
                 if (this.getMode() === 'line') {
                     symbolizerObj.perpendicularOffset = textFs.down(
                         'numberfield[name=perpendicularoffset]')
                         .getValue().toString() || BasiGX.util.SLD.
-                            DEFAULT_LABEL_PERPENDICULAROFFSET;
+                        DEFAULT_LABEL_PERPENDICULAROFFSET;
                     symbolizerObj.labelFollowLine = textFs.down(
                         'checkbox[name=followlinelabel]')
                         .getValue().toString() || BasiGX.util.SLD.
-                            DEFAULT_LABEL_FOLLOW_LINE;
+                        DEFAULT_LABEL_FOLLOW_LINE;
                 } else {
                     symbolizerObj.labelAnchorPointX = textFs.down(
                         'numberfield[name=labelanchorpointx]')
                         .getValue().toString() || BasiGX.util.SLD.
-                            DEFAULT_LABEL_ANCHORPOINTX;
+                        DEFAULT_LABEL_ANCHORPOINTX;
                     symbolizerObj.labelAnchorPointY = textFs.down(
                         'numberfield[name=labelanchorpointy]')
                         .getValue().toString() || BasiGX.util.SLD.
-                            DEFAULT_LABEL_ANCHORPOINTY;
+                        DEFAULT_LABEL_ANCHORPOINTY;
                     symbolizerObj.labelDisplacementX = textFs.down(
                         'numberfield[name=labeldisplacementx]')
                         .getValue().toString() || BasiGX.util.SLD.
-                            DEFAULT_LABEL_DISPLACEMENTX;
+                        DEFAULT_LABEL_DISPLACEMENTX;
                     symbolizerObj.labelDisplacementY = textFs.down(
                         'numberfield[name=labeldisplacementy]')
                         .getValue().toString() || BasiGX.util.SLD.
-                            DEFAULT_LABEL_DISPLACEMENTY;
+                        DEFAULT_LABEL_DISPLACEMENTY;
                     symbolizerObj.labelRotation = textFs.down(
                         'numberfield[name=labelrotation]')
                         .getValue().toString() || BasiGX.util.SLD.
-                            DEFAULT_LABEL_ROTATION;
+                        DEFAULT_LABEL_ROTATION;
                 }
 
                 sldObj = BasiGX.util.SLD.setTextSymbolizerInRule(
@@ -1619,8 +1625,10 @@ Ext.define('BasiGX.view.container.SLDStyler', {
                     sldObj
                 );
             } else {
-                // If the checkbox "text style" is unchecked, remove the text symbolizer from sldObj
-                sldObj = BasiGX.util.SLD.removeTextSymbolizerFromRule(me.getRuleName(), sldObj);
+                // If the checkbox "text style" is unchecked, remove the text
+                // symbolizer from sldObj
+                sldObj = BasiGX.util.SLD.removeTextSymbolizerFromRule(
+                    me.getRuleName(), sldObj);
             }
         }
 

--- a/test/spec/util/SLD.test.js
+++ b/test/spec/util/SLD.test.js
@@ -47,6 +47,32 @@ describe('BasiGX.util.SLD', function() {
                     '</sld:Stroke>' +
                   '</sld:PolygonSymbolizer>' +
                 '</sld:Rule>' +
+                '<sld:Rule>' +
+                  '<sld:Name>rule2</sld:Name>' +
+                  '<sld:TextSymbolizer>' +
+                  '<sld:Label>' +
+                  '<ogc:PropertyName>ao_key</ogc:PropertyName>' +
+                  '</sld:Label>' +
+                    '<sld:Font>' +
+                      '<sld:CssParameter name="font-family">SansSerif</sld:CssParameter>' +
+                      '<sld:CssParameter name="font-size">12</sld:CssParameter>' +
+                      '<sld:CssParameter name="font-style">normal</sld:CssParameter>' +
+                      '<sld:CssParameter name="font-weight">normal</sld:CssParameter>' +
+                    '</sld:Font>' +
+                  '</sld:TextSymbolizer>' +
+                  '<sld:PointSymbolizer>' +
+                    '<sld:Graphic>' +
+                      '<sld:Mark>' +
+                        '<sld:WellKnownName>circle</sld:WellKnownName>' +
+                        '<sld:Fill>' +
+                          '<sld:CssParameter name="fill">#ff6600</sld:CssParameter>' +
+                        '</sld:Fill>' +
+                        '<sld:Stroke/>' +
+                      '</sld:Mark>' +
+                      '<sld:Size>6</sld:Size>' +
+                    '</sld:Graphic>' +
+                  '</sld:PointSymbolizer>' +
+                '</sld:Rule>' +
               '</sld:FeatureTypeStyle>' +
             '</sld:UserStyle>' +
           '</sld:NamedLayer>' +
@@ -189,6 +215,71 @@ describe('BasiGX.util.SLD', function() {
                 symbolizerObj.graphicRotation);
             expect(graphic.size.content[0]).to.equal(
                 symbolizerObj.graphicSize);
+        });
+        it('updates a text symbolizer correctly', function() {
+            var obj = BasiGX.util.SLD.toSldObject(sld);
+            var ruleName = 'rule1';
+            var symbolizerObj = {
+                fontFamily: 'SansSerif',
+                fontSize: '13',
+                fontStyle: 'italic',
+                fontWeight: 'bold',
+                fontFillColor: '#cc0f0f',
+                labelAnchorPointX: '0.5',
+                labelAnchorPointY: '-0.5',
+                labelDisplacementX: '2',
+                labelDisplacementY: '4',
+                labelRotation: '15'
+            };
+            var modifiedObj = BasiGX.util.SLD
+                .setTextSymbolizerInRule(symbolizerObj, ruleName, obj);
+            expect(modifiedObj).to.not.be(undefined);
+            expect(modifiedObj).to.be.an('object');
+            var value = modifiedObj.value.namedLayerOrUserLayer[0]
+                .namedStyleOrUserStyle[0].featureTypeStyle[0].rule[0]
+                .symbolizer[1].value;
+            expect(value.font.cssParameter[0].content[0]).to.equal(
+                symbolizerObj.fontFamily);
+            expect(value.font.cssParameter[1].content[0]).to.equal(
+                symbolizerObj.fontSize);
+            expect(value.font.cssParameter[2].content[0]).to.equal(
+                symbolizerObj.fontStyle);
+            expect(value.font.cssParameter[3].content[0]).to.equal(
+                symbolizerObj.fontWeight);
+            expect(value.fill.cssParameter[0].content[0]).to.equal(
+                symbolizerObj.fontFillColor);
+            expect(value.labelPlacement.pointPlacement
+                .anchorPoint.anchorPointX.content[0]).to.equal(
+                symbolizerObj.labelAnchorPointX);
+            expect(value.labelPlacement.pointPlacement
+                .anchorPoint.anchorPointY.content[0]).to.equal(
+                symbolizerObj.labelAnchorPointY);
+            expect(value.labelPlacement.pointPlacement
+                .displacement.displacementX.content[0]).to.equal(
+                symbolizerObj.labelDisplacementX);
+            expect(value.labelPlacement.pointPlacement
+                .displacement.displacementY.content[0]).to.equal(
+                symbolizerObj.labelDisplacementY);
+            expect(value.labelPlacement
+                .pointPlacement.rotation.content[0]).to.equal(
+                symbolizerObj.labelRotation);
+        });
+        it('removes a text symbolizer correctly', function() {
+            var obj = BasiGX.util.SLD.toSldObject(sld);
+            var ruleName = 'rule2';
+            var modifiedObj = BasiGX.util.SLD
+                .removeTextSymbolizerFromRule(ruleName, obj);
+            expect(modifiedObj).to.not.be(undefined);
+            expect(modifiedObj).to.be.an('object');
+            var symbolizers = modifiedObj.value.namedLayerOrUserLayer[0]
+                .namedStyleOrUserStyle[0].featureTypeStyle[0].rule[1]
+                .symbolizer;
+            expect(symbolizers).to.be.an('array');
+            expect(symbolizers.length).to.equal(1);
+            expect(symbolizers[0].value.TYPE_NAME).to.equal(
+                'SLD_1_0_0.PointSymbolizer');
+            expect(symbolizers[0].value.TYPE_NAME).to.not.equal(
+                'SLD_1_0_0.TextSymbolizer');
         });
     });
 });


### PR DESCRIPTION
Resolves an issue with the BasiGX text symbolizer: The default style couldn't be disabled, which resulted in URLs appearing on the map when the default label attribute `name` was used
- adds a checkbox to the text symbolizer form which disables it
- adds util method to remove the text symbolizer from a given rule
- adds tests for the text symbolizer and the `removeTextSymbolizerFromRule` util method

@terrestris/devs Please review