### PR TITLE
Execute CSW search on ENTER in search text field

### DIFF
--- a/src/view/form/CSW.js
+++ b/src/view/form/CSW.js
@@ -208,6 +208,15 @@ Ext.define('BasiGX.view.form.CSW', {
                     change: function(textfield) {
                         var view = textfield.up('basigx-form-csw');
                         view.resetState();
+                    },
+                    specialkey: function (textfield, evt) {
+                        // execute search on ENTER is hit inside the textfield
+                        if(evt.getKey() === evt.ENTER){
+                            evt.preventDefault();
+                            var view = textfield.up('basigx-form-csw');
+                            view.resetState();
+                            view.requestGetRecords();
+                        }
                     }
                 }
             }]


### PR DESCRIPTION
This ensures that the CSW search is executed if the ENTER key is hit inside the search text field of the `BasiGX.view.form.CSW`.