### PR TITLE
Fixes client side shape download

### DIFF
--- a/src/util/Download.js
+++ b/src/util/Download.js
@@ -50,12 +50,18 @@ Ext.define('BasiGX.util.Download', {
                 window.navigator.msSaveBlob(blob, name + '.' + format);
             } else {
                 var a = document.createElement('a');
-                a.href = 'data:application/octet-stream;base64,' + result;
-                a.target = '_blank';
-                a.download = name + '.' + format;
-                document.body.appendChild(a);
-                a.click();
-                document.body.removeChild(a);
+                result.then(function(data) {
+                    var reader = new FileReader();
+                    reader.onload = function(event) {
+                        a.href = event.target.result;
+                        a.target = '_blank';
+                        a.download = name + '.' + format;
+                        document.body.appendChild(a);
+                        a.click();
+                        document.body.removeChild(a);
+                    };
+                    reader.readAsDataURL(data);
+                });
             }
         },
 


### PR DESCRIPTION
The client side shape download was not working for non-IE browsers.

@terrestris/devs Please review.