### PR TITLE
Make ZoomIn and ZoomOut buttons more configurable

### DIFF
--- a/src/view/button/ZoomIn.js
+++ b/src/view/button/ZoomIn.js
@@ -60,7 +60,12 @@ Ext.define('BasiGX.view.button.ZoomIn', {
     glyph: 'xf00e@FontAwesome',
     html: '<i class="fa fa-search-plus fa-2x"></i>',
 
-    toggleGroup: 'navigation',
+    /**
+     * ZoomIn button is not toggleable per default and behaves like simple
+     * button. If #toggleGroup is set by instantiation the `click` handler will
+     * be ignored and `toggle` handler will be used instead.
+     */
+    toggleGroup: null,
 
     /**
      * A config object to show this tool in action (live demo) when using the
@@ -78,32 +83,43 @@ Ext.define('BasiGX.view.button.ZoomIn', {
     config: {
         /**
          * When set to true zoom in by clicking and dragging on the map is
-         * enabled. Default is true.
+         * enabled. Only applicable if instantiated as toggle button.
+         * Default is true.
          */
         enableZoomInWithBox: true,
         /**
          * Whether zoom action should be animated or not. Default is true.
          */
-        enableAnimation: true,
+        animate: true,
         /**
          * Reference to ol DragZoom interaction which will be used if
          * #enableZoomInWithBox is set to true.
          */
-        dragZoomInteraction: null,
+        dragZoomInInteraction: null,
         /**
          * Default zoom animation duration in milliseconds. Only applicable if
-         * #enableAnimation is set to true.
+         * #animate is set to true.
          */
         animationDuration: 500
     },
 
     listeners: {
-        toggle: function (btn, pressed) {
+        afterrender: function() {
             var me = this;
-            //fallback
             if (Ext.isEmpty(me.olMap)) {
                 me.olMap = BasiGX.util.Map.getMapComponent().getMap();
             }
+        },
+        click: function() {
+            var me = this;
+            // do nothing if configured as toggle button
+            if (!Ext.isEmpty(me.toggleGroup)) {
+                return;
+            }
+            me.zoomIn();
+        },
+        toggle: function (btn, pressed) {
+            var me = this;
             if (me.enableZoomInWithBox) {
                 if (!me.dragZoomInInteraction) {
                     me.dragZoomInInteraction = new ol.interaction.DragZoom({
@@ -137,7 +153,7 @@ Ext.define('BasiGX.view.button.ZoomIn', {
         var olView = me.olMap.getView();
 
         // This if is need for backwards comaptibility to ol
-        if (me.enableAnimation) {
+        if (me.animate) {
             if (ol.animation) {
                 zoom = ol.animation.zoom({
                     resolution: olView.getResolution(),

--- a/src/view/button/ZoomIn.js
+++ b/src/view/button/ZoomIn.js
@@ -35,8 +35,12 @@ Ext.define('BasiGX.view.button.ZoomIn', {
         data: {
             tooltip: 'Hineinzoomen',
             text: null,
-            documentation: '<h2>Hineinzoomen</h2>• Ein Klick auf den Button ' +
-                'vergrößert die Karte um eine Zoomstufe.'
+            documentation: '<h2>Hineinzoomen</h2>' +
+                '• Ein Klick auf den Button aktiviert ZoomIn-Modus:<br>' +
+                '• Ein Klick in die Karte vergrößert sie um eine Zoomstufe. ' +
+                '• Wird ein Rechteck über die Karte gezogen, zoomt die Karte ' +
+                'zum gewählten Ausschnitt (Button muss mit der Option ' +
+                '`enableZoomInWithBox=true` konfiguriert sein).'
         }
     },
 

--- a/src/view/button/ZoomIn.js
+++ b/src/view/button/ZoomIn.js
@@ -62,8 +62,9 @@ Ext.define('BasiGX.view.button.ZoomIn', {
 
     /**
      * ZoomIn button is not toggleable per default and behaves like simple
-     * button. If #toggleGroup is set by instantiation the `click` handler will
-     * be ignored and `toggle` handler will be used instead.
+     * button. If #toggleGroup or #enableToggle is set by instantiation the
+     * `click` handler will be ignored and `toggle` handler will be used
+     * instead.
      */
     toggleGroup: null,
 
@@ -113,12 +114,12 @@ Ext.define('BasiGX.view.button.ZoomIn', {
         click: function() {
             var me = this;
             // do nothing if configured as toggle button
-            if (!Ext.isEmpty(me.toggleGroup)) {
+            if (me.enableToggle) {
                 return;
             }
             me.zoomIn();
         },
-        toggle: function (btn, pressed) {
+        toggle: function(btn, pressed) {
             var me = this;
             if (me.enableZoomInWithBox) {
                 if (!me.dragZoomInInteraction) {

--- a/src/view/button/ZoomOut.js
+++ b/src/view/button/ZoomOut.js
@@ -57,7 +57,12 @@ Ext.define('BasiGX.view.button.ZoomOut', {
      */
     olMap: null,
 
-    toggleGroup: 'navigation',
+    /**
+     * ZoomOut button is not toggleable per default and behaves like simple
+     * button. If #toggleGroup is set by instantiation the `click` handler will
+     * be ignored and `toggle` handler will be used instead.
+     */
+    toggleGroup: null,
 
     /**
      * The icons the button should use.
@@ -82,31 +87,43 @@ Ext.define('BasiGX.view.button.ZoomOut', {
     config: {
         /**
          * When set to true zoom out by clicking and dragging on the map is
-         * enabled. Default is false.
+         * enabled. Only applicable if instantiated as toggle button.
+         * Default is false.
          */
         enableZoomOutWithBox: false,
         /**
          * Whether zoom action should be animated or not. Default is true.
          */
-        enableAnimation: true,
+        animate: true,
         /**
          * Reference to ol DragZoom interaction which will be used if
          * #enableZoomOutWithBox is set to true.
          */
         dragZoomOutInteraction: null,
         /**
-         * Default zoom animation duration in milliseconds.
+         * Default zoom animation duration in milliseconds. Only applicable if
+         * #animate is set to true.
          */
         animationDuration: 500
     },
 
     listeners: {
-        toggle: function (btn, pressed) {
+        afterrender: function () {
             var me = this;
-            //fallback
             if (Ext.isEmpty(me.olMap)) {
                 me.olMap = BasiGX.util.Map.getMapComponent().getMap();
             }
+        },
+        click: function () {
+            var me = this;
+            // do nothing if configured as toggle button
+            if (!Ext.isEmpty(me.toggleGroup)) {
+                return;
+            }
+            me.zoomOut();
+        },
+        toggle: function (btn, pressed) {
+            var me = this;
             if (me.enableZoomOutWithBox) {
                 if (!me.dragZoomOutInteraction) {
                     me.dragZoomOutInteraction = new ol.interaction.DragZoom({
@@ -141,7 +158,7 @@ Ext.define('BasiGX.view.button.ZoomOut', {
         var olView = me.olMap.getView();
 
         // This if is need for backwards compatibility to ol
-        if (me.enableAnimation) {
+        if (me.animate) {
             if (ol.animation) {
                 zoom = ol.animation.zoom({
                     resolution: olView.getResolution(),

--- a/src/view/button/ZoomOut.js
+++ b/src/view/button/ZoomOut.js
@@ -59,8 +59,9 @@ Ext.define('BasiGX.view.button.ZoomOut', {
 
     /**
      * ZoomOut button is not toggleable per default and behaves like simple
-     * button. If #toggleGroup is set by instantiation the `click` handler will
-     * be ignored and `toggle` handler will be used instead.
+     * button. If #toggleGroup or #enableToggle is set by instantiation the
+     * `click` handler will be ignored and `toggle` handler will be used
+     * instead.
      */
     toggleGroup: null,
 
@@ -108,21 +109,21 @@ Ext.define('BasiGX.view.button.ZoomOut', {
     },
 
     listeners: {
-        afterrender: function () {
+        afterrender: function() {
             var me = this;
             if (Ext.isEmpty(me.olMap)) {
                 me.olMap = BasiGX.util.Map.getMapComponent().getMap();
             }
         },
-        click: function () {
+        click: function() {
             var me = this;
             // do nothing if configured as toggle button
-            if (!Ext.isEmpty(me.toggleGroup)) {
+            if (me.enableToggle) {
                 return;
             }
             me.zoomOut();
         },
-        toggle: function (btn, pressed) {
+        toggle: function(btn, pressed) {
             var me = this;
             if (me.enableZoomOutWithBox) {
                 if (!me.dragZoomOutInteraction) {
@@ -152,7 +153,7 @@ Ext.define('BasiGX.view.button.ZoomOut', {
      * Callback function of `click` event on the map while zoomOut button is
      * toggled.
      */
-    zoomOut: function () {
+    zoomOut: function() {
         var me = this;
         var zoom;
         var olView = me.olMap.getView();

--- a/src/view/button/ZoomOut.js
+++ b/src/view/button/ZoomOut.js
@@ -35,8 +35,13 @@ Ext.define('BasiGX.view.button.ZoomOut', {
         data: {
             tooltip: 'Herauszoomen',
             text: null,
-            documentation: '<h2>Herauszoomen</h2>• Ein Klick auf den Button ' +
-                'verkleinert die Karte um eine Zoomstufe.'
+            documentation: '<h2>Herauszoomen</h2>' +
+                '• Ein Klick auf den Button aktiviert ZoomOut-Modus:<br>' +
+                '• Ein Klick in die Karte verkleinert sie um eine Zoomstufe. ' +
+                '• Wird ein Rechteck über die Karte gezogen, zoomt die Karte ' +
+                'zum gewählten Ausschnitt (Button muss mit der Option ' +
+                '`enableZoomOutWithBox=true` konfiguriert sein).'
+
         }
     },
 

--- a/test/spec/view/button/ZoomIn.test.js
+++ b/test/spec/view/button/ZoomIn.test.js
@@ -1,15 +1,71 @@
 Ext.Loader.syncRequire(['BasiGX.view.button.ZoomIn']);
 
 describe('BasiGX.view.button.ZoomIn', function() {
+
+    var btn;
+    var testObjs;
+    var map;
+
+    beforeEach(function() {
+        testObjs = TestUtil.setupTestObjects({
+            mapOpts: {
+                view: new ol.View({
+                    resolutions: [50, 100, 200, 400, 800],
+                    resolution: 100
+                })
+            }
+        });
+        map = testObjs.map;
+        btn = Ext.create('BasiGX.view.button.ZoomIn', {
+            olMap: map
+        });
+    });
+
+    afterEach(function() {
+        if (btn) {
+            btn.destroy();
+        }
+        TestUtil.teardownTestObjects(testObjs);
+    });
+
     describe('Basics', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.ZoomIn).to.not.be(undefined);
         });
         it('can be instantiated', function() {
-            var btn = Ext.create('BasiGX.view.button.ZoomIn');
             expect(btn).to.be.a(BasiGX.view.button.ZoomIn);
             // teardown
             btn.destroy();
+        });
+        it('has some default configs', function() {
+            expect(btn.enableZoomInWithBox).to.not.be(undefined);
+            expect(btn.enableAnimation).to.not.be(undefined);
+            expect(btn.dragZoomInteraction).to.not.be(undefined);
+            expect(btn.animationDuration).to.not.be(undefined);
+            expect(btn.enableZoomInWithBox).to.be(true);
+            expect(btn.enableAnimation).to.be(true);
+            expect(btn.dragZoomInteraction).to.be(null);
+            expect(typeof btn.animationDuration).to.be('number');
+        });
+    });
+
+    describe('Handler', function() {
+        it('adds ol DragZoom interaction on toggle', function() {
+            var intCount = btn.olMap.getInteractions().getArray().length;
+            btn.toggle();
+            expect(btn.olMap.getInteractions().getArray().length).to.be(intCount + 1);
+        });
+    });
+
+    describe('Static methods', function() {
+        describe('zoomIn', function() {
+            it('halves the ol view resolution on call', function() {
+                var view = btn.olMap.getView();
+                var oldRes = view.getResolution();
+                btn.enableAnimation = false;
+                btn.zoomIn();
+                expect(view.getResolution()).to.be(oldRes / 2);
+            });
         });
     });
 });

--- a/test/spec/view/button/ZoomIn.test.js
+++ b/test/spec/view/button/ZoomIn.test.js
@@ -17,7 +17,8 @@ describe('BasiGX.view.button.ZoomIn', function() {
         });
         map = testObjs.map;
         btn = Ext.create('BasiGX.view.button.ZoomIn', {
-            olMap: map
+            olMap: map,
+            toggleGroup: 'tg'
         });
     });
 
@@ -39,12 +40,12 @@ describe('BasiGX.view.button.ZoomIn', function() {
         });
         it('has some default configs', function() {
             expect(btn.enableZoomInWithBox).to.not.be(undefined);
-            expect(btn.enableAnimation).to.not.be(undefined);
-            expect(btn.dragZoomInteraction).to.not.be(undefined);
+            expect(btn.animate).to.not.be(undefined);
+            expect(btn.dragZoomInInteraction).to.not.be(undefined);
             expect(btn.animationDuration).to.not.be(undefined);
             expect(btn.enableZoomInWithBox).to.be(true);
-            expect(btn.enableAnimation).to.be(true);
-            expect(btn.dragZoomInteraction).to.be(null);
+            expect(btn.animate).to.be(true);
+            expect(btn.dragZoomInInteraction).to.be(null);
             expect(typeof btn.animationDuration).to.be('number');
         });
     });
@@ -55,6 +56,20 @@ describe('BasiGX.view.button.ZoomIn', function() {
             btn.toggle();
             expect(btn.olMap.getInteractions().getArray().length).to.be(intCount + 1);
         });
+        it('doesn\'t do anything on click if configured as toggle button', function() {
+            var got = btn.click();
+            expect(got).to.be(undefined);
+        });
+        it('calls zoomIn method on click if configured as simple button', function() {
+            var btn2 = Ext.create('BasiGX.view.button.ZoomIn', {
+                olMap: map
+            });
+            var spy = sinon.spy(btn2, 'zoomIn');
+            btn2.click();
+            expect(spy.called).to.be(true);
+            btn2.zoomIn.restore();
+            btn2.destroy();
+        });
     });
 
     describe('Static methods', function() {
@@ -62,7 +77,7 @@ describe('BasiGX.view.button.ZoomIn', function() {
             it('halves the ol view resolution on call', function() {
                 var view = btn.olMap.getView();
                 var oldRes = view.getResolution();
-                btn.enableAnimation = false;
+                btn.animate = false;
                 btn.zoomIn();
                 expect(view.getResolution()).to.be(oldRes / 2);
             });

--- a/test/spec/view/button/ZoomOut.test.js
+++ b/test/spec/view/button/ZoomOut.test.js
@@ -1,15 +1,75 @@
 Ext.Loader.syncRequire(['BasiGX.view.button.ZoomOut']);
 
 describe('BasiGX.view.button.ZoomOut', function() {
+
+    var btn;
+    var testObjs;
+    var map;
+
+    beforeEach(function() {
+        testObjs = TestUtil.setupTestObjects({
+            mapOpts: {
+                view: new ol.View({
+                    resolutions: [50, 100, 200, 400, 800],
+                    resolution: 100
+                })
+            }
+        });
+        map = testObjs.map;
+        btn = Ext.create('BasiGX.view.button.ZoomOut', {
+            olMap: map
+        });
+    });
+
+    afterEach(function() {
+        if (btn) {
+            btn.destroy();
+        }
+        TestUtil.teardownTestObjects(testObjs);
+    });
+
     describe('Basics', function() {
         it('is defined', function() {
             expect(BasiGX.view.button.ZoomOut).to.not.be(undefined);
         });
         it('can be instantiated', function() {
-            var btn = Ext.create('BasiGX.view.button.ZoomOut');
             expect(btn).to.be.a(BasiGX.view.button.ZoomOut);
             // teardown
             btn.destroy();
+        });
+        it('has some default configs', function() {
+            expect(btn.enableZoomOutWithBox).to.not.be(undefined);
+            expect(btn.enableAnimation).to.not.be(undefined);
+            expect(btn.dragZoomOutInteraction).to.not.be(undefined);
+            expect(btn.animationDuration).to.not.be(undefined);
+            expect(btn.enableZoomOutWithBox).to.be(false);
+            expect(btn.enableAnimation).to.be(true);
+            expect(btn.dragZoomOutInteraction).to.be(null);
+            expect(typeof btn.animationDuration).to.be('number');
+        });
+    });
+
+    describe('Handler', function() {
+        it('adds ol DragZoom interaction on toggle', function() {
+            var intCount = btn.olMap.getInteractions().getArray().length;
+            // zoom out with box is not enabled -> no interaction added
+            btn.toggle();
+            expect(btn.olMap.getInteractions().getArray().length).to.be(intCount);
+            btn.enableZoomOutWithBox = true;
+            btn.toggle();
+            expect(btn.olMap.getInteractions().getArray().length).to.be(intCount + 1);
+        });
+    });
+
+    describe('Static methods', function() {
+        describe('zoomOut', function() {
+            it('doubles the ol view resolution on call', function() {
+                var view = btn.olMap.getView();
+                var oldRes = view.getResolution();
+                btn.enableAnimation = false;
+                btn.zoomOut();
+                expect(view.getResolution()).to.be(oldRes * 2);
+            });
         });
     });
 });

--- a/test/spec/view/button/ZoomOut.test.js
+++ b/test/spec/view/button/ZoomOut.test.js
@@ -17,7 +17,8 @@ describe('BasiGX.view.button.ZoomOut', function() {
         });
         map = testObjs.map;
         btn = Ext.create('BasiGX.view.button.ZoomOut', {
-            olMap: map
+            olMap: map,
+            toggleGroup: 'tg'
         });
     });
 
@@ -39,11 +40,11 @@ describe('BasiGX.view.button.ZoomOut', function() {
         });
         it('has some default configs', function() {
             expect(btn.enableZoomOutWithBox).to.not.be(undefined);
-            expect(btn.enableAnimation).to.not.be(undefined);
+            expect(btn.animate).to.not.be(undefined);
             expect(btn.dragZoomOutInteraction).to.not.be(undefined);
             expect(btn.animationDuration).to.not.be(undefined);
             expect(btn.enableZoomOutWithBox).to.be(false);
-            expect(btn.enableAnimation).to.be(true);
+            expect(btn.animate).to.be(true);
             expect(btn.dragZoomOutInteraction).to.be(null);
             expect(typeof btn.animationDuration).to.be('number');
         });
@@ -59,6 +60,20 @@ describe('BasiGX.view.button.ZoomOut', function() {
             btn.toggle();
             expect(btn.olMap.getInteractions().getArray().length).to.be(intCount + 1);
         });
+        it('doesn\'t do anything on click if configured as toggle button', function () {
+            var got = btn.click();
+            expect(got).to.be(undefined);
+        });
+        it('calls zoomOut method on click if configured as simple button', function () {
+            var btn2 = Ext.create('BasiGX.view.button.ZoomOut', {
+                olMap: map
+            });
+            var spy = sinon.spy(btn2, 'zoomOut');
+            btn2.click();
+            expect(spy.called).to.be(true);
+            btn2.zoomOut.restore();
+            btn2.destroy();
+        });
     });
 
     describe('Static methods', function() {
@@ -66,7 +81,7 @@ describe('BasiGX.view.button.ZoomOut', function() {
             it('doubles the ol view resolution on call', function() {
                 var view = btn.olMap.getView();
                 var oldRes = view.getResolution();
-                btn.enableAnimation = false;
+                btn.animate = false;
                 btn.zoomOut();
                 expect(view.getResolution()).to.be(oldRes * 2);
             });


### PR DESCRIPTION
Added following options to make zoom buttons config more comfortable:
* `enableZoomInWithBox` / `enableZoomOutWithBox` -> Enables zoom with box without `shift` key
* `enableAnimation` -> Enables animation while zooming
* `dragZoomInteraction` / `dragZoomOutInteraction` -> Custom `ol.interaction.DragZoom` which will be used while zooming with box
* `animationDuration` -> Custom animation duration

Please review @weskamm 

