### PR TITLE
Only show the OK button for warn message boxes

### DIFF
--- a/src/util/MsgBox.js
+++ b/src/util/MsgBox.js
@@ -128,7 +128,7 @@ Ext.define('BasiGX.util.MsgBox', {
             var staticMe = BasiGX.util.MsgBox;
             var defaultConf = {
                 title: staticMe.msgBoxTitleWarn,
-                buttons: Ext.MessageBox.OKCANCEL,
+                buttons: Ext.MessageBox.OK,
                 icon: Ext.Msg.WARNING
             };
             staticMe.show(msg, defaultConf, userConf);


### PR DESCRIPTION
This sets the default for the buttons to show to `Ext.MessageBox.OK` as it's normally not needed to distinguish between `OK` and `Cancel` for warn messages.

Please review @terrestris/devs.