### PR TITLE
Add missed scope on map click listener

### DIFF
--- a/src/view/button/ZoomOut.js
+++ b/src/view/button/ZoomOut.js
@@ -141,7 +141,7 @@ Ext.define('BasiGX.view.button.ZoomOut', {
                     me.dragZoomOutInteraction.setActive(true);
                 }
             } else {
-                me.olMap.un('click', me.zoomOut);
+                me.olMap.un('click', me.zoomOut, me);
                 if (me.enableZoomOutWithBox) {
                     me.dragZoomOutInteraction.setActive(false);
                 }


### PR DESCRIPTION
This fixes the `zoomOut` button behavior to ensure that `click` listener on the map turns unregistered if button was untoggled.

Please review @terrestris/devs 