### PR TITLE
Get values for keys with unclear spelling in objects

### DIFF
--- a/src/util/Object.js
+++ b/src/util/Object.js
@@ -97,6 +97,24 @@ Ext.define('BasiGX.util.Object', {
         },
 
         /**
+         * A utility method to get the layers-key from an object which
+         * represents URL params. Will first try the keys `LAYERS`, then
+         * `layers` and finally all sorts of mixed casing spellings like
+         * `lAyERs`.
+         *
+         * @param {Object} params The object to look in.
+         * @return {*} The value for the layers key in the first matched casing
+         *     variant
+         */
+        layersFromParams: function(params) {
+            var commonVariants = ['LAYERS', 'layers'];
+            var variantRegEx = /^layers$/i;
+            return BasiGX.util.Object.getValueSpellingVariants(
+                params, commonVariants, variantRegEx
+            );
+        },
+
+        /**
          * Method may be used to return a value of a given input object by a
          * provided query key. The query key can be used in two ways:
          *   * Single-value: Find the first matching key in the provided object

--- a/src/util/Object.js
+++ b/src/util/Object.js
@@ -22,9 +22,79 @@
  */
 Ext.define('BasiGX.util.Object', {
 
-    requires: ['BasiGX.util.Application'],
+    requires: [
+        'Ext.Object',
+        'BasiGX.util.Application'
+    ],
 
     statics: {
+        /**
+         * Returns the value of a key in the passed object, when we do not know
+         * exactly how the key was spelled (e.g. with regard to casing). This
+         * can be useful, if the object contains key-value-pairs which
+         * represent URL-parameters. With this method you can e.g. find LAYERS,
+         * layers and any other casing (by providing a regular expression) in an
+         * object that represents common WMS query paramers like the ones from
+         * `wmsSource.getParams()`.
+         *
+         * Example:
+         *
+         *     var params = wmsSource.getParams();
+         *     var layers = BasiGX.util.Object.getValueSpellingVariants(
+         *         params, ['LAYERS', 'layers'], /^layers$/i
+         *     );
+         *     // layers now contains the value of e.g. params.LAYERS,
+         *     // params.layers or params.LaYeRs
+         *
+         * @param {Object} obj The object in which the key whose spelling is
+         *     unclear will be looked up. Required.
+         * @param {String[]} commonVariants An array of strings with common
+         *     variants of the key, these will be looked up first and in order.
+         *     At least `commonVariants` or `variantRe` must be passed. You can
+         *     pass both. If one of the keys herein is existing in `obj`, we'll
+         *     return the value at that key and will not make use of the regular
+         *     expression in `variantRe`.
+         * @param {RegExp} variantRe A regular expression matching the key of
+         *     which we do not know the spelling. At least `variantRe` or
+         *     `commonVariants` must be passed. You can pass both. If a common
+         *     variant exists in `obj`, this will not be considered. Otherwise
+         *     the *first* key in `obj` that matches the regular expression will
+         *     be used.
+         * @return {*} The value stored in `obj` at the first variant of the key
+         *     that matched.
+         */
+        getValueSpellingVariants: function(obj, commonVariants, variantRe) {
+            var foundValue = undefined;
+            if (!obj) {
+                return foundValue; // nothing to search in passed
+            }
+            var hasCommonVariants = Ext.isArray(commonVariants);
+            var hasVariantRegex = variantRe && variantRe instanceof RegExp;
+            if(!hasVariantRegex && !hasCommonVariants) {
+                return foundValue; // Neither RegExp nor common variants passed
+            }
+            if (!hasCommonVariants) {
+                commonVariants = [];
+            }
+            Ext.each(commonVariants, function(commonVariant) {
+                if (commonVariant in obj) {
+                    foundValue = obj[commonVariant];
+                    return false; // exit `Ext.each` early
+                }
+            });
+            if(!Ext.isDefined(foundValue) && hasVariantRegex) {
+                // since we did not find a common variant check all keys against
+                // the regular expression
+                var keys = Ext.Object.getKeys(obj);
+                Ext.each(keys, function(key) {
+                    if (key && variantRe.test(key)) {
+                        foundValue = obj[key];
+                        return false; // exit `Ext.each` early
+                    }
+                });
+            }
+            return foundValue;
+        },
 
         /**
          * Method may be used to return a value of a given input object by a

--- a/test/spec/util/Object.test.js
+++ b/test/spec/util/Object.test.js
@@ -6,35 +6,103 @@ describe('BasiGX.util.Object', function() {
             expect(BasiGX.util.Object).to.not.be(undefined);
         });
     });
-    describe('Usage of static Methods', function() {
-        var testObject;
-        beforeEach(function() {
-            testObject = {
-                firstLevel: true,
-                level: 'first',
-                firstNested: {
-                    secondLevel: true,
-                    level: 'second'
-                }
-            };
+    describe('Static methods', function() {
+        describe('#getValueSpellingVariants', function() {
+            var cls = BasiGX.util.Object;
+
+            it('returns `undefined` when no object passed', function() {
+                expect(cls.getValueSpellingVariants()).to.be(undefined);
+            });
+
+            it('returns `undefined` when neither commonVariants nor regex passed', function() {
+                expect(cls.getValueSpellingVariants({foo: 1})).to.be(undefined);
+            });
+
+            it('returns `undefined` when commonVariants wrongly passed', function() {
+                expect(cls.getValueSpellingVariants({foo: 1}, 'foo')).to.be(undefined);
+            });
+
+            it('returns `undefined` when regex wrongly passed', function() {
+                expect(cls.getValueSpellingVariants({foo: 1}, [], 'foo')).to.be(undefined);
+            });
+
+            it('returns `undefined` when empty common variants', function() {
+                var obj = {FOO: 123, LAYERS: 1};
+                var got = cls.getValueSpellingVariants(
+                    obj, []
+                );
+                expect(got).to.be(undefined);
+            });
+
+            it('accepts a common variant', function() {
+                var obj = {FOO: 123, LAYERS: 1};
+                var got = cls.getValueSpellingVariants(obj, ['LAYERS']);
+                expect(got).to.be(1);
+            });
+
+            it('accepts many common variants', function() {
+                var obj = {FOO: 123, LAYERS: 1};
+                var got = cls.getValueSpellingVariants(
+                    obj, ['layers', 'LAYERS']
+                );
+                expect(got).to.be(1);
+            });
+
+            it('accepts a regular expression', function() {
+                var obj = {FOO: 123, LAYERS: 1};
+                var got = cls.getValueSpellingVariants(
+                    obj, null, /layers/i
+                );
+                expect(got).to.be(1);
+            });
+
+            it('first checks common variants', function() {
+                var obj = {FOO: 123, layers: 'nope' , LAYERS: 'aye'};
+                var got = cls.getValueSpellingVariants(
+                    obj, ['LAYERS'], /layers/i
+                );
+                expect(got).to.be('aye');
+            });
+
+            it('then checks via regular expression', function() {
+                var obj = {FOO: 123, layers: 'nope' , LAYERS: 'aye'};
+                var got = cls.getValueSpellingVariants(
+                    obj, ['LaYeRs'], /LAYERS/
+                );
+                expect(got).to.be('aye');
+            });
         });
+        describe('#getValue', function() {
+            var testObject;
+            beforeEach(function() {
+                testObject = {
+                    firstLevel: true,
+                    level: 'first',
+                    firstNested: {
+                        secondLevel: true,
+                        level: 'second'
+                    }
+                };
+            });
 
-        it('does throw on empty getValue call', function() {
-            expect(BasiGX.util.Object.getValue).
-                to.throwError();
-        });
-        it('returns as expected on getValue call', function() {
+            it('does throw on empty getValue call', function() {
+                expect(BasiGX.util.Object.getValue).to.throwError();
+            });
+            it('returns as expected on getValue call', function() {
 
-            var retVal1 = BasiGX.util.Object.getValue('level', testObject);
-            expect(retVal1).to.be('first');
+                var retVal1 = BasiGX.util.Object.getValue('level', testObject);
+                expect(retVal1).to.be('first');
 
-            var retVal2 = BasiGX.util.Object.getValue('firstNested/level',
-                testObject);
-            expect(retVal2).to.be('second');
+                var retVal2 = BasiGX.util.Object.getValue(
+                    'firstNested/level', testObject
+                );
+                expect(retVal2).to.be('second');
 
-            var retVal3 = BasiGX.util.Object.getValue('secondLevel',
-                testObject);
-            expect(retVal3).to.be(true);
-        });
-    });
+                var retVal3 = BasiGX.util.Object.getValue(
+                    'secondLevel', testObject
+                );
+                expect(retVal3).to.be(true);
+            });
+        }); // end of '#getValue'
+    }); // end of 'Static methods'
 });

--- a/test/spec/util/Object.test.js
+++ b/test/spec/util/Object.test.js
@@ -71,7 +71,27 @@ describe('BasiGX.util.Object', function() {
                 );
                 expect(got).to.be('aye');
             });
-        });
+        }); // end of '#getValueSpellingVariants'
+
+        describe('#layersFromParams', function() {
+            var cls = BasiGX.util.Object;
+            it('can be used to get layers in uppercase (LAYERS)', function() {
+                var params = {foo: 'bar', LAYERS: 'yay!'};
+                var got = cls.layersFromParams(params);
+                expect(got).to.be('yay!');
+            });
+            it('can be used to get layers in lowercase (layers)', function() {
+                var params = {foo: 'bar', layers: 'yay!'};
+                var got = cls.layersFromParams(params);
+                expect(got).to.be('yay!');
+            });
+            it('can be used to get layers in any casing (e.g. LaYeRs)', function() {
+                var params = {foo: 'bar', LaYeRs: 'yay!'};
+                var got = cls.layersFromParams(params);
+                expect(got).to.be('yay!');
+            });
+        }); // end of '#layersFromParams'
+
         describe('#getValue', function() {
             var testObject;
             beforeEach(function() {


### PR DESCRIPTION
It sometimes is desirable to get values from objects where the actual spelling of the key is unclear, e.g. when we write stuff like…

```js
var params = wmsSource.getParams();
var layer = params.LAYERS // will miss params.layers and any other spelling
```

Since the above reflects user-passed values and they are accepted and vald in basically any casing, but at the same time several spelling are more common than others, this PR adds a new method to do just this.

```js
var params = wmsSource.getParams();
var layers = BasiGX.util.Object.getValueSpellingVariants(
    params, ['LAYERS', 'layers'], /^layers$/i
);
// layers now contains the value of e.g. params.LAYERS,
// params.layers or params.LaYeRs, whatever we find first
```

Since getting the layers param is quite often requested, this also adds anothe rconvenience method `layersFromParams`, that calls into `getValueSpellingVariants` with the above configuration.

Please review.

See also https://github.com/terrestris/BasiGX/pull/438#discussion_r280983349