### PR TITLE
Fixes tooltip binding in base button

### DIFF
--- a/src/view/button/Base.js
+++ b/src/view/button/Base.js
@@ -21,21 +21,23 @@
 Ext.define('BasiGX.view.button.Base', {
     extend: 'Ext.Button',
     xtype: 'basigx-button-base',
+
     viewModel: {
         data: {}
     },
     bind: {},
+
     /**
      *
      */
-    constructor: function() {
+    constructor: function () {
         var me = this;
         me.callParent(arguments);
         if (me.setTooltip) {
             var bind = me.config.bind;
             var ttFromViewModel = me.getViewModel().get('tooltip');
             if (ttFromViewModel) {
-                bind.tooltip = ttFromViewModel;
+                bind.tooltip = '{tooltip}';
             }
             me.setBind(bind);
         }


### PR DESCRIPTION
This removes the constructor and adds binding for `text` and `tooltip` for the `BasiGX.view.button.Base`.