### PR TITLE
Add a CSW form to retrieve WMS layers through CSW

### DIFF
--- a/src/view/button/CSW.js
+++ b/src/view/button/CSW.js
@@ -1,0 +1,111 @@
+/* Copyright (c) 2015-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * CSW Button
+ *
+ * Button used to instanciate the basigx-form-csw in order to add a
+ * service to the map
+ *
+ * @class BasiGX.view.button.CSW
+ */
+Ext.define('BasiGX.view.button.CSW', {
+    extend: 'BasiGX.view.button.Base',
+    xtype: 'basigx-button-csw',
+
+    requires: [
+        'Ext.window.Window',
+        'Ext.app.ViewModel',
+        'BasiGX.view.form.CSW',
+        'BasiGX.util.Animate'
+    ],
+
+    /**
+     *
+     */
+    viewModel: {
+        data: {
+            tooltip: 'CSW abfragen',
+            text: 'CSW <span style="font-size: 1.7em; ' +
+                'font-weight: normal;">⊕</span>',
+            windowTitle: 'CSW abfragen',
+            documentation: '<h2>CSW abfragen</h2>• Ein Klick auf den ' +
+                'Button öffnet ein Fenster, in dem Sie mit Hilfe einer ' +
+                'CSW-URL einen Kartendienst der Karte hinzufügen ' +
+                'können.'
+        }
+    },
+
+    /**
+     *
+     */
+    bind: {
+        text: '{text}'
+    },
+
+    /**
+     * The window instance which will be created by this button.
+     *
+     * @type {Ext.window.Window}
+     * @private
+     */
+    _win: null,
+
+    /**
+     *
+     */
+    config: {
+        windowConfig: {
+            // can be used by subclasses to apply/merge
+            // additional/other values for the window
+        }
+    },
+
+    handler: function() {
+        var win = this._win;
+        if (!win) {
+            var windowConfig = {
+                name: 'csw-window',
+                title: this.getViewModel().get('windowTitle'),
+                width: 500,
+                height: 400,
+                layout: 'fit',
+                constrain: true,
+                items: [{
+                    xtype: 'basigx-form-csw'
+                }]
+            };
+
+            var windowConfigToApply = this.getWindowConfig();
+            Ext.apply(windowConfig, windowConfigToApply);
+
+            win = Ext.create('Ext.window.Window', windowConfig);
+            this._win = win;
+            win.show();
+        } else {
+            BasiGX.util.Animate.shake(win);
+        }
+    },
+
+    /**
+     * Do any necessary cleanup (e.g. remove listeners, destroy dependent
+     * objects …).
+     */
+    onDestroy: function() {
+        if (this._win) {
+            this._win.destroy();
+        }
+    }
+});

