### PR TITLE
Use layersFromParams utility method

### DIFF
--- a/src/util/Layer.js
+++ b/src/util/Layer.js
@@ -21,7 +21,8 @@
  */
 Ext.define('BasiGX.util.Layer', {
     requires: [
-        'BasiGX.util.Map'
+        'BasiGX.util.Map',
+        'BasiGX.util.Object'
     ],
     statics: {
         /**
@@ -92,6 +93,7 @@ Ext.define('BasiGX.util.Layer', {
             if (!map) {
                 map = BasiGX.util.Map.getMapComponent().getMap();
             }
+            var ObjectUtil = BasiGX.util.Object;
             var mapLayers = map.getLayers();
             var olLayer;
             var foundIt = false;
@@ -101,10 +103,14 @@ Ext.define('BasiGX.util.Layer', {
                     return;
                 }
                 if (layer instanceof ol.layer.Layer &&
-                    layer.getSource() instanceof ol.source.TileWMS &&
-                    layer.getSource().getParams().LAYERS === layersParam) {
-                    olLayer = layer;
-                    foundIt = true;
+                    (layer.getSource() instanceof ol.source.TileWMS
+                    || layer.getSource() instanceof ol.source.ImageWMS)) {
+
+                    var params = layer.getSource().getParams();
+                    if(ObjectUtil.layersFromParams(params) === layersParam) {
+                        olLayer = layer;
+                        foundIt = true;
+                    }
                 } else if (layer instanceof ol.layer.Group) {
                     var groupLayers = layer.getLayers();
 

--- a/src/util/Layer.js
+++ b/src/util/Layer.js
@@ -107,7 +107,7 @@ Ext.define('BasiGX.util.Layer', {
                     || layer.getSource() instanceof ol.source.ImageWMS)) {
 
                     var params = layer.getSource().getParams();
-                    if(ObjectUtil.layersFromParams(params) === layersParam) {
+                    if (ObjectUtil.layersFromParams(params) === layersParam) {
                         olLayer = layer;
                         foundIt = true;
                     }

--- a/src/util/Object.js
+++ b/src/util/Object.js
@@ -23,8 +23,7 @@
 Ext.define('BasiGX.util.Object', {
 
     requires: [
-        'Ext.Object',
-        'BasiGX.util.Application'
+        'Ext.Object'
     ],
 
     statics: {
@@ -126,7 +125,9 @@ Ext.define('BasiGX.util.Object', {
          * @param {String} queryKey The key to be searched.
          * @param {Object} [queryObject] The object to be searched on. If not
          *     provided the global application context (on root-level) will
-         *     be used.
+         *     be used. You should alway pass queryObject if possible, the
+         *     guessing of the queryObject is *deprecated*, future versions
+         *     might remove this behaviour.
          *
          * @return {*} The target value or `undefined` if the given couldn't be
          *     found.
@@ -134,14 +135,25 @@ Ext.define('BasiGX.util.Object', {
         getValue: function(queryKey, queryObject) {
             var queryMatch;
 
-            // if weren't called with an queryObject, get the global application
-            // context as input value
+            // *deprecated* If we weren't called with an queryObject, get the
+            // global application context as input value, *deprecated*.
             if (!queryObject) {
-                queryObject = BasiGX.util.Application.getAppContext() ||
-                    Ext && Ext.app && Ext.app.Application &&
-                    Ext.app.Application.instance &&
-                    Ext.app.Application.instance.getApplicationContext ?
-                    Ext.app.Application.instance.getApplicationContext() : null;
+                Ext.Logger.warn('Not passing a query object to `getValue` of ' +
+                    '`BasiGX.util.Object` is deprecated.');
+                if ('Application' in BasiGX.util) {
+                    // …we cannot require BasiGX.util.Application since this
+                    // would introduce a circular dependency. We should also
+                    // probably not guess in a library utility method, but
+                    // determine it in application code
+                    queryObject = BasiGX.util.Application.getAppContext();
+                } else {
+                    var appInstance = BasiGX.util.Object.getValue(
+                        'app/Application/instance', Ext
+                    );
+                    if (appInstance) {
+                        queryObject = appInstance.getApplicationContext();
+                    }
+                }
             }
 
             if (!Ext.isObject(queryObject)) {

--- a/src/util/WFS.js
+++ b/src/util/WFS.js
@@ -22,10 +22,11 @@ Ext.define('BasiGX.util.WFS', {
 
     requires: [
         'BasiGX.util.CSRF',
-        'BasiGX.util.Url',
         'BasiGX.util.Filter',
         'BasiGX.util.Jsonix',
-        'BasiGX.util.Namespace'
+        'BasiGX.util.Namespace',
+        'BasiGX.util.Object',
+        'BasiGX.util.Url'
     ],
 
     inheritableStatics: {
@@ -486,7 +487,8 @@ Ext.define('BasiGX.util.WFS', {
                 viewParams = '';
             }
 
-            var featureType = layer.getSource().getParams().LAYERS;
+            var params = layer.getSource().getParams();
+            var featureType = BasiGX.util.Object.layersFromParams(params);
             var ns = featureType.split(':')[0];
             var namespaceUtil = BasiGX.util.Namespace;
             var nsUri = namespaceUtil.namespaceUriFromNamespace(ns);

--- a/test/spec/util/Layer.test.js
+++ b/test/spec/util/Layer.test.js
@@ -236,6 +236,125 @@ describe('BasiGX.util.Layer', function() {
         // TODO add meaningful tests
     });
 
+    describe('#getLayerByLayersParam', function() {
+        it('is a defined function', function() {
+            expect(BasiGX.util.Layer.getLayerByLayersParam).to.be.a(Function);
+        });
+
+        var makeTileLayer = function(params) {
+            return new ol.layer.Tile({
+                source: new ol.source.TileWMS({
+                    url: '',
+                    params: params
+                })
+            });
+        };
+        var makeImageLayer = function(params) {
+            return new ol.layer.Image({
+                source: new ol.source.ImageWMS({
+                    url: '',
+                    params: params
+                })
+            });
+        };
+        var tileLayer1 = makeTileLayer({LAYERS: 'abc:def-1'});
+        var tileLayer2 = makeTileLayer({layers: 'abc:def-2'});
+        var tileLayer3 = makeTileLayer({LaYErS: 'abc:def-3'}); // casing crazy
+        var tileLayer4 = makeTileLayer({LAYERS: 'abc:def-4'});
+        var tileLayer5 = makeTileLayer({layers: 'abc:def-5'});
+        var tileLayer6 = makeTileLayer({layERS: 'abc:def-6'}); // casing crazy
+
+        var imageLayer1 = makeImageLayer({LAYERS: 'uvw:xyz-1'});
+        var imageLayer2 = makeImageLayer({layers: 'uvw:xyz-2'});
+        var imageLayer3 = makeImageLayer({LayeRS: 'uvw:xyz-3'}); // casing crazy
+        var imageLayer4 = makeImageLayer({LAYERS: 'uvw:xyz-4'});
+        var imageLayer5 = makeImageLayer({layers: 'uvw:xyz-5'});
+        var imageLayer6 = makeImageLayer({lAyErs: 'uvw:xyz-6'}); // casing crazy
+
+        var deepgroup = new ol.layer.Group({
+            layers: [
+                new ol.layer.Group({
+                    layers: [
+                        tileLayer4, tileLayer5, tileLayer6,
+                        imageLayer4, imageLayer5, imageLayer6
+                    ]
+                })
+            ]
+        });
+        var m = new ol.Map({
+            layers: [
+                tileLayer1, tileLayer2, tileLayer3,
+                imageLayer1, imageLayer2, imageLayer3,
+                deepgroup
+            ]
+        });
+
+        it('returns undefined if not found', function() {
+            var got = BasiGX.util.Layer.getLayerByLayersParam('piep:matz', m);
+            expect(got).to.be(undefined);
+        });
+
+        it('finds a tilelayer (param casing: LAYERS)', function() {
+            var got = BasiGX.util.Layer.getLayerByLayersParam('abc:def-1', m);
+            expect(got).to.be(tileLayer1);
+        });
+
+        it('finds a tilelayer (param casing: layers)', function() {
+            var got = BasiGX.util.Layer.getLayerByLayersParam('abc:def-2', m);
+            expect(got).to.be(tileLayer2);
+        });
+
+        it('finds a tilelayer (param casing: crazy)', function() {
+            var got = BasiGX.util.Layer.getLayerByLayersParam('abc:def-3', m);
+            expect(got).to.be(tileLayer3);
+        });
+
+        it('finds an imagelayer (param casing: LAYERS)', function() {
+            var got = BasiGX.util.Layer.getLayerByLayersParam('uvw:xyz-1', m);
+            expect(got).to.be(imageLayer1);
+        });
+
+        it('finds an imagelayer (param casing: layers)', function() {
+            var got = BasiGX.util.Layer.getLayerByLayersParam('uvw:xyz-2', m);
+            expect(got).to.be(imageLayer2);
+        });
+
+        it('finds an imagelayer (param casing: crazy)', function() {
+            var got = BasiGX.util.Layer.getLayerByLayersParam('uvw:xyz-3', m);
+            expect(got).to.be(imageLayer3);
+        });
+
+        it('finds a tilelayer (param casing: LAYERS) in a group', function() {
+            var got = BasiGX.util.Layer.getLayerByLayersParam('abc:def-4', m);
+            expect(got).to.be(tileLayer4);
+        });
+
+        it('finds a tilelayer (param casing: layers) in a group', function() {
+            var got = BasiGX.util.Layer.getLayerByLayersParam('abc:def-5', m);
+            expect(got).to.be(tileLayer5);
+        });
+
+        it('finds a tilelayer (param casing: crazy) in a group', function() {
+            var got = BasiGX.util.Layer.getLayerByLayersParam('abc:def-6', m);
+            expect(got).to.be(tileLayer6);
+        });
+
+        it('finds an imagelayer (param casing: LAYERS) in a group', function() {
+            var got = BasiGX.util.Layer.getLayerByLayersParam('uvw:xyz-4', m);
+            expect(got).to.be(imageLayer4);
+        });
+
+        it('finds an imagelayer (param casing: layers) in a group', function() {
+            var got = BasiGX.util.Layer.getLayerByLayersParam('uvw:xyz-5', m);
+            expect(got).to.be(imageLayer5);
+        });
+
+        it('finds an imagelayer (param casing: crazy) in a group', function() {
+            var got = BasiGX.util.Layer.getLayerByLayersParam('uvw:xyz-6', m);
+            expect(got).to.be(imageLayer6);
+        });
+    });
+
     after(function() {
         TestUtil.teardownTestObjects(testObjs);
     });


### PR DESCRIPTION
This PR suggests to use `BasiGX.util.Object.layersFromParams` from #439 in two classes:

* `BasiGX.util.WFS` (where this was [first noticed](https://github.com/terrestris/BasiGX/pull/438#discussion_r280983349))
* `BasiGX.util.Layer`

The method `BasiGX.util.Layer.getLayerByLayersParam`was also changed to find not only layers with a source `ol.source.TileWMS`, but als those with a source of `ol.source.ImageWMS`. As that partical method also didn't have any tests, I added some as well.

Please review.

