### PR TITLE
Use configured animation duration and fix several other minors in zoom buttons

### DIFF
--- a/src/view/button/ZoomIn.js
+++ b/src/view/button/ZoomIn.js
@@ -154,7 +154,7 @@ Ext.define('BasiGX.view.button.ZoomIn', {
         var zoom;
         var olView = me.olMap.getView();
 
-        // This if is need for backwards comaptibility to ol
+        // This if is need for backwards compatibility to ol
         if (me.animate) {
             if (ol.animation) {
                 zoom = ol.animation.zoom({

--- a/src/view/button/ZoomIn.js
+++ b/src/view/button/ZoomIn.js
@@ -94,13 +94,13 @@ Ext.define('BasiGX.view.button.ZoomIn', {
          */
         animate: true,
         /**
-         * Reference to ol DragZoom interaction which will be used if
-         * #enableZoomInWithBox is set to true.
+         * Reference to the OpenLayers DragZoom interaction which will be used
+         * if the configuration #enableZoomInWithBox is set to true.
          */
         dragZoomInInteraction: null,
         /**
          * Default zoom animation duration in milliseconds. Only applicable if
-         * #animate is set to true.
+         * the configuration #animate is set to true.
          */
         animationDuration: 500
     },

--- a/src/view/button/ZoomIn.js
+++ b/src/view/button/ZoomIn.js
@@ -37,7 +37,8 @@ Ext.define('BasiGX.view.button.ZoomIn', {
             text: null,
             documentation: '<h2>Hineinzoomen</h2>' +
                 '• Ein Klick auf den Button aktiviert ZoomIn-Modus:<br>' +
-                '• Ein Klick in die Karte vergrößert sie um eine Zoomstufe. ' +
+                '• Ein Klick in die Karte vergrößert sie um eine Zoomstufe.' +
+                '<br>' +
                 '• Wird ein Rechteck über die Karte gezogen, zoomt die Karte ' +
                 'zum gewählten Ausschnitt (Button muss mit der Option ' +
                 '`enableZoomInWithBox=true` konfiguriert sein).'

--- a/src/view/button/ZoomOut.js
+++ b/src/view/button/ZoomOut.js
@@ -164,14 +164,14 @@ Ext.define('BasiGX.view.button.ZoomOut', {
             if (ol.animation) {
                 zoom = ol.animation.zoom({
                     resolution: olView.getResolution(),
-                    duration: 500
+                    duration: me.animationDuration
                 });
                 me.olMap.beforeRender(zoom);
                 olView.setResolution(olView.getResolution() * 2);
             } else {
                 olView.animate({
                     resolution: olView.getResolution() * 2,
-                    duration: 500
+                    duration: me.animationDuration
                 });
             }
         } else {

--- a/src/view/button/ZoomOut.js
+++ b/src/view/button/ZoomOut.js
@@ -98,13 +98,13 @@ Ext.define('BasiGX.view.button.ZoomOut', {
          */
         animate: true,
         /**
-         * Reference to ol DragZoom interaction which will be used if
-         * #enableZoomOutWithBox is set to true.
+         * Reference to the OpenLayers DragZoom interaction which will be used
+         * if the configuration #enableZoomOutWithBox is set to true.
          */
         dragZoomOutInteraction: null,
         /**
          * Default zoom animation duration in milliseconds. Only applicable if
-         * #animate is set to true.
+         * the configuration #animate is set to true.
          */
         animationDuration: 500
     },

--- a/src/view/button/ZoomOut.js
+++ b/src/view/button/ZoomOut.js
@@ -37,7 +37,8 @@ Ext.define('BasiGX.view.button.ZoomOut', {
             text: null,
             documentation: '<h2>Herauszoomen</h2>' +
                 '• Ein Klick auf den Button aktiviert ZoomOut-Modus:<br>' +
-                '• Ein Klick in die Karte verkleinert sie um eine Zoomstufe. ' +
+                '• Ein Klick in die Karte verkleinert sie um eine Zoomstufe.' +
+                '<br>' +
                 '• Wird ein Rechteck über die Karte gezogen, zoomt die Karte ' +
                 'zum gewählten Ausschnitt (Button muss mit der Option ' +
                 '`enableZoomOutWithBox=true` konfiguriert sein).'


### PR DESCRIPTION
This fixes a bunch of smaller issues and one bug in the `ZoomIn` and `ZoomOut` buttons:

* The `documentation` entries got some additional markup so that at least they look like a list even though they aren't one
* In the API docs for some configs some sentences were reworded, so that new lines in `/** */` would not start with `#`; that leads to rendering issues once the documentation is rendered with JSDuck (the picture below shows the current rendering before the changes in this PR)
![a](https://user-images.githubusercontent.com/227934/57184467-51fdb800-6ebc-11e9-8e9c-1f7fdccf0762.png)
* One typo in inline docs is removed
* bugfix: A hardcoded animation duration of 500 ms is removed and instead the already existing user configurable value is used.

Please review.

 