### PR TITLE
Update eslint and mocha dependencies to their latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -216,6 +216,12 @@
             "dev": true,
             "optional": true
         },
+        "ansi-colors": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+            "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+            "dev": true
+        },
         "ansi-escapes": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -753,6 +759,23 @@
             "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
             "dev": true
         },
+        "cliui": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+            "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+            "dev": true,
+            "requires": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
+            }
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -1021,6 +1044,15 @@
                 }
             }
         },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
+        },
         "define-property": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -1072,6 +1104,12 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "dev": true
+        },
+        "detect-file": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
             "dev": true
         },
         "di": {
@@ -1134,6 +1172,15 @@
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
             "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
             "dev": true
+        },
+        "end-of-stream": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "dev": true,
+            "requires": {
+                "once": "^1.4.0"
+            }
         },
         "engine.io": {
             "version": "3.2.1",
@@ -1252,6 +1299,31 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "es-abstract": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+            "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+            "dev": true,
+            "requires": {
+                "es-to-primitive": "^1.2.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "is-callable": "^1.1.4",
+                "is-regex": "^1.0.4",
+                "object-keys": "^1.0.12"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
         "es6-promise": {
             "version": "4.2.5",
             "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
@@ -1307,9 +1379,9 @@
             }
         },
         "eslint": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.14.0.tgz",
-            "integrity": "sha512-jrOhiYyENRrRnWlMYANlGZTqb89r2FuRT+615AabBoajhNjeh9ywDNlh2LU9vTqf0WYN+L3xdXuIi7xuj/tK9w==",
+            "version": "5.14.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.14.1.tgz",
+            "integrity": "sha512-CyUMbmsjxedx8B0mr79mNOqetvkbij/zrXnFeK2zc3pGRn3/tibjiNAv/3UxFEyfMDjh+ZqTrJrEGBFiGfD5Og==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
@@ -1439,6 +1511,21 @@
             "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
             "dev": true
         },
+        "execa": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+            }
+        },
         "expand-braces": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
@@ -1539,6 +1626,15 @@
                     "integrity": "sha1-x6jTI2BoNiBZp+RlH8aITosftK4=",
                     "dev": true
                 }
+            }
+        },
+        "expand-tilde": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "expect.js": {
@@ -1811,6 +1907,46 @@
                 "pinkie-promise": "^2.0.0"
             }
         },
+        "findup-sync": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+            "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+            "dev": true,
+            "requires": {
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
+            },
+            "dependencies": {
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                }
+            }
+        },
+        "flat": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+            "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "~2.0.3"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+                    "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+                    "dev": true
+                }
+            }
+        },
         "flat-cache": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -1921,7 +2057,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -2336,7 +2473,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -2392,6 +2530,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -2435,14 +2574,22 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -2450,11 +2597,26 @@
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
+        "get-caller-file": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+            "dev": true
+        },
         "get-stdin": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
             "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
             "dev": true
+        },
+        "get-stream": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+            "dev": true,
+            "requires": {
+                "pump": "^3.0.0"
+            }
         },
         "get-value": {
             "version": "2.0.6",
@@ -2504,6 +2666,30 @@
                         "is-extglob": "^2.1.0"
                     }
                 }
+            }
+        },
+        "global-modules": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+            "dev": true,
+            "requires": {
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
+            }
+        },
+        "global-prefix": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
             }
         },
         "globals": {
@@ -2569,6 +2755,15 @@
                 "har-schema": "^2.0.0"
             }
         },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
         "has-binary2": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
@@ -2596,6 +2791,12 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
             "dev": true
         },
         "has-value": {
@@ -2631,10 +2832,19 @@
             }
         },
         "he": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true
+        },
+        "homedir-polyfill": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+            "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+            "dev": true,
+            "requires": {
+                "parse-passwd": "^1.0.0"
+            }
         },
         "hosted-git-info": {
             "version": "2.7.1",
@@ -2759,6 +2969,12 @@
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
             "dev": true
         },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "dev": true
