### PR TITLE
Update dependencies mocha and karma

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -251,6 +251,17 @@
             "requires": {
                 "micromatch": "^3.1.4",
                 "normalize-path": "^2.1.1"
+            },
+            "dependencies": {
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true,
+                    "requires": {
+                        "remove-trailing-separator": "^1.0.1"
+                    }
+                }
             }
         },
         "append-transform": {
@@ -299,12 +310,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
             "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
-            "dev": true
-        },
-        "array-slice": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-            "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
             "dev": true
         },
         "array-unique": {
@@ -486,9 +491,9 @@
             }
         },
         "binary-extensions": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-            "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
+            "integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==",
             "dev": true
         },
         "blob": {
@@ -701,24 +706,23 @@
             "dev": true
         },
         "chokidar": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-            "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.2.tgz",
+            "integrity": "sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==",
             "dev": true,
             "requires": {
                 "anymatch": "^2.0.0",
-                "async-each": "^1.0.0",
-                "braces": "^2.3.0",
-                "fsevents": "^1.2.2",
+                "async-each": "^1.0.1",
+                "braces": "^2.3.2",
+                "fsevents": "^1.2.7",
                 "glob-parent": "^3.1.0",
-                "inherits": "^2.0.1",
+                "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",
                 "is-glob": "^4.0.0",
-                "lodash.debounce": "^4.0.8",
-                "normalize-path": "^2.1.1",
+                "normalize-path": "^3.0.0",
                 "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.0.0",
-                "upath": "^1.0.5"
+                "readdirp": "^2.2.1",
+                "upath": "^1.1.0"
             }
         },
         "class-utils": {
@@ -806,15 +810,6 @@
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
             "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
             "dev": true
-        },
-        "combine-lists": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz",
-            "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
-            "dev": true,
-            "requires": {
-                "lodash": "^4.5.0"
-            }
         },
         "combined-stream": {
             "version": "1.0.7",
@@ -922,9 +917,9 @@
             "dev": true
         },
         "core-js": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
-            "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==",
+            "version": "2.6.5",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+            "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
             "dev": true
         },
         "core-util-is": {
@@ -985,9 +980,9 @@
             }
         },
         "date-format": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
-            "integrity": "sha1-YV6CjiM90aubua4JUODOzPpuytg=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.0.0.tgz",
+            "integrity": "sha512-M6UqVvZVgFYqZL1SfHsRGIQSz3ZL+qgbsV5Lp1Vj61LZVYuEwcMXYay7DRDtYs2HQQBK5hQtQ0fD9aEJ89V0LA==",
             "dev": true
         },
         "dateformat": {
@@ -1526,34 +1521,6 @@
                 "strip-eof": "^1.0.0"
             }
         },
-        "expand-braces": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
-            "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
-            "dev": true,
-            "requires": {
-                "array-slice": "^0.2.3",
-                "array-unique": "^0.2.1",
-                "braces": "^0.1.2"
-            },
-            "dependencies": {
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-                    "dev": true
-                },
-                "braces": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
-                    "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
-                    "dev": true,
-                    "requires": {
-                        "expand-range": "^0.1.0"
-                    }
-                }
-            }
-        },
         "expand-brackets": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -1600,30 +1567,6 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
-                }
-            }
-        },
-        "expand-range": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
-            "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
-            "dev": true,
-            "requires": {
-                "is-number": "^0.1.1",
-                "repeat-string": "^0.2.2"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "0.1.1",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
-                    "integrity": "sha1-aaevEWlj1HIG7JvZtIoUIW8eOAY=",
-                    "dev": true
-                },
-                "repeat-string": {
-                    "version": "0.2.2",
-                    "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
-                    "integrity": "sha1-x6jTI2BoNiBZp+RlH8aITosftK4=",
                     "dev": true
                 }
             }
@@ -1965,28 +1908,22 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
-            "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+            "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
             "dev": true,
             "requires": {
-                "debug": "=3.1.0"
+                "debug": "^3.2.6"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
                 }
             }
         },
@@ -2031,6 +1968,17 @@
                 "null-check": "^1.0.0"
             }
         },
+        "fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2057,8 +2005,7 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -2079,14 +2026,12 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2101,20 +2046,17 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -2231,8 +2173,7 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -2244,7 +2185,6 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2259,7 +2199,6 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -2267,14 +2206,12 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -2293,7 +2230,6 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -2374,8 +2310,7 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2387,7 +2322,6 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2473,8 +2407,7 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -2510,7 +2443,6 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2530,7 +2462,6 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -2574,14 +2505,12 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 }
             }
         },
@@ -2711,9 +2640,9 @@
             "dev": true
         },
         "handlebars": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-            "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+            "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
             "dev": true,
             "requires": {
                 "async": "^2.5.0",
@@ -2723,12 +2652,12 @@
             },
             "dependencies": {
                 "async": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-                    "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+                    "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
                     "dev": true,
                     "requires": {
-                        "lodash": "^4.17.10"
+                        "lodash": "^4.17.11"
                     }
                 },
                 "source-map": {
@@ -3539,6 +3468,15 @@
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
         },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
         "jsprim": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -3558,28 +3496,27 @@
             "dev": true
         },
         "karma": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/karma/-/karma-4.0.0.tgz",
