### PR TITLE
Fix a bug when removing textSymbolizer

### DIFF
--- a/src/util/SLD.js
+++ b/src/util/SLD.js
@@ -364,7 +364,9 @@ Ext.define('BasiGX.util.SLD', {
                         return false;
                     }
                 });
-                rules[ruleMatchIdx].symbolizer.splice(symbolizerIndex, 1);
+                if (symbolizerIndex) {
+                    rules[ruleMatchIdx].symbolizer.splice(symbolizerIndex, 1);
+                }
             }
             return sldObject;
         },

--- a/src/util/SLD.js
+++ b/src/util/SLD.js
@@ -364,7 +364,7 @@ Ext.define('BasiGX.util.SLD', {
                         return false;
                     }
                 });
-                if (symbolizerIndex) {
+                if (Ext.isNumeric(symbolizerIndex)) {
                     rules[ruleMatchIdx].symbolizer.splice(symbolizerIndex, 1);
                 }
             }


### PR DESCRIPTION
Another bugfix for #385: 
When the SLD had no textSymbolizer the pointSymbolizer was removed instead