+        },
         "inquirer": {
             "version": "6.2.2",
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
@@ -2807,6 +3023,12 @@
                     }
                 }
             }
+        },
+        "invert-kv": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+            "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+            "dev": true
         },
         "is-accessor-descriptor": {
             "version": "0.1.6",
@@ -2858,6 +3080,12 @@
                 "builtin-modules": "^1.0.0"
             }
         },
+        "is-callable": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+            "dev": true
+        },
         "is-data-descriptor": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -2877,6 +3105,12 @@
                     }
                 }
             }
+        },
+        "is-date-object": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "dev": true
         },
         "is-descriptor": {
             "version": "0.1.6",
@@ -2967,6 +3201,30 @@
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
             "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
             "dev": true
+        },
+        "is-regex": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.1"
+            }
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "is-symbol": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.0"
+            }
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -3425,6 +3683,15 @@
             "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
             "dev": true
         },
+        "lcid": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+            "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+            "dev": true,
+            "requires": {
+                "invert-kv": "^2.0.0"
+            }
+        },
         "lcov-parse": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
@@ -3458,6 +3725,24 @@
                     "version": "2.3.0",
                     "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
+            }
+        },
+        "locate-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+            "dev": true,
+            "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+            },
+            "dependencies": {
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
                     "dev": true
                 }
             }
@@ -3554,6 +3839,15 @@
                 "pify": "^3.0.0"
             }
         },
+        "map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dev": true,
+            "requires": {
+                "p-defer": "^1.0.0"
+            }
+        },
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -3580,6 +3874,17 @@
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
             "dev": true
+        },
+        "mem": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+            "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+            "dev": true,
+            "requires": {
+                "map-age-cleaner": "^0.1.1",
+                "mimic-fn": "^1.0.0",
+                "p-is-promise": "^2.0.0"
+            }
         },
         "meow": {
             "version": "3.7.0",
@@ -3701,51 +4006,43 @@
             }
         },
         "mocha": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.0.0.tgz",
+            "integrity": "sha512-A7g9k3yr8oJaXn2IItFnfgjyxFc/LTe6Wwv7FczP+e8G74o9xYNSbMYmCf1ouldRojLrFcOb+z75P6Ak0GX6ug==",
             "dev": true,
             "requires": {
+                "ansi-colors": "3.2.3",
                 "browser-stdout": "1.3.1",
-                "commander": "2.15.1",
-                "debug": "3.1.0",
+                "debug": "3.2.6",
                 "diff": "3.5.0",
                 "escape-string-regexp": "1.0.5",
-                "glob": "7.1.2",
+                "findup-sync": "2.0.0",
+                "glob": "7.1.3",
                 "growl": "1.10.5",
-                "he": "1.1.1",
+                "he": "1.2.0",
+                "js-yaml": "3.12.0",
+                "log-symbols": "2.2.0",
                 "minimatch": "3.0.4",
                 "mkdirp": "0.5.1",
-                "supports-color": "5.4.0"
+                "ms": "2.1.1",
+                "node-environment-flags": "1.0.4",
+                "object.assign": "4.1.0",
+                "strip-json-comments": "2.0.1",
+                "supports-color": "6.0.0",
+                "which": "1.3.1",
+                "wide-align": "1.1.3",
+                "yargs": "12.0.5",
+                "yargs-parser": "11.1.1",
+                "yargs-unparser": "1.5.0"
             },
             "dependencies": {
-                "commander": {
-                    "version": "2.15.1",
-                    "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-                    "dev": true
-                },
                 "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.2",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "ms": "^2.1.1"
                     }
                 },
                 "growl": {
@@ -3754,16 +4051,10 @@
                     "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
                     "dev": true
                 },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
-                },
                 "supports-color": {
-                    "version": "5.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+                    "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
                     "dev": true,
                     "requires": {
                         "has-flag": "^3.0.0"
@@ -3848,6 +4139,15 @@
                 }
             }
         },
