### PR TITLE
More flexible regular expression to work w/ filters

### DIFF
--- a/src/util/WFS.js
+++ b/src/util/WFS.js
@@ -40,12 +40,14 @@ Ext.define('BasiGX.util.WFS', {
          *
          * * Index `0`: Complete match.
          * * Index `1`: `<ogc:Filter>` start tag including attributes, if any.
+         *   Will also match non-prefixed variant `<Filter>`
          * * Index `2`: Anything between `<ogc:Filter>` start and end tag.
-         * * Index `3`: `</ogc:Filter>` end tag.
+         * * Index `3`: `</ogc:Filter>` end tag.  Will also match
+         *   non-prefixed variant `</Filter>`
          *
          * Hat-tip: http://www.regular-expressions.info/examples.html
          */
-        reMatchFilter: /(<ogc:Filter\b[^>]*>)(.*?)(<\/ogc:Filter>)/,
+        reMatchFilter: /(<(?:ogc:)?Filter\b[^>]*>)(.*?)(<\/(?:ogc:)?Filter>)/,
 
         /**
          * The WFS GetFeature XML body template
@@ -337,10 +339,11 @@ Ext.define('BasiGX.util.WFS', {
         },
 
         /**
-         * Returns the contents of filter with the outermost `<ogc:Filter>`
-         * removed.
+         * Returns the contents of filter with the outermost `<ogc:Filter>` or
+         * `<Filter>` removed.
          *
-         * @param {String} filter The filter to remove `<ogc:Filter>` from.
+         * @param {String} filter The filter to remove `<ogc:Filter>` /
+         *     `<Filter>` from.
          * @return {String} The contents of the filter.
          */
         unwrapFilter: function(filter) {
@@ -353,12 +356,13 @@ Ext.define('BasiGX.util.WFS', {
         },
 
         /**
-         * Returns the actually used `<ogc:Filter>` start tag from the passed
-         * OGC filter.
+         * Returns the actually used `<ogc:Filter>` / `<Filter>` start tag
+         * from the passed OGC filter.
          *
-         * @param {String} filter The filter to get the `<ogc:Filter>` from.
-         * @return {String} The `<ogc:Filter>` of the filter or the empty
-         *     string.
+         * @param {String} filter The filter to get the `<ogc:Filter>` /
+         *     `<Filter>` from.
+         * @return {String} The `<ogc:Filter>` / `<Filter>` of the filter or
+         *     the empty string.
          */
         getFilterPrefix: function(filter) {
             var regex = BasiGX.util.WFS.reMatchFilter;

--- a/test/spec/util/WFS.test.js
+++ b/test/spec/util/WFS.test.js
@@ -473,6 +473,63 @@ describe('BasiGX.util.WFS', function() {
             });
         });
 
+        // unwrapFilter
+        describe('#unwrapFilter', function() {
+            var unwrapFilter = BasiGX.util.WFS.unwrapFilter;
+            it('can unwrap non-namespaced filters', function() {
+                var filter = '<Filter><Inside>Humpty</Inside></Filter>';
+                var got = unwrapFilter(filter);
+                var expected = '<Inside>Humpty</Inside>';
+                expect(got).to.be(expected);
+            });
+            it('can unwrap namespaced filters', function() {
+                var filter = '<ogc:Filter><Inside>Humpty</Inside></ogc:Filter>';
+                var got = unwrapFilter(filter);
+                var expected = '<Inside>Humpty</Inside>';
+                expect(got).to.be(expected);
+            });
+            it('returns the input if not passed a filter', function() {
+                var filter = '<Something>Dumpty</Something>';
+                var got = unwrapFilter(filter);
+                expect(got).to.be(filter);
+            });
+        }); // end of unwrapFilter
+
+        // getFilterPrefix
+        describe('#getFilterPrefix', function() {
+            var getFilterPrefix = BasiGX.util.WFS.getFilterPrefix;
+            it('can get the prefix if non-namespaced filter', function() {
+                var filter = '<Filter><Inside>Humpty</Inside></Filter>';
+                var got = getFilterPrefix(filter);
+                var expected = '<Filter>';
+                expect(got).to.be(expected);
+            });
+            it('can get the prefix if namespaced filter', function() {
+                var filter = '<ogc:Filter><Inside>Humpty</Inside></ogc:Filter>';
+                var got = getFilterPrefix(filter);
+                var expected = '<ogc:Filter>';
+                expect(got).to.be(expected);
+            });
+            it('ensures the prefix keeps any attributes (non-namespaced)', function() {
+                var filter = '<Filter if="you" have="ghosts"><YouHaveEvrThng/></Filter>';
+                var got = getFilterPrefix(filter);
+                var expected = '<Filter if="you" have="ghosts">';
+                expect(got).to.be(expected);
+            });
+            it('ensures the prefix keeps any attributes (namespaced)', function() {
+                var filter = '<ogc:Filter if="you" have="ghosts"><YouHaveEvrThng/></ogc:Filter>';
+                var got = getFilterPrefix(filter);
+                var expected = '<ogc:Filter if="you" have="ghosts">';
+                expect(got).to.be(expected);
+            });
+            it('returns an empty string if not passed a filter', function() {
+                var filter = '<Something>Dumpty</Something>';
+                var got = getFilterPrefix(filter);
+                var expected = '';
+                expect(got).to.be(expected);
+            });
+        }); // end of getFilterPrefix
+
     });
 
 });


### PR DESCRIPTION
This changes the WFS util so it can be used to work with filters
that either have or don't have the `ogc:` namespace prefix.

The methods `unwrapFilter` and `getFilterPrefix` both will be
positively affected by this change.

Please review.