-            "integrity": "sha512-EFoFs3F6G0BcUGPNOn/YloGOb3h09hzTguyXlg6loHlKY76qbJikkcyPk43m2kfRF65TUGda/mig29QQtyhm1g==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/karma/-/karma-4.0.1.tgz",
+            "integrity": "sha512-ind+4s03BqIXas7ZmraV3/kc5+mnqwCd+VDX1FndS6jxbt03kQKX2vXrWxNLuCjVYmhMwOZosAEKMM0a2q7w7A==",
             "dev": true,
             "requires": {
                 "bluebird": "^3.3.0",
                 "body-parser": "^1.16.1",
+                "braces": "^2.3.2",
                 "chokidar": "^2.0.3",
                 "colors": "^1.1.0",
-                "combine-lists": "^1.0.0",
                 "connect": "^3.6.0",
                 "core-js": "^2.2.0",
                 "di": "^0.0.1",
                 "dom-serialize": "^2.2.0",
-                "expand-braces": "^0.1.1",
                 "flatted": "^2.0.0",
                 "glob": "^7.1.1",
                 "graceful-fs": "^4.1.2",
                 "http-proxy": "^1.13.0",
                 "isbinaryfile": "^3.0.0",
-                "lodash": "^4.17.5",
-                "log4js": "^3.0.0",
+                "lodash": "^4.17.11",
+                "log4js": "^4.0.0",
                 "mime": "^2.3.1",
                 "minimatch": "^3.0.2",
                 "optimist": "^0.6.1",
@@ -3753,12 +3690,6 @@
             "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
             "dev": true
         },
-        "lodash.debounce": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-            "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-            "dev": true
-        },
         "log-driver": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
@@ -3775,24 +3706,18 @@
             }
         },
         "log4js": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/log4js/-/log4js-3.0.6.tgz",
-            "integrity": "sha512-ezXZk6oPJCWL483zj64pNkMuY/NcRX5MPiB0zE6tjZM137aeusrOnW1ecxgF9cmwMWkBMhjteQxBPoZBh9FDxQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/log4js/-/log4js-4.0.2.tgz",
+            "integrity": "sha512-KE7HjiieVDPPdveA3bJZSuu0n8chMkFl8mIoisBFxwEJ9FmXe4YzNuiqSwYUiR1K8q8/5/8Yd6AClENY1RA9ww==",
             "dev": true,
             "requires": {
-                "circular-json": "^0.5.5",
-                "date-format": "^1.2.0",
+                "date-format": "^2.0.0",
                 "debug": "^3.1.0",
+                "flatted": "^2.0.0",
                 "rfdc": "^1.1.2",
-                "streamroller": "0.7.0"
+                "streamroller": "^1.0.1"
             },
             "dependencies": {
-                "circular-json": {
-                    "version": "0.5.9",
-                    "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
-                    "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==",
-                    "dev": true
-                },
                 "debug": {
                     "version": "3.2.6",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -4006,9 +3931,9 @@
             }
         },
         "mocha": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.0.1.tgz",
-            "integrity": "sha512-tQzCxWqxSD6Oyg5r7Ptbev0yAMD8p+Vfh4snPFuiUsWqYj0eVYTDT2DkEY307FTj0WRlIWN9rWMMAUzRmijgVQ==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.0.2.tgz",
+            "integrity": "sha512-RtTJsmmToGyeTznSOMoM6TPEk1A84FQaHIciKrRqARZx+B5ccJ5tXlmJzEKGBxZdqk9UjpRsesZTUkZmR5YnuQ==",
             "dev": true,
             "requires": {
                 "ansi-colors": "3.2.3",
@@ -4044,12 +3969,6 @@
                     "requires": {
                         "ms": "^2.1.1"
                     }
-                },
-                "growl": {
-                    "version": "1.10.5",
-                    "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-                    "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-                    "dev": true
                 },
                 "supports-color": {
                     "version": "6.0.0",
@@ -4170,13 +4089,10 @@
             }
         },
         "normalize-path": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-            "dev": true,
-            "requires": {
-                "remove-trailing-separator": "^1.0.1"
-            }
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true
         },
         "npm-run-path": {
             "version": "2.0.2",
@@ -5380,17 +5296,27 @@
             "dev": true
         },
         "streamroller": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
-            "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-1.0.3.tgz",
+            "integrity": "sha512-P7z9NwP51EltdZ81otaGAN3ob+/F88USJE546joNq7bqRNTe6jc74fTBDyynxP4qpIfKlt/CesEYicuMzI0yJg==",
             "dev": true,
             "requires": {
-                "date-format": "^1.2.0",
+                "async": "^2.6.1",
+                "date-format": "^2.0.0",
                 "debug": "^3.1.0",
-                "mkdirp": "^0.5.1",
-                "readable-stream": "^2.3.0"
+                "fs-extra": "^7.0.0",
+                "lodash": "^4.17.10"
             },
             "dependencies": {
+                "async": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+                    "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.11"
+                    }
+                },
                 "debug": {
                     "version": "3.2.6",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -5738,6 +5664,12 @@
                     }
                 }
             }
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true
         },
         "unpipe": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "eslint": "5.14.1",
         "expect.js": "0.3.1",
         "istanbul": "0.4.5",
-        "karma": "4.0.0",
+        "karma": "4.0.1",
         "karma-chrome-launcher": "2.2.0",
         "karma-coverage": "1.1.2",
         "karma-coverage-istanbul-reporter": "2.0.5",
@@ -61,7 +61,7 @@
         "karma-mocha": "1.3.0",
         "karma-mocha-reporter": "2.2.5",
         "karma-sinon": "1.0.5",
-        "mocha": "6.0.1",
+        "mocha": "6.0.2",
         "puppeteer": "1.12.2",
         "rimraf": "2.6.3",
         "sinon": "7.2.5"


### PR DESCRIPTION
This updates the following dependencies

* `karma` from `4.0.0` to `4.0.1`
* `mocha` from `6.0.1` to `6.0.2`

Additionally two security issues were fixed by running `npm audit fix`.

Closes #405 
Closes #407