### PR TITLE
Fixes calculation for hover overlay positioning

### DIFF
--- a/src/plugin/Hover.js
+++ b/src/plugin/Hover.js
@@ -506,7 +506,7 @@ Ext.define('BasiGX.plugin.Hover', {
      */
     getPositioningConfig: function(pixel, div, mapComponent) {
         // measure the passed div first:
-        div.style.display = 'inline'; // so we can measure it!
+        div.style.display = 'table-cell'; // so we can measure it!
         var divEl = Ext.get(Ext.getBody().dom.appendChild(div));
         var divDims = [divEl.getWidth(), divEl.getHeight()];
         if (this.maxHeight) {


### PR DESCRIPTION
The positioning calculation for the `ol.overlay` of the hover plugin was wrong when the innerHtml contained divs.
`'table-cell'` is used as display-mode for the wrapping div to ignore child divs, which may transform the wrapper.