+        "node-environment-flags": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.4.tgz",
+            "integrity": "sha512-M9rwCnWVLW7PX+NUWe3ejEdiLYinRpsEre9hMkU/6NS4h+EEulYaDH1gCEZ2gyXsmw+RXYDaV2JkkTNcsPDJ0Q==",
+            "dev": true,
+            "requires": {
+                "object.getownpropertydescriptors": "^2.0.3"
+            }
+        },
         "nopt": {
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -3876,6 +4176,15 @@
             "dev": true,
             "requires": {
                 "remove-trailing-separator": "^1.0.1"
+            }
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
+            "requires": {
+                "path-key": "^2.0.0"
             }
         },
         "null-check": {
@@ -3939,6 +4248,12 @@
                 }
             }
         },
+        "object-keys": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+            "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+            "dev": true
+        },
         "object-visit": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -3946,6 +4261,28 @@
             "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.1"
             }
         },
         "object.pick": {
@@ -4022,10 +4359,63 @@
                 "wordwrap": "~1.0.0"
             }
         },
+        "os-locale": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+            "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+            "dev": true,
+            "requires": {
+                "execa": "^1.0.0",
+                "lcid": "^2.0.0",
+                "mem": "^4.0.0"
+            }
+        },
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+            "dev": true
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
+        },
+        "p-is-promise": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+            "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+            "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+            "dev": true,
+            "requires": {
+                "p-try": "^2.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+            "dev": true,
+            "requires": {
+                "p-limit": "^2.0.0"
+            }
+        },
+        "p-try": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+            "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
             "dev": true
         },
         "parent-module": {
@@ -4045,6 +4435,12 @@
             "requires": {
                 "error-ex": "^1.2.0"
             }
+        },
+        "parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+            "dev": true
         },
         "parseqs": {
             "version": "0.0.5",
@@ -4211,6 +4607,16 @@
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
             "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
             "dev": true
+        },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
         },
         "punycode": {
             "version": "2.1.1",
@@ -4411,6 +4817,18 @@
                 "uuid": "^3.3.2"
             }
         },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
+        },
         "requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -4422,6 +4840,16 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
             "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
             "dev": true
+        },
+        "resolve-dir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
+            }
         },
         "resolve-from": {
             "version": "4.0.0",
@@ -4509,6 +4937,12 @@
             "version": "5.6.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
             "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+            "dev": true
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
             "dev": true
         },
         "set-value": {
@@ -5005,6 +5439,12 @@
                 "is-utf8": "^0.2.0"
             }
         },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
         "strip-indent": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
@@ -5442,11 +5882,73 @@
                 "isexe": "^2.0.0"
             }
         },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "wide-align": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.2 || 2"
+            }
+        },
         "wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
             "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
             "dev": true
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
+            }
         },
         "wrappy": {
             "version": "1.0.2",
@@ -5478,11 +5980,77 @@
             "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
             "dev": true
         },
+        "y18n": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "dev": true
+        },
         "yallist": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
             "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
             "dev": true
+        },
+        "yargs": {
+            "version": "12.0.5",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+            "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+            "dev": true,
+            "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^3.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1 || ^4.0.0",
+                "yargs-parser": "^11.1.1"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+            "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+                    "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+                    "dev": true
+                }
+            }
+        },
+        "yargs-unparser": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
+            "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+            "dev": true,
+            "requires": {
+                "flat": "^4.1.0",
+                "lodash": "^4.17.11",
+                "yargs": "^12.0.5"
+            }
         },
         "yauzl": {
             "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     },
     "devDependencies": {
         "coveralls": "3.0.2",
-        "eslint": "5.14.0",
+        "eslint": "5.14.1",
         "expect.js": "0.3.1",
         "istanbul": "0.4.5",
         "karma": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "karma-mocha": "1.3.0",
         "karma-mocha-reporter": "2.2.5",
         "karma-sinon": "1.0.5",
-        "mocha": "5.2.0",
+        "mocha": "6.0.0",
         "puppeteer": "1.12.2",
         "rimraf": "2.6.3",
         "sinon": "7.2.4"


### PR DESCRIPTION
This PR suggests to update

* `eslint` to `v5.14.1`
* `mocha` to `v6.0.0`

Please review.