--- a/src/view/button/CSW.js
+++ b/src/view/button/CSW.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-present terrestris GmbH & Co. KG
+/* Copyright (c) 2019-present terrestris GmbH & Co. KG
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -37,10 +37,10 @@ Ext.define('BasiGX.view.button.CSW', {
      */
     viewModel: {
         data: {
-            tooltip: 'CSW abfragen',
+            tooltip: 'Katalogservice für externe Karteninhalte (CSW) abfragen',
             text: 'CSW <span style="font-size: 1.7em; ' +
                 'font-weight: normal;">⊕</span>',
-            windowTitle: 'CSW abfragen',
+            windowTitle: 'Web Catalogue Service (CSW) abfragen',
             documentation: '<h2>CSW abfragen</h2>• Ein Klick auf den ' +
                 'Button öffnet ein Fenster, in dem Sie mit Hilfe einer ' +
                 'CSW-URL einen Kartendienst der Karte hinzufügen ' +

--- a/src/view/form/CSW.js
+++ b/src/view/form/CSW.js
@@ -1,0 +1,614 @@
+/* Copyright (c) 2015-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * CSW FormPanel
+ *
+ * Used to find OGC services through CSW and add them to the map.
+ * Currently only WMS layers are supported
+ *
+ * @class BasiGX.view.form.CSW
+ */
+Ext.define('BasiGX.view.form.CSW', {
+    extend: 'Ext.form.Panel',
+    xtype: 'basigx-form-csw',
+
+    requires: [
+        'Ext.app.ViewModel',
+        'Ext.button.Button',
+        'Ext.form.FieldContainer',
+        'Ext.form.FieldSet',
+        'Ext.form.field.Text',
+        'Ext.form.field.Hidden',
+        'Ext.form.field.ComboBox',
+        'Ext.layout.container.Anchor',
+        'Ext.layout.container.HBox',
+        'Ext.toolbar.Toolbar',
+
+        'BasiGX.util.MsgBox',
+        'BasiGX.view.form.AddWms'
+    ],
+
+    viewModel: {
+        data: {
+            queryParamsFieldSetTitle: 'CSW Basis URL',
+            availableLayesFieldSetTitle: 'Verfügbare CSW Dienste',
+            resetBtnText: 'Zurücksetzen',
+            cswSearchTextFieldLabel: 'Suchbegriff (optional)',
+            requestLayersBtnText: 'Verfügbare CSW-Dienste abfragen',
+            errorNoServiceFound: 'Es konnte kein passender Dienst gefunden ' +
+              'werden',
+            errorRequestFailed: 'Die angegebene URL konnte nicht abgefragt ' +
+              'werden',
+            errorCouldntParseResponse: 'Die erhaltene Antwort konnte nicht ' +
+              'erfolgreich geparst werden',
+            msgRequestTimedOut: 'Die Anfrage wurde nicht schnell genug ' +
+              'beantwortet und abgebrochen',
+            msgServiceException: 'Eine OGC ServiceException ist aufgetreten',
+            msgCorsMisconfiguration: 'HTTP access control (CORS) auf dem ' +
+              'Zielserver vermutlich nicht korrekt konfiguriert',
+            msgUnauthorized: 'Der Client ist nicht gegenüber dem Zielserver ' +
+              'authentifiziert',
+            msgForbidden: 'Der Client hat keinen Zugriff auf die angefragte ' +
+              'Ressource',
+            msgFileNotFound: 'Die angefragte Ressource existiert nicht',
+            msgTooManyRequests: 'Der Client hat zu viele Anfragen gestellt',
+            msgServiceUnavailable: 'Der Server ist derzeit nicht verfügbar ' +
+              '(zu viele Anfragen bzw. Wartungsmodus)',
+            msgGatewayTimeOut: 'Der Server fungierte als Gateway und das ' +
+              'Originalziel hat zu langsam geantwortet',
+            msgClientError: 'Ein unspezifizierter Clientfehler ist aufgetreten',
+            msgServerError: 'Ein unspezifizierter Serverfehler ist aufgetreten',
+            documentation: '<h2>CSW hinzufügen</h2>• In diesem Dialog ' +
+              'können Sie mit Hilfe einer CSW-URL ' +
+              'einen Kartendienst der Karte hinzufügen.'
+        }
+    },
+
+    padding: 5,
+    layout: 'anchor',
+    defaults: {
+        anchor: '100%'
+    },
+
+    scrollable: true,
+
+
+    config: {
+
+        /**
+         * With these CSW urls we fill the combobox. If this is empty (default),
+         * no combobox will be rendered but a plain textfield.
+         */
+        cswBaseUrls: [],
+
+        /**
+         * Default url for the textfield or combobox.
+         */
+        defaultUrl: 'https://data.mundialis.de/geonetwork/srv/ger/csw?',
+
+        /**
+         * Whether we will send the `X-Requested-With` header when fetching the
+         * CSW records from the URL. The `X-Requested-With` header is
+         * usually added for XHR, but adding it should lead to a preflight
+         * request (see https://goo.gl/6JzdUI), which some servers fail.
+         *
+         * @type {Boolean}
+         */
+        useDefaultXhrHeader: false,
+
+        /**
+         * Whether the request against the CSW servers will contain the ExtJS
+         * cache buster (`_dc=123…`) or not. If set to `false`, the param will
+         * not be send, if set to `true`, we'll pass it along (ExtJS default
+         * behaviour).
+         *
+         * The name of this parameter is taken from the config option of
+         * `Ext.Ajax`, turning the boolean logic around would be even more
+         * confusing.
+         *
+         * Defaults to `true`, e.g. the cache buster will be send along in the
+         * GET-request.
+         *
+         * @type {Boolean}
+         */
+        disableCaching: true
+    },
+
+    /**
+     * Keeps track of the viewModel key of the last error (if any).
+     *
+     * @private
+     */
+    lastErrorMsgKey: null,
+
+    items: [
+        {
+            xtype: 'fieldset',
+            layout: 'anchor',
+            defaults: {
+                anchor: '100%'
+            },
+            bind: {
+                title: '{queryParamsFieldSetTitle}'
+            },
+            items: [{
+                xtype: 'textfield',
+                bind: {
+                    fieldLabel: '{cswUrlTextFieldLabel}'
+                },
+                name: 'cswUrl',
+                allowBlank: false,
+                value: null,
+                listeners: {
+                    change: function(textfield) {
+                        var view = textfield.up('basigx-form-csw');
+                        view.resetState();
+                    },
+                    beforerender: function(textfield) {
+                        var view = textfield.up('basigx-form-csw');
+                        var countUrls = view.cswBaseUrls.length;
+                        if (countUrls !== 0) {
+                            textfield.setHidden(true);
+                        }
+                    }
+                }
+            }, {
+                xtype: 'combobox',
+                bind: {
+                    fieldLabel: '{cswUrlTextFieldLabel}'
+                },
+                store: null,
+                name: 'cswUrlCombo',
+                allowBlank: false,
+                value: null,
+                listeners: {
+                    change: function(combobox) {
+                        var view = combobox.up('basigx-form-csw');
+                        view.resetState();
+                    },
+                    beforerender: function(combobox) {
+                        var view = combobox.up('basigx-form-csw');
+                        var countUrls = view.cswBaseUrls.length;
+                        if (countUrls === 0) {
+                            combobox.setHidden(true);
+                        } else {
+                            var urlCsw = view.cswBaseUrls;
+                            combobox.setStore(urlCsw);
+                        }
+                    }
+                }
+            }, {
+                xtype: 'textfield',
+                bind: {
+                    fieldLabel: '{cswSearchTextFieldLabel}'
+                },
+                name: 'searchtext',
+                allowBlank: false,
+                value: null,
+                listeners: {
+                    change: function(textfield) {
+                        var view = textfield.up('basigx-form-csw');
+                        view.resetState();
+                    }
+                }
+            }]
+        },
+        {
+            xtype: 'fieldset',
+            name: 'fs-available-layers',
+            layout: 'anchor',
+            scrollable: 'y',
+            maxHeight: 200,
+            hidden: true,
+            padding: 5,
+            defaults: {
+                anchor: '100%'
+            },
+            bind: {
+                title: '{availableLayesFieldSetTitle}'
+            }
+        }
+    ],
+
+    // Reset and Submit buttons
+    buttons: [
+        {
+            name: 'resetFormBtn',
+            bind: {
+                text: '{resetBtnText}'
+            },
+            handler: function(btn) {
+                var view = btn.up('basigx-form-csw');
+                view.getForm().reset();
+                view.removeAddLayersComponents();
+                view.resetState();
+                var defaultValue = view.defaultUrl;
+                var combo = view.down('combobox[name=cswUrlCombo]');
+                combo.setValue(defaultValue);
+                var textfield = view.down('textfield[name=cswUrl]');
+                textfield.setValue(defaultValue);
+            }
+        },
+        '->',
+        {
+            bind: {
+                text: '{requestLayersBtnText}'
+            },
+            name: 'requestLayersBtn',
+            handler: function(btn) {
+                var view = btn.up('basigx-form-csw');
+                view.resetState();
+                view.requestGetRecords();
+            }
+        }
+    ],
+
+    /**
+     * Initializes the form.
+     */
+    initComponent: function() {
+        var me = this;
+        me.callParent();
+        var defaultValue = me.defaultUrl;
+        var combo = me.down('combobox[name=cswUrlCombo]');
+        var textfield = me.down('textfield[name=cswUrl]');
+        combo.setValue(defaultValue);
+        textfield.setValue(defaultValue);
+    },
+
+    /**
+     * Resets our internal state tracking properties for tracking the tried
+     * versions and the last error message key we have determined.
+     *
+     * @private
+     */
+    resetState: function() {
+        var me = this;
+        me.lastErrorMsgKey = null;
+        var addWmsForm = me.down('basigx-form-addwms');
+        if (addWmsForm) {
+            addWmsForm.hide();
+        }
+        var buttonsContainer = me.down('[name=fs-available-layers]');
+        buttonsContainer.hide();
+    },
+
+    /**
+     * Returns a key for a viewModel property for the passed HTTP status code or
+     * null if we don't consider the status code an error.
+     *
+     * @param {Number} status The HTTP status code of the last response.
+     * @return {String} An error message key to be looked up in the viewModel.
+     * @private
+     */
+    responseStatusToErrorMsgKey: function(status) {
+        status = parseInt(status, 10);
+        // handle very common ones specifically
+        if (status === 0) {
+            // Most likely CORS
+            // * either not enabled at all
+            // * or misconfigured
+            return 'msgCorsMisconfiguration';
+        } else if (status === 401) {
+            return 'msgUnauthorized';
+        } else if (status === 403) {
+            return 'msgForbidden';
+        } else if (status === 404) {
+            return 'msgFileNotFound';
+        } else if (status === 429) {
+            return 'msgTooManyRequests';
+        } else if (status === 503) {
+            return 'msgServiceUnavailable';
+        } else if (status === 504) {
+            return 'msgGatewayTimeOut';
+        } else if (status >= 400 && status < 500) {
+            return 'msgClientError';
+        } else if (status >= 500) {
+            return 'msgServerError';
+        }
+        return null;
+    },
+
+    /**
+     * Will be called with the `get layers` button. Issues a CSW `GetRecords`
+     * request, parses the response and will create layer entries for all
+     * WMS layers (more support for e.g. WFS to come).
+     */
+    requestGetRecords: function() {
+        var me = this;
+        var form = me.getForm();
+        var combo = me.down('combo[name=cswUrlCombo]');
+        var textfield = me.down('textfield[name=cswUrl]');
+        var searchtext = me.down('textfield[name=searchtext]').getValue();
+        if (combo.isVisible() && !combo.isValid() ||
+            textfield.isVisible() && !textfield.isValid()) {
+            return;
+        }
+        me.setLoading(true);
+        me.removeAddLayersComponents();
+        var values = form.getValues();
+        var url;
+
+        if (me.cswBaseUrls.length === 0) {
+            url = values.cswUrl;
+        } else {
+            url = values.cswUrlCombo;
+        }
+
+        var postBody =
+          '<?xml version="1.0" encoding="UTF-8"?>' +
+            '<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"' +
+            ' service="CSW" version="2.0.2" resultType="results">' +
+              '<csw:Query typeNames="csw:Record">' +
+                '<csw:ElementSetName>full</csw:ElementSetName>' +
+                '<csw:Constraint version="1.1.0">' +
+                  '<Filter xmlns="http://www.opengis.net/ogc" ' +
+                  'xmlns:gml="http://www.opengis.net/gml">' +
+                    '<PropertyIsLike wildCard="%" singleChar="_" ' +
+                    'escapeChar="\\">' +
+                      '<PropertyName>AnyText</PropertyName>' +
+                      '<Literal>%' + searchtext + '%</Literal>' +
+                    '</PropertyIsLike>' +
+                  '</Filter>' +
+                '</csw:Constraint>' +
+              '</csw:Query>' +
+            '</csw:GetRecords>';
+
+        Ext.Ajax.request({
+            url: url,
+            method: 'POST',
+            xmlData: postBody,
+            useDefaultXhrHeader: me.getUseDefaultXhrHeader(),
+            disableCaching: me.getDisableCaching(),
+            success: me.onGetRecordsSuccess,
+            failure: me.onGetRecordsFailure,
+            scope: me
+        });
+    },
+
+    /**
+     * Returns true if the passed responseText is a service exception report.
+     *
+     * @param {String} responseText The responseText of a request which is
+     *     possibly a service exception report.
+     * @return {Boolean} Whether the response is a service exception report
+     *     document.
+     */
+    isServiceExceptionReport: function(responseText) {
+        if (!responseText) {
+            return false;
+        }
+        return (/<ServiceExceptionReport/g).test(responseText);
+    },
+
+    /**
+     * Called if we could successfully query for the records of a CSW, this
+     * method will examine the answer and eventually set up a fieldset for all
+     * the layers that we have found in the server's answer.
+     *
+     * @param {XMLHttpRequest} response The response of the request.
+     */
+    onGetRecordsSuccess: function(response) {
+        var me = this;
+        me.lastErrorMsgKey = null;
+        // some servers answer with a ServiceExceptionReport. In that case, we
+        // have to manually call the failure callback.
+        if (me.isServiceExceptionReport(response.responseText)) {
+            me.onGetRecordsFailure(response);
+            return;
+        }
+
+        var viewModel = me.getViewModel();
+        try {
+            var p = new DOMParser();
+            var dom = p.parseFromString(response.responseText, 'text/xml');
+            var records = dom.getElementsByTagName('csw:Record');
+            var wmsLayers = [];
+            for (var i = 0; i < records.length; i++) {
+                var record = records[i];
+                var uri = record.getElementsByTagName('dc:URI')[0];
+                if (uri) {
+                    var protocol = uri.getAttribute('protocol');
+                    if (protocol && protocol.toUpperCase().indexOf(
+                        'OGC:WMS') > -1) {
+                        var url = uri.innerHTML;
+                        var name = uri.getAttribute('name');
+                        var title = record.getElementsByTagName('dc:title')[0];
+                        if (title) {
+                            title = title.innerHTML;
+                        }
+                        var description = record.getElementsByTagName(
+                            'dc:description')[0];
+                        if (description) {
+                            description = description.innerHTML;
+                        }
+                        wmsLayers.push({
+                            url: url,
+                            name: name,
+                            title: title,
+                            description: description
+                        });
+                    }
+                }
+            }
+        } catch (ex) {
+            BasiGX.warn(viewModel.get('errorCouldntParseResponse'));
+            me.setLoading(false);
+            return;
+        }
+        me.setLoading(false);
+        if (wmsLayers.length === 0) {
+            BasiGX.warn(me.getErrorMessage('errorNoServiceFound'));
+        } else {
+            me.fillAvailableLayersFieldset(wmsLayers);
+        }
+    },
+
+    /**
+     * Called if we could not successfully query the records of a CSW.
+     *
+     * @param {XMLHttpRequest} response The response of the request.
+     */
+    onGetRecordsFailure: function(response) {
+        var me = this;
+        var status = response.status;
+        var responseText = response.responseText;
+        var errDetails = [];
+        // Keep track of the last error, to eventually inform the user
+        me.lastErrorMsgKey = me.responseStatusToErrorMsgKey(status);
+
+        // we might simply have timed out
+        if (response.timedout) {
+            me.lastErrorMsgKey = 'msgRequestTimedOut';
+        }
+
+        // If we still do not have a msg key and a OK status, check if it's a SE
+        if (me.lastErrorMsgKey === null && status >= 200 && status < 300) {
+            if (me.isServiceExceptionReport(responseText)) {
+                // overwrite the key from the status, this should be considered
+                // an error
+                me.lastErrorMsgKey = 'msgServiceException';
+                errDetails = me.exceptionDetailsFromReport(responseText);
+            }
+        }
+
+        me.setLoading(false);
+        BasiGX.warn(me.getErrorMessage('errorRequestFailed', errDetails));
+    },
+
+    /**
+     * Returns an array of `<ServiceException>` text contents of the passed
+     * `<ServiceExceptionReport>` or an empty array.
+     *
+     * @param {String} exceptionReport An OGC ServiceExceptionReport as string.
+     * @return {Array<String>} exceptionReport An array of `<ServiceException>`
+     *     text contents of the passed `<ServiceExceptionReport>` or an empty
+     *     array.
+     */
+    exceptionDetailsFromReport: function(exceptionReport) {
+        var exceptionDetails = [];
+        if (DOMParser) {
+            var parser = new DOMParser();
+            try {
+                var xml = parser.parseFromString(exceptionReport, 'text/xml');
+                var exceptions = Ext.DomQuery.select('ServiceException', xml);
+                Ext.each(exceptions, function(exception) {
+                    exceptionDetails.push(exception.innerHTML);
+                });
+            } catch (e) {
+                // pass
+                Ext.Logger.warn('Failed to parse responseText as XML: ' + e);
+            }
+        }
+        return exceptionDetails;
+    },
+
+    /**
+     * Returns the error message to display to the user for the passed key,
+     * optionally adding the passed details.
+     *
+     * @param {String} errorKey The key to look up in the view model for the
+     *     error.
+     * @param {Array<String>} [errorDetails] Optional array of details to
+     *     display.
+     * @return {String} The error message to display.
+     * @private
+     */
+    getErrorMessage: function(errorKey, errorDetails) {
+        var me = this;
+        var viewModel = me.getViewModel();
+
+        var msg = viewModel.get(errorKey);
+        if (me.lastErrorMsgKey !== null) {
+            msg += '<br /><br />' + viewModel.get(me.lastErrorMsgKey);
+        }
+        if (errorDetails && errorDetails.length > 0) {
+            msg += '<ul>';
+            Ext.each(errorDetails, function(errorDetail) {
+                msg += '<li>' + errorDetail + '</li>';
+            });
+            msg += '</ul>';
+        }
+        return msg;
+    },
+
+    /**
+     * Remove the buttons for layers from previous requests.
+     */
+    removeAddLayersComponents: function() {
+        var me = this;
+        var buttonsContainer = me.down('[name=fs-available-layers]');
+        buttonsContainer.removeAll();
+    },
+
+    /**
+     * Updates the avaialable layers fieldset with matching entries.
+     *
+     * @param {Array} layers The layer objects for which the we shall fill
+     *     the fieldset.
+     */
+    fillAvailableLayersFieldset: function(layers) {
+        var me = this;
+        me.removeAddLayersComponents();
+        var fs = me.down('[name=fs-available-layers]');
+        fs.show();
+        var buttons = [];
+        Ext.each(layers, function(layer) {
+            buttons.push({
+                xtype: 'button',
+                text: layer.title || layer.name,
+                layer: layer,
+                autoEl: {
+                    'tag': 'div',
+                    'data-qtip': layer.description
+                },
+                handler: me.getWmsLayer
+            });
+        });
+        fs.add(buttons);
+    },
+
+    /**
+     * Handles the button click by setting up the basigx-form-addwms,
+     * adding the defaultUrl to it and automatically issue a GetCapabilities
+     * request so the user can select a WMS layer.
+     * TODO: support different OGC services here, not only WMS
+     *
+     * @param {Ext.button.Button} btn The button that has been pressed.
+     *   It contains the layer information to prepare setup of layers.
+     */
+    getWmsLayer: function(btn) {
+        var form = this.up('form');
+        var layer = btn.layer;
+        var addWmsForm = form.down('basigx-form-addwms');
+        if (!addWmsForm) {
+            addWmsForm = Ext.create('BasiGX.view.form.AddWms', {
+                defaultUrl: layer.url
+            });
+            form.add(addWmsForm);
+            var toolBar = addWmsForm.down('toolbar[dock=bottom]');
+            if (toolBar) {
+                toolBar.hide();
+            }
+        } else {
+            addWmsForm.setDefaultUrl(layer.url);
+            addWmsForm.down('textfield[name=url]').setValue(layer.url);
+
+        }
+        addWmsForm.show();
+        addWmsForm.requestGetCapabilities();
+    }
+});

--- a/src/view/form/CSW.js
+++ b/src/view/form/CSW.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-present terrestris GmbH & Co. KG
+/* Copyright (c) 2019-present terrestris GmbH & Co. KG
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -100,31 +100,37 @@ Ext.define('BasiGX.view.form.CSW', {
         defaultUrl: 'https://data.mundialis.de/geonetwork/srv/ger/csw?',
 
         /**
-         * Whether we will send the `X-Requested-With` header when fetching the
-         * CSW records from the URL. The `X-Requested-With` header is
-         * usually added for XHR, but adding it should lead to a preflight
-         * request (see https://goo.gl/6JzdUI), which some servers fail.
-         *
-         * @type {Boolean}
+         * Additional parameters that will be applied to the `Ext.Ajax.request`
          */
-        useDefaultXhrHeader: false,
+        additionalRequestParams: {
 
-        /**
-         * Whether the request against the CSW servers will contain the ExtJS
-         * cache buster (`_dc=123…`) or not. If set to `false`, the param will
-         * not be send, if set to `true`, we'll pass it along (ExtJS default
-         * behaviour).
-         *
-         * The name of this parameter is taken from the config option of
-         * `Ext.Ajax`, turning the boolean logic around would be even more
-         * confusing.
-         *
-         * Defaults to `true`, e.g. the cache buster will be send along in the
-         * GET-request.
-         *
-         * @type {Boolean}
-         */
-        disableCaching: true
+            /**
+             * Whether we will send the `X-Requested-With` header when fetching
+             * the CSW records from the URL. The `X-Requested-With` header is
+             * usually added for XHR, but adding it should lead to a preflight
+             * request (see https://goo.gl/6JzdUI), which some servers fail.
+             *
+             * @type {Boolean}
+             */
+            useDefaultXhrHeader: false,
+
+            /**
+             * Whether the request against the CSW servers will contain the
+             * ExtJS cache buster (`_dc=123…`) or not. If set to `false`, the
+             * param will not be send, if set to `true`, we'll pass it along
+             * (ExtJS default behaviour).
+             *
+             * The name of this parameter is taken from the config option of
+             * `Ext.Ajax`, turning the boolean logic around would be even more
+             * confusing.
+             *
+             * Defaults to `true`, e.g. the cache buster will be send along in
+             * the GET-request.
+             *
+             * @type {Boolean}
+             */
+            disableCaching: true
+        }
     },
 
     /**
@@ -367,16 +373,16 @@ Ext.define('BasiGX.view.form.CSW', {
               '</csw:Query>' +
             '</csw:GetRecords>';
 
-        Ext.Ajax.request({
+        var options = {
             url: url,
             method: 'POST',
             xmlData: postBody,
-            useDefaultXhrHeader: me.getUseDefaultXhrHeader(),
-            disableCaching: me.getDisableCaching(),
             success: me.onGetRecordsSuccess,
             failure: me.onGetRecordsFailure,
             scope: me
-        });
+        };
+        Ext.apply(options, me.getAdditionalRequestParams());
+        Ext.Ajax.request(options);
     },
 
     /**

--- a/test/resources/ows/csw-response.xml
+++ b/test/resources/ows/csw-response.xml
@@ -1,0 +1,342 @@
+<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
+<csw:SearchStatus timestamp="2019-07-10T14:48:51"/>
+<csw:SearchResults numberOfRecordsMatched="40" numberOfRecordsReturned="10" elementSet="full" nextRecord="11">
+<csw:Record xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:identifier>bd50d623-6cf6-4853-a8c4-3c3dcb720326</dc:identifier>
+<dc:title>Buitenplaatsen</dc:title>
+<dc:type>dataset</dc:type>
+<dc:subject>rijksmonument</dc:subject>
+<dc:subject>monument</dc:subject>
+<dc:subject>landschapsarchitectuur</dc:subject>
+<dc:subject>architectuurgeschiedenis</dc:subject>
+<dc:subject>bouwkunde</dc:subject>
+<dc:subject>structure</dc:subject>
+<dc:format>Shape, WMS, WFS</dc:format>
+<dc:format>ESRI Shape</dc:format>
+<dct:abstract>
+De dataset bevat de begrenzingen van de rijksbeschermde buitenplaatsen waar de Rijksdienst voor het Cultureel Erfgoed een nauwkeurige digitale begrenzing van heeft gemaakt.
+</dct:abstract>
+<dc:rights>otherRestrictions</dc:rights>
+<dc:source>
+In de periode 2011 tot en met 2013 is van alle rijksbeschermde buitenplaatsen waarvoor de begrenzingskaart niet digitaal gemaakt is (maar vaak wel als scan van de papieren kaart aanwezig), of de begrenzingskaart geheel ontbrak, een digitale begrenzing getekend. Van de buitenplaatsen waarvan geen (digitale of analoge) aanwijzingskaart beschikbaar is, is de geleverde contour bedoeld als indicatieve grens: hieraan kunnen geen rechten ontleend worden. Uitsluitend de uiterste begrenzing van de buitenplaatsen zijn in de kaartlaag opgenomen, de complexonderdeelnummers niet. Dit betekent dat de begrenzingen de beschermde aanleg van de buitenplaatsen betreffen en GEEN uitsluitsel geven over welke objecten binnen die begrenzingen ook zelfstandig als rijksmonument zijn beschermd. Dit is geen INSPIRE dataset.
+</dc:source>
+<dc:format>Shape, WMS, WFS</dc:format>
+<dc:format>ESRI Shape</dc:format>
+<ows:BoundingBox crs="urn:ogc:def:crs:EPSG::28992">
+<ows:LowerCorner>7.21097 50.7539</ows:LowerCorner>
+<ows:UpperCorner>3.37087 53.4658</ows:UpperCorner>
+</ows:BoundingBox>
+<dc:URI protocol="OGC:WMS" name="Buitenplaatsen" description="Buitenplaatsen">
+http://services.rce.geovoorziening.nl/buitenplaatsen/wms
+</dc:URI>
+<dc:URI protocol="OGC:WFS" name="Buitenplaatsen" description="Buitenplaatsen">
+http://services.rce.geovoorziening.nl/buitenplaatsen/wfs
+</dc:URI>
+<dc:URI protocol="download" name="Download Buitenplaatsenkaartlaag in ESRI Shape formaat">
+http://www.cultureelerfgoed.nl/sites/default/files/downloads/dossiers/rce_buitenplaatsen_vlakken_0.zip
+</dc:URI>
+<dc:URI protocol="image/png" name="thumbnail">
+http://services.rce.geovoorziening.nl/www/PreviewBuitenplaatsenKlein200x150.png
+</dc:URI>
+</csw:Record>
+<csw:Record xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:identifier>dfe5b146-354f-4bc7-99b1-6713817afac9</dc:identifier>
+<dc:title>Archeologische Monumenten Kaart (2014)</dc:title>
+<dc:type>dataset</dc:type>
+<dc:subject>archeologisch monument</dc:subject>
+<dc:subject>archeologie</dc:subject>
+<dc:subject>cultuurhistorie</dc:subject>
+<dc:subject>Beschermde gebieden</dc:subject>
+<dc:subject>environment</dc:subject>
+<dc:format/>
+<dct:abstract>
+De Archeologische Monumenten Kaart (AMK) is in samenwerking met de verschillende provincies en gemeentelijk archeologen ontwikkeld. De kaart bevat een overzicht van archeologische terreinen in Nederland. De AMK is een van de bronnen om ruimtelijke plannen, zoals streek- en bestemmingsplannen, te kunnen opstellen, beoordelen en toetsen op hun gevolgen voor de archeologie. Een groot aantal provincies gebruikt de AMK ook als bron voor de ontwikkeling van digitale cultuurhistorische waardenkaarten. De terreinen zijn beoordeeld op de criteria kwaliteit, zeldzaamheid, representativiteit, ensemblewaarde en belevingswaarde. Op grond van deze criteria zijn de terreinen ingedeeld in terreinen met archeologische waarde, hoge archeologische waarde en zeer hoge archeologische waarde. Onder deze laatste categorie vallen ook de wettelijk beschermde monumenten. De AMK vormt altijd een momentopname van de archeologische kennis over een provincie. Ieder jaar komen er nieuwe archeologische terreinen bij. Bestaande terreinen kunnen vervallen, groter of juist kleiner worden. Daarnaast kunnen ook buiten de terreinen die op de AMK staan, waardevolle archeologische resten liggen.
+</dct:abstract>
+<dc:rights>otherRestrictions</dc:rights>
+<dc:source>
+De begrenzingen van de monumenten zijn deels overgenomen uit de top10vector. Dit is geen INSPIRE dataset.
+</dc:source>
+<dc:format/>
+<ows:BoundingBox crs="urn:ogc:def:crs:EPSG::28992">
+<ows:LowerCorner>7.21097 50.7539</ows:LowerCorner>
+<ows:UpperCorner>3.37087 53.4658</ows:UpperCorner>
+</ows:BoundingBox>
+<dc:URI protocol="OGC:WMS" name="ArcheologicalMonuments" description="Archeologische Monumenten">http://services.rce.geovoorziening.nl/rce/wms</dc:URI>
+<dc:URI protocol="OGC:WFS" name="ArcheologicalMonuments" description="Archeologische Monumenten">http://services.rce.geovoorziening.nl/rce/wfs</dc:URI>
+<dc:URI protocol="INSPIRE Atom" name="Atom feed ArcheologicalMonuments" description="Atom feed Archeologische Monumenten">
+http://services.rce.geovoorziening.nl/www/download/data/Archeologische_Monumenten_nl.xml
+</dc:URI>
+<dc:URI protocol="website" name="Archeologische Monumentenkaart (AMK)">http://www.cultureelerfgoed.nl</dc:URI>
+<dc:URI protocol="image/png" name="thumbnail">
+http://services.rce.geovoorziening.nl/www/PreviewAMKklein200x150.png
+</dc:URI>
+</csw:Record>
+<csw:Record xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:identifier>88a3c1ae-902e-4efa-8663-ddd836101929</dc:identifier>
+<dc:title>Werelderfgoed</dc:title>
+<dc:type>dataset</dc:type>
+<dc:subject>werelderfgoed</dc:subject>
+<dc:subject>UNESCO</dc:subject>
+<dc:subject>Beschermde gebieden</dc:subject>
+<dc:subject>structure</dc:subject>
+<dc:format/>
+<dct:abstract>
+Begrenzingen van het Nederlandse cultureel erfgoed dat vanwege haar uitzonderlijke universele waarde door het Werelderfgoed comite van UNESCO is geplaatst op de Werelderfgoedlijst. De begrenzingen zijn gebaseerd op de kaarten die destijds opgenomen waren in het nominatiedossier dat aan Unesco is aangeboden.
+</dct:abstract>
+<dc:rights>otherRestrictions</dc:rights>
+<dc:source>
+De begrenzingen zijn door de Rijksdienst voor het Cultureel Erfgoed gedigitaliseerd op basis van TOP10vector/Top10NL, GBKN/BGT en topografische kaarten 1:25.000.
+</dc:source>
+<dc:format/>
+<ows:BoundingBox crs="urn:ogc:def:crs:EPSG::28992">
+<ows:LowerCorner>7.2 50.8</ows:LowerCorner>
+<ows:UpperCorner>3.4 53.6</ows:UpperCorner>
+</ows:BoundingBox>
+<dc:URI protocol="OGC:WMS" name="WorldHeritage" description="Unesco Wereld Erfgoed">http://services.rce.geovoorziening.nl/rce/wms</dc:URI>
+<dc:URI protocol="OGC:WFS" name="WorldHeritage" description="Unesco Wereld Erfgoed">http://services.rce.geovoorziening.nl/rce/wfs</dc:URI>
+<dc:URI protocol="INSPIRE Atom" name="Atom feed WorldHeritage" description="Atom feed Unesco Wereld Erfgoed">
+http://services.rce.geovoorziening.nl/www/download/data/Unesco_Werelderfgoed_nl.xml
+</dc:URI>
+<dc:URI protocol="image/png" name="thumbnail">
+http://services.rce.geovoorziening.nl/www/PreviewWerelderfgoedKlein200x150.png
+</dc:URI>
+</csw:Record>
+<csw:Record xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:identifier>6f84efeb-fc1d-4565-a721-80735ea57dbd</dc:identifier>
+<dc:title>Rijksmonumenten</dc:title>
+<dc:type>dataset</dc:type>
+<dc:subject>rijksmonument</dc:subject>
+<dc:subject>monument</dc:subject>
+<dc:subject>kunstgeschiedenis</dc:subject>
+<dc:subject>architectuurgeschiedenis</dc:subject>
+<dc:subject>bouwkunde</dc:subject>
+<dc:subject>archeologie</dc:subject>
+<dc:subject>cultuurhistorie</dc:subject>
+<dc:subject>cultureel erfgoed</dc:subject>
+<dc:subject>RCE</dc:subject>
+<dc:subject>Beschermde gebieden</dc:subject>
+<dc:subject>structure</dc:subject>
+<dc:format>Shape, GML, WMS, WFS</dc:format>
+<dct:abstract>
+In de dataset 'Rijksmonumenten' zijn gegevens opgenomen van alle monumenten in Nederland die door het Rijk zijn aangewezen als beschermd monument. Deze rijksmonumenten zijn van nationale betekenis. De gegevens in de dataset zijn ontleend aan het Rijksmonumentenregister zoals beheerd door de Rijksdienst voor het Cultureel Erfgoed. Een monument dat is ingeschreven in dit register heeft de beschermde status. Als de aanwijzingsprocedure van een monument nog niet is afgerond dan heeft het een voorbeschermde status.
+</dct:abstract>
+<dc:rights>otherRestrictions</dc:rights>
+<dc:source>
+Het Rijksmonumentenregister is fysiek opgenomen in de Objecten Databank (ODB). Maandelijks wordt uit deze ODB een extract gegenereerd. Uit dit extract worden vervolgens de digitale kaartlagen gegenereerd die gebruikt kunnen worden in Geografische Informatie Systemen.
+</dc:source>
+<dc:format>Shape, GML, WMS, WFS</dc:format>
+<ows:BoundingBox crs="urn:ogc:def:crs:EPSG::28992">
+<ows:LowerCorner>7.21097 50.7539</ows:LowerCorner>
+<ows:UpperCorner>3.37087 53.4658</ows:UpperCorner>
+</ows:BoundingBox>
+<dc:URI protocol="OGC:WMS" name="NationalListedMonuments">http://services.rce.geovoorziening.nl/rce/wms</dc:URI>
+<dc:URI protocol="OGC:WFS" name="NationalListedMonuments">http://services.rce.geovoorziening.nl/rce/wfs</dc:URI>
+<dc:URI protocol="INSPIRE Atom" name="Atom feed NationalListedMonuments">
+http://services.rce.geovoorziening.nl/www/download/data/Rijksmonumenten_nl.xml
+</dc:URI>
+<dc:URI protocol="download" name="Download Rijksmonumenten kaartlaag in ESRI Shape formaat">
+http://services.rce.geovoorziening.nl/www/download/data/Rijksmonumenten_nl.xml
+</dc:URI>
+</csw:Record>
+<csw:Record xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:identifier>4e2ef670-cddd-11dd-ad8b-0800200c9a66</dc:identifier>
+<dc:title>Stads- en Dorpsgezichten</dc:title>
+<dc:type>dataset</dc:type>
+<dc:subject>historische geografie</dc:subject>
+<dc:subject>stedenbouwkunde</dc:subject>
+<dc:subject>planologie</dc:subject>
+<dc:subject>architectuurgeschiedenis</dc:subject>
+<dc:subject>bouwkunde</dc:subject>
+<dc:subject>Beschermde gebieden</dc:subject>
+<dc:subject>planningCadastre</dc:subject>
+<dc:format>ESRI Shape</dc:format>
+<dct:abstract>
+De Stads- en Dorpsgezichtenkaartlaag bevat alle gebieden waarvoor de procedure is gestart om het gebied aan te wijzen als rijksbeschermd stads- of dorpsgezicht (ex artikel 35 van de Monumentenwet 1988). In de default weergave van de INSPIRE Web Map Service worden alleen de aangewezen stads- en dorpsgezichten getoond. De kwaliteit van de ligging van de begrenzing van de stads- en dorpsgezichten is wisselend. Zie de informatie over de datakwaliteit.
+</dct:abstract>
+<dc:rights>otherRestrictions</dc:rights>
+<dc:source>
+Voor een klein aantal gebieden zijn bij het digitaliseren van de begrenzing de GBKN en de kadastrale percelen uit het LKI als referentieondergronden gebruikt. Voor deze gebieden geldt dat de begrenzing wat ligging betreft identiek is aan de begrenzing die op de officiele (papieren) kaart staat die bij het aanwijzingsbesluit en -toelichting is gevoegd. Zie het veld Ondergrond. De ligging van de begrenzingen in de provincies Friesland en Limburg is visueel vergeleken met die in de aanwijzingskaarten en waar nodig verbeterd. Hierbij is gebruik gemaakt van de topografische kaart op schaal 1:10.000 (TOP10vector). De verbeteringen hebben de kwaliteit van de ligging van de begrenzingen verhoogd maar nemen niet het risico weg dat de ligging van de begrenzingen mogelijk tot maximaal zo'n 20 meter afwijkt van die op de officiele aanwijzingskaarten. Voor de overige provincies is deze controle niet uitgevoerd. De kwaliteit van de ligging van de begrenzingen is voor deze provincies onduidelijk. Op basis van de ervaringen opgedaan tijdens het werken met de kaartlaag en bij de controle van de begrenzingen in Friesland en Limburg, kan de maximale afwijking in de ligging van de begrenzing worden ingeschat op ongeveer 100 meter. Voor meer informatie over de beschrijvende gegevens van de stads- en dorpsgezichten en de ligging van de begrenzing kan contact opgenomen worden met de Rijksdienst voor het Cultureel Erfgoed, telefoon: 033-4217456 of info@cultureelerfgoed.nl
+</dc:source>
+<dc:format>ESRI Shape</dc:format>
+<ows:BoundingBox crs="urn:ogc:def:crs:EPSG::28992">
+<ows:LowerCorner>7.21097 50.7539</ows:LowerCorner>
+<ows:UpperCorner>3.37087 53.4658</ows:UpperCorner>
+</ows:BoundingBox>
+<dc:URI protocol="OGC:WMS" name="Townscapes" description="Stads- en Dorpsgezichten">http://services.rce.geovoorziening.nl/rce/wms</dc:URI>
+<dc:URI protocol="OGC:WFS" name="Townscapes" description="Stads- en Dorpsgezichten">http://services.rce.geovoorziening.nl/rce/wfs</dc:URI>
+<dc:URI protocol="INSPIRE Atom" name="Atom feed Townscapes" description="Atom feed Stads- en Dorpsgezichten">
+http://services.rce.geovoorziening.nl/www/download/data/Stads_en_Dorpsgezichten_nl.xml
+</dc:URI>
+<dc:URI protocol="download" name="Stads- en dorpsgezichtenkaartlaag">
+http://services.rce.geovoorziening.nl/www/download/data/Stads_en_Dorpsgezichten_nl.xml
+</dc:URI>
+<dc:URI protocol="website" name="Kaart met stads- en dorpsgezichten">
+https://www.cultureelerfgoed.nl/onderwerpen/bronnen-en-kaarten/overzicht/kaart-van-beschermde-stads--en-dorpsgezichten
+</dc:URI>
+<dc:URI protocol="image/png" name="thumbnail">
+http://services.rce.geovoorziening.nl/www/PreviewStadsEnDorpsgezichtenKlein200x150.png
+</dc:URI>
+</csw:Record>
+<csw:Record xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:identifier>719f3336-f112-4d03-90da-e56178ecfbd5</dc:identifier>
+<dc:title>
+Kaart van Hoog Nederland met afgedekte pleistocene sedimenten
+</dc:title>
+<dc:type>dataset</dc:type>
+<dc:subject>archeologie</dc:subject>
+<dc:subject>environment</dc:subject>
+<dc:format>WMS, WFS</dc:format>
+<dct:abstract>
+Hoog Nederland is het deel van Nederland waar het oppervlak grotendeels bestaat uit pleistocene afzettingen. Ongeveer een kwart van dit areaal is tijdens het Holoceen (na 10.000 BP) afgedekt door sediment dat is afgezet door water (colluvium, beek- en rivierafzettingen e.d.), wind (stuifzand), plantengroei (veen) en de mens (cultuurdekken). Door deze afdekkingen zijn de archologische resten veelal beter beschermd tegen latere verstoringen.
+</dct:abstract>
+<dc:rights>otherRestrictions</dc:rights>
+<dc:language>dut</dc:language>
+<dc:source>
+Bij het selecteren van de afzettingen is gebruikgemaakt van de digitale Bodemkaart van Nederland 1:50.000 en de toelichting daarop. Verder is gebruikgemaakt van de IKAW (1:50.000), de digitale kaart van de archeoregio’s en de paleogeografische kaart van P.C. Vos. Dit is geen INSPIRE dataset.
+</dc:source>
+<dc:format>WMS, WFS</dc:format>
+<ows:BoundingBox crs="urn:ogc:def:crs:EPSG::28992">
+<ows:LowerCorner>7.21097 50.7539</ows:LowerCorner>
+<ows:UpperCorner>3.37087 53.4658</ows:UpperCorner>
+</ows:BoundingBox>
+<dc:URI protocol="OGC:WMS" name="Afgedekt_Pleistoceen">
+http://services.rce.geovoorziening.nl/afgedekt_pleistoceen/wms?
+</dc:URI>
+<dc:URI protocol="OGC:WFS" name="Afgedekt_Pleistoceen">
+http://services.rce.geovoorziening.nl/afgedekt_pleistoceen/wfs?
+</dc:URI>
+</csw:Record>
+<csw:Record xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:identifier>c635759c-6cf0-4d6c-b6a1-7ae3f9028034</dc:identifier>
+<dc:title>Top Pleistocene oppervlakte</dc:title>
+<dc:type>dataset</dc:type>
+<dc:subject>archeologie</dc:subject>
+<dc:subject>geoscientificInformation</dc:subject>
+<dc:format>WMS, WFS</dc:format>
+<dct:abstract>
+Deze kaarten geven de ligging van de top van de Pleistocene oppervlakte weer, dat in de loop van het Holoceen voor een groot deel is bedekt met zee- en rivierafzettingen en veen. Eén van de kaartlagen (plzgeul) betreft een reconstructie van het Pleistocene oppervlak aan het begin van het Holoceen (ca. 9000 v. Chr; meter t.o.v. NAP). De andere kaartlaag (plmgeul) geeft de huidige ligging van het Pleistocene oppervlakte weer (meter t.o.v. NAP). Hierop zijn de grote Holocene geulinsnijdingen in de Nederlandse kustvlakte (de rode geulvormen) goed zichtbaar.
+</dct:abstract>
+<dc:rights>otherRestrictions</dc:rights>
+<dc:language>dut</dc:language>
+<dc:source>
+Deze reconstructie is gebaseerd op de analyse en interpretatie van tienduizenden grondboringen, onderzoek naar de vorming en ouderdom van geologische afzettingen in de bodem en archeologische informatie. Dit is geen INSPIRE dataset.
+</dc:source>
+<dc:format>WMS, WFS</dc:format>
+<ows:BoundingBox crs="urn:ogc:def:crs:EPSG::28992">
+<ows:LowerCorner>7.21097 50.7539</ows:LowerCorner>
+<ows:UpperCorner>3.37087 53.4658</ows:UpperCorner>
+</ows:BoundingBox>
+<dc:URI protocol="OGC:WMS" name="plzgeul">
+http://services.rce.geovoorziening.nl/toppleistoceen/wms?
+</dc:URI>
+<dc:URI protocol="OGC:WMS" name="plmgeul">
+http://services.rce.geovoorziening.nl/toppleistoceen/wms?
+</dc:URI>
+<dc:URI protocol="OGC:WFS" name="plzgeul">
+http://services.rce.geovoorziening.nl/toppleistoceen/wfs?
+</dc:URI>
+<dc:URI protocol="OGC:WFS" name="plmgeul">
+http://services.rce.geovoorziening.nl/toppleistoceen/wfs?
+</dc:URI>
+</csw:Record>
+<csw:Record xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:identifier>15dc2644-1822-4fc2-8536-2bb2058c4a43</dc:identifier>
+<dc:title>Hunebedden</dc:title>
+<dc:type>dataset</dc:type>
+<dc:subject>hunebedden</dc:subject>
+<dc:subject>historische geografie</dc:subject>
+<dc:subject>landschap</dc:subject>
+<dc:subject>RCE</dc:subject>
+<dc:subject>archeologie</dc:subject>
+<dc:subject>rijksmonument</dc:subject>
+<dc:subject>monument</dc:subject>
+<dc:subject>cultureel erfgoed</dc:subject>
+<dc:subject>erfgoed</dc:subject>
+<dc:subject>society</dc:subject>
+<dc:format>Shape, WMS, WFS, GML</dc:format>
+<dct:abstract>
+In de dataset 'Hunebedden' zijn de locaties opgenomen van alle hunebedden die nog zichtbaar zijn.
+</dct:abstract>
+<dc:rights>otherRestrictions</dc:rights>
+<dc:language>dut</dc:language>
+<dc:source>
+De begrenzingen van de hunebedden zijn in het terrein opgemeten. Het Object Databank nummer (ODB) komt vanuit het Rijksmonumentenregister. Dit is geen INSPIRE dataset.
+</dc:source>
+<dc:format>Shape, WMS, WFS, GML</dc:format>
+<ows:BoundingBox crs="urn:ogc:def:crs:EPSG::28992">
+<ows:LowerCorner>7.3492139987157365 52.68925339087892</ows:LowerCorner>
+<ows:UpperCorner>5.683574594362337 53.23490775195891</ows:UpperCorner>
+</ows:BoundingBox>
+<dc:URI protocol="OGC:WMS" name="Hunebedden">
+http://services.rce.geovoorziening.nl/landschapsatlas/wms?
+</dc:URI>
+<dc:URI protocol="OGC:WFS" name="Hunebedden">
+http://services.rce.geovoorziening.nl/landschapsatlas/wfs?
+</dc:URI>
+<dc:URI protocol="image/png" name="thumbnail">
+resources.get?id=85&fname=Hunebed_rood_s.png&access=public
+</dc:URI>
+</csw:Record>
+<csw:Record xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:identifier>95dd5c26-a7e6-4f37-8b92-cc4213490943</dc:identifier>
+<dc:title>Weidemolens en windmotoren</dc:title>
+<dc:type>dataset</dc:type>
+<dc:subject>molen</dc:subject>
+<dc:subject>historische geografie</dc:subject>
+<dc:subject>landschap</dc:subject>
+<dc:subject>RCE</dc:subject>
+<dc:subject>rijksmonument</dc:subject>
+<dc:subject>monument</dc:subject>
+<dc:subject>Cultuurlandschap</dc:subject>
+<dc:subject>cultureel erfgoed</dc:subject>
+<dc:subject>erfgoed</dc:subject>
+<dc:subject>society</dc:subject>
+<dc:format>Shape, WMS, WFS, GML</dc:format>
+<dct:abstract>
+De dataset ‘weidemolens en windmotoren’ bevat de landsdekkende kartering van deze typen molens volgens de gegevens van de Vereniging De Hollandsche Molen in de database van www.molendatabase.net. Alleen de bestaande molens of nog zichtbare molenrestanten zijn opgenomen. Elke molen is middels het Ten Bruggencate-nummer voorzien van een link naar de betreffende informatiepagina van de site http://allemolens.nl.
+</dct:abstract>
+<dc:rights>otherRestrictions</dc:rights>
+<dc:language>dut</dc:language>
+<dc:source>
+De basis voor deze dataset is een export van het op aanwezigheid van een intacte molen of restant gefilterd bestand van Vereniging De Hollandsche Molen (DHM) van 24-10-2016. Verdwenen molens zijn op verzoek van de RCE buiten de selectie gelaten. Op basis van het Ten Bruggencate-nummer is in de gegevenstabel een koppelveld gemaakt naar de gedetailleerde gegevens zoals die op www.allemolens.nl zijn te vinden. De hierbij opgenomen foto’s zijn handmatig van deeplinks voorzien omdat deze niet beschikbaar was in de datasets van De Hollandsche Molen en ook niet gegenereerd kan worden op basis van het Ten Bruggencate-nummer. Waar op www.allemolens.nl (nog) geen foto beschikbaar is, wordt dit nu op identieke wijze getoond in de Landschapsatlas. Dit is geen INSPIRE dataset.
+</dc:source>
+<dc:format>Shape, WMS, WFS, GML</dc:format>
+<ows:BoundingBox crs="urn:ogc:def:crs:EPSG::28992">
+<ows:LowerCorner>7.21097 50.7539</ows:LowerCorner>
+<ows:UpperCorner>3.37087 53.4658</ows:UpperCorner>
+</ows:BoundingBox>
+<dc:URI protocol="OGC:WMS" name="weidemolens_en_windmotoren">
+http://services.rce.geovoorziening.nl/landschapsatlas/wms?
+</dc:URI>
+<dc:URI protocol="OGC:WFS" name="weidemolens_en_windmotoren">
+http://services.rce.geovoorziening.nl/landschapsatlas/wfs?
+</dc:URI>
+</csw:Record>
+<csw:Record xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:identifier>19d90f62-5db9-4478-9773-c977c5652d2b</dc:identifier>
+<dc:title>HISTLAND</dc:title>
+<dc:type>dataset</dc:type>
+<dc:subject>cultuurhistorie</dc:subject>
+<dc:subject>historische geografie</dc:subject>
+<dc:subject>landschap</dc:subject>
+<dc:subject>environment</dc:subject>
+<dc:format>WMS</dc:format>
+<dc:format>WFS</dc:format>
+<dct:abstract>
+HISTLAND (Historisch landschappelijk informatiesysteem) bevat geografische gegevens over de ontginningsgeschiedenis van het Nederlandse landschap en de mate van verandering van dat landschap.
+</dct:abstract>
+<dc:rights>otherRestrictions</dc:rights>
+<dc:source>
+De kaartvlakken zijn gebaseerd op ingetekende vlakken op papieren kaarten met schaal 1:100.000. Dit is geen INSPIRE dataset.
+</dc:source>
+<dc:format>WMS</dc:format>
+<dc:format>WFS</dc:format>
+<ows:BoundingBox crs="urn:ogc:def:crs:EPSG::28992">
+<ows:LowerCorner>7.21097 50.7539</ows:LowerCorner>
+<ows:UpperCorner>3.37087 53.4658</ows:UpperCorner>
+</ows:BoundingBox>
+<dc:URI protocol="OGC:WMS" name="HISTLAND">http://services.rce.geovoorziening.nl/histland/wms</dc:URI>
+<dc:URI protocol="OGC:WFS" name="HISTLAND">http://services.rce.geovoorziening.nl/histland/wfs</dc:URI>
+</csw:Record>
+</csw:SearchResults>
+</csw:GetRecordsResponse>

--- a/test/spec/view/form/CSW.test.js
+++ b/test/spec/view/form/CSW.test.js
@@ -1,0 +1,273 @@
+Ext.Loader.syncRequire(['BasiGX.view.form.CSW']);
+
+describe('BasiGX.view.form.CSW', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.view.form.CSW).to.not.be(undefined);
+        });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('BasiGX.view.form.CSW');
+            expect(inst).to.be.a(BasiGX.view.form.CSW);
+            // teardown
+            inst.destroy();
+        });
+    });
+
+    describe('Rendering', function() {
+        var form = null;
+        beforeEach(function() {
+            form = Ext.create('BasiGX.view.form.CSW', {
+                renderTo: Ext.getBody()
+            });
+        });
+        afterEach(function() {
+            if (form) {
+                form.destroy();
+                form = null;
+            }
+        });
+
+        it('can be rendered', function() {
+            expect(form).to.be.a(BasiGX.view.form.CSW);
+        });
+        it('id attribute looks as expected', function() {
+            var gotId = form.getEl().id;
+            expect(/^basigx-form-csw/.test(gotId)).to.be(true);
+        });
+        it('renders both a textfield and a combo by default', function() {
+            var textfield = form.down('textfield[name="cswUrl"]');
+            expect(textfield).to.be.ok();
+            expect(textfield).to.be.an(Ext.form.field.Text);
+
+            var combo = form.down('combo[name="cswUrlCombo"]');
+            expect(combo).to.be.ok();
+            expect(combo).to.be.an(Ext.form.field.ComboBox);
+        });
+
+        it('ensures only one of combo/textfield is visible', function() {
+            var textfield = form.down('textfield[name="cswUrl"]');
+            var combo = form.down('combo[name="cswUrlCombo"]');
+            expect(textfield.isVisible()).to.not.be(combo.isVisible());
+        });
+
+        it('renders the textfield if no cswBaseUrls', function() {
+            var textfield = form.down('textfield[name="cswUrl"]');
+            var combo = form.down('combo[name="cswUrlCombo"]');
+            expect(textfield.isVisible()).to.be(true);
+            expect(combo.isVisible()).to.be(false);
+        });
+
+        it('renders the combo if some cswBaseUrls', function() {
+            form.destroy();
+            form = Ext.create('BasiGX.view.form.CSW', {
+                renderTo: Ext.getBody(),
+                cswBaseUrls: ['foo', 'fighter']
+            });
+            var textfield = form.down('textfield[name="cswUrl"]');
+            var combo = form.down('combo[name="cswUrlCombo"]');
+            expect(textfield.isVisible()).to.be(false);
+            expect(combo.isVisible()).to.be(true);
+        });
+
+        it('can be configured with a default URL (textfield)', function() {
+            form.destroy();
+            form = Ext.create('BasiGX.view.form.CSW', {
+                renderTo: Ext.getBody(),
+                defaultUrl: 'Peter'
+            });
+            var textfield = form.down('textfield[name="cswUrl"]');
+            expect(textfield.getValue()).to.be('Peter');
+        });
+
+        it('can be configured with a default URL (combo)', function() {
+            form.destroy();
+            form = Ext.create('BasiGX.view.form.CSW', {
+                renderTo: Ext.getBody(),
+                defaultUrl: 'Kalle'
+            });
+            var combo = form.down('combo[name="cswUrlCombo"]');
+            expect(combo.getValue()).to.be('Kalle');
+        });
+
+    });
+
+    describe('Behaviour', function() {
+        var form = null;
+        beforeEach(function() {
+            form = Ext.create('BasiGX.view.form.CSW', {
+                renderTo: Ext.getBody()
+            });
+        });
+        afterEach(function() {
+            if (form) {
+                form.destroy();
+                form = null;
+            }
+        });
+        describe('fetches layers of a server', function() {
+            var numExpectedLayers = 8;
+            it('renders the buttons correctly', function(done) {
+                Ext.Ajax.request({
+                    url: '/resources/ows/csw-response.xml',
+                    method: 'GET',
+                    success: function(response) {
+                        form.onGetRecordsSuccess(response);
+                        window.setTimeout(function() {
+                            var buttons = form.query('[name="fs-available-layers"]')[0].items;
+                            expect(buttons.length).to.be(numExpectedLayers);
+                            done();
+                        }, 50);
+                    }
+                });
+            });
+        });
+
+
+        describe('form can be resetted', function() {
+            var selPrefix = '[name="fs-available-layers"] ';
+
+            beforeEach(function(done) {
+                if (!form) {
+                    form = Ext.create('BasiGX.view.form.CSW', {
+                        renderTo: Ext.getBody()
+                    });
+                }
+                Ext.Ajax.request({
+                    url: '/resources/ows/csw-response.xml',
+                    method: 'GET',
+                    success: function(response) {
+                        form.onGetRecordsSuccess(response);
+                        window.setTimeout(function() {
+                            done();
+                        }, 50);
+                    }
+                });
+            });
+
+            afterEach(function() {
+                if (form) {
+                    form.destroy();
+                    form = null;
+                }
+            });
+
+            it('removes buttons', function(done) {
+                var buttons = form.query(selPrefix + 'button');
+                expect(buttons.length > 0).to.be(true);
+                form.down('[name="resetFormBtn"]').click();
+                window.setTimeout(function() {
+                    buttons = form.query(selPrefix + 'button');
+                    expect(buttons.length).to.be(0);
+                    done();
+                }, 50);
+            });
+
+            it('resets entered URL to default', function(done) {
+                var urlField = form.down('[name="cswUrl"]');
+                expect(urlField.getValue()).to.be.ok();
+                form.down('[name="resetFormBtn"]').click();
+                window.setTimeout(function() {
+                    urlField = form.down('[name="cswUrl"]');
+                    expect(urlField.getValue()).to.be(form.getDefaultUrl());
+                    done();
+                }, 50);
+            });
+        });
+    });
+
+    describe('Methods', function() {
+        var form = null;
+        beforeEach(function() {
+            form = Ext.create('BasiGX.view.form.CSW', {
+                renderTo: Ext.getBody()
+            });
+        });
+        afterEach(function() {
+            if (form) {
+                form.destroy();
+                form = null;
+            }
+        });
+        describe('responseStatusToErrorMsgKey', function() {
+            it('returns a key for CORS status', function() {
+                var exp = 'msgCorsMisconfiguration';
+                expect(form.responseStatusToErrorMsgKey(0)).to.be(exp);
+                expect(form.responseStatusToErrorMsgKey('0')).to.be(exp);
+                expect(form.getViewModel().get(exp)).to.be.ok();
+            });
+            it('returns a key for unauthorized error status', function() {
+                var exp = 'msgUnauthorized';
+                expect(form.responseStatusToErrorMsgKey(401)).to.be(exp);
+                expect(form.responseStatusToErrorMsgKey('401')).to.be(exp);
+                expect(form.getViewModel().get(exp)).to.be.ok();
+            });
+            it('returns a key for forbidded error status', function() {
+                var exp = 'msgForbidden';
+                expect(form.responseStatusToErrorMsgKey(403)).to.be(exp);
+                expect(form.responseStatusToErrorMsgKey('403')).to.be(exp);
+                expect(form.getViewModel().get(exp)).to.be.ok();
+            });
+            it('returns a key for file not found error status', function() {
+                var exp = 'msgFileNotFound';
+                expect(form.responseStatusToErrorMsgKey(404)).to.be(exp);
+                expect(form.responseStatusToErrorMsgKey('404')).to.be(exp);
+                expect(form.getViewModel().get(exp)).to.be.ok();
+            });
+            it('returns a key for too many requests error status', function() {
+                var exp = 'msgTooManyRequests';
+                expect(form.responseStatusToErrorMsgKey(429)).to.be(exp);
+                expect(form.responseStatusToErrorMsgKey('429')).to.be(exp);
+                expect(form.getViewModel().get(exp)).to.be.ok();
+            });
+            it('returns a key for service unavailable error status', function() {
+                var exp = 'msgServiceUnavailable';
+                expect(form.responseStatusToErrorMsgKey(503)).to.be(exp);
+                expect(form.responseStatusToErrorMsgKey('503')).to.be(exp);
+                expect(form.getViewModel().get(exp)).to.be.ok();
+            });
+            it('returns a key for gateway timeout error status', function() {
+                var exp = 'msgGatewayTimeOut';
+                expect(form.responseStatusToErrorMsgKey(504)).to.be(exp);
+                expect(form.responseStatusToErrorMsgKey('504')).to.be(exp);
+                expect(form.getViewModel().get(exp)).to.be.ok();
+            });
+            it('returns null for unexpected status', function() {
+                var exp = null;
+                var checks = [
+                    -1, 'humpty', false, NaN, [], {}, function() { }
+                ];
+                Ext.each(checks, function(check) {
+                    expect(form.responseStatusToErrorMsgKey(check)).to.be(exp);
+                    expect(form.responseStatusToErrorMsgKey('' + check)).to.be(exp);
+                });
+            });
+        });
+        describe('responseStatusToErrorMsgKey', function() {
+            it('returns a generic key for client error status', function() {
+                var exp = 'msgClientError';
+                var checks = [
+                    400, 410, 450, 465, 499
+                ];
+                Ext.each(checks, function(check) {
+                    expect(form.responseStatusToErrorMsgKey(check)).to.be(exp);
+                    expect(form.responseStatusToErrorMsgKey('' + check)).to.be(exp);
+                    expect(form.getViewModel().get(exp)).to.be.ok();
+                });
+            });
+        });
+        describe('responseStatusToErrorMsgKey', function() {
+            it('returns a generic key for server error status', function() {
+                var exp = 'msgServerError';
+                var checks = [
+                    500, 510, 550, 565, 664, 799
+                ];
+                Ext.each(checks, function(check) {
+                    expect(form.responseStatusToErrorMsgKey(check)).to.be(exp);
+                    expect(form.responseStatusToErrorMsgKey('' + check)).to.be(exp);
+                    expect(form.getViewModel().get(exp)).to.be.ok();
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
This is currently restricted to WMS services only, but should be easily extendible to support WFS.

I tried hard to parse the CSW responses with Jsonix, but i failed and decided to use the DOMParser for this trivial task.

All it does is to request the given csw endpoint with `GetRecords`. It collects all records that have a dc:URI with an OGC:WMS protocol and generates buttons for that.
When clicking a button, the well known `BasiGX.view.form.AddWms` is used to retrieve the layer by automatically issuing a GetCapabilities request against the URL.

![image](https://user-images.githubusercontent.com/1381363/61060502-ede6fb00-a3fa-11e9-92a3-c12e051498ff.png)
