### PR TITLE
Reset window reference on destroying properly

### DIFF
--- a/src/view/button/AddWms.js
+++ b/src/view/button/AddWms.js
@@ -131,8 +131,7 @@ Ext.define('BasiGX.view.button.AddWms', {
     },
 
     handler: function() {
-        var win = this._win;
-        if (!win) {
+        if (!this._win) {
             var windowConfig = {
                 name: 'add-wms-window',
                 title: this.getViewModel().get('windowTitle'),
@@ -142,27 +141,29 @@ Ext.define('BasiGX.view.button.AddWms', {
                 constrain: true,
                 items: [{
                     xtype: 'basigx-form-addwms'
-                }]
+                }],
+                listeners: {
+                    destroy: this.onDestroy,
+                    scope: this
+                }
             };
 
             var windowConfigToApply = this.getWindowConfig();
             Ext.apply(windowConfig, windowConfigToApply);
 
-            win = Ext.create('Ext.window.Window', windowConfig);
-            this._win = win;
-            win.show();
+            this._win = Ext.create('Ext.window.Window', windowConfig);
+            this._win.show();
         } else {
-            BasiGX.util.Animate.shake(win);
+            BasiGX.util.Animate.shake(this._win);
         }
     },
 
     /**
-     * Do any necessary cleanup (e.g. remove listeners, destroy dependent
-     * objects …).
+     * Reset window reference
      */
     onDestroy: function() {
         if (this._win) {
-            this._win.destroy();
+            this._win = null;
         }
     }
 });

--- a/src/view/button/CoordinateTransform.js
+++ b/src/view/button/CoordinateTransform.js
@@ -80,9 +80,8 @@ Ext.define('BasiGX.view.button.CoordinateTransform', {
      */
     config: {
         handler: function() {
-            var win = this._win;
-            if (!win) {
-                win = Ext.create('Ext.window.Window', {
+            if (!this._win) {
+                this._win = Ext.create('Ext.window.Window', {
                     name: 'coordinate-transform-window',
                     title: this.getViewModel().get('windowTitle'),
                     width: 500,
@@ -93,23 +92,25 @@ Ext.define('BasiGX.view.button.CoordinateTransform', {
                         xtype: 'basigx-form-coordinatetransform',
                         coordinateSystemsToUse: this.coordinateSystemsToUse,
                         transformCenterOnRender: this.transformCenterOnRender
-                    }]
+                    }],
+                    listeners: {
+                        destroy: this.onDestroy,
+                        scope: this
+                    }
                 });
-                this._win = win;
-                win.show();
+                this._win.show();
             } else {
-                BasiGX.util.Animate.shake(win);
+                BasiGX.util.Animate.shake(this._win);
             }
         }
     },
 
     /**
-     * Do any necessary cleanup (e.g. remove listeners, destroy dependent
-     * objects …).
+     * Reset window reference
      */
     onDestroy: function() {
         if (this._win) {
-            this._win.destroy();
+            this._win = null;
         }
     }
 });

--- a/test/spec/view/button/AddWms.test.js
+++ b/test/spec/view/button/AddWms.test.js
@@ -31,6 +31,9 @@ describe('BasiGX.view.button.AddWms', function() {
             expect(wins.length).to.be(1);
             var forms = wins[0].query('basigx-form-addwms');
             expect(forms.length).to.be(1);
+            Ext.each(wins, function(w) {
+                w.close();
+            });
             // teardown
             btn.destroy();
         });
@@ -46,6 +49,11 @@ describe('BasiGX.view.button.AddWms', function() {
             expect(wins.length).to.be(1);
             var forms = wins[0].query('basigx-form-addwms');
             expect(forms.length).to.be(1);
+            expect(btn._win === wins[0]);
+            Ext.each(wins, function (w) {
+                w.close();
+            });
+            expect(btn._win === null);
             // teardown
             btn.destroy();
         });
@@ -55,9 +63,16 @@ describe('BasiGX.view.button.AddWms', function() {
                 renderTo: Ext.getBody()
             });
             btn.click();
-            btn.destroy();
             var wins = Ext.ComponentQuery.query('window[name=add-wms-window]');
+            expect(wins.length).to.be(1);
+            Ext.each(wins, function (w) {
+                w.close();
+            });
+            wins = Ext.ComponentQuery.query('window[name=add-wms-window]');
             expect(wins.length).to.be(0);
+            expect(btn._win === null);
+            // teardown
+            btn.destroy();
         });
     });
 });

--- a/test/spec/view/button/CoordinateTransform.test.js
+++ b/test/spec/view/button/CoordinateTransform.test.js
@@ -40,6 +40,9 @@ describe('BasiGX.view.button.CoordinateTransform', function() {
                 expect(wins.length).to.be(1);
                 var forms = wins[0].query('basigx-form-coordinatetransform');
                 expect(forms.length).to.be(1);
+                Ext.each(wins, function (w) {
+                    w.close();
+                });
                 // teardown
                 btn.destroy();
             }
@@ -61,6 +64,11 @@ describe('BasiGX.view.button.CoordinateTransform', function() {
             expect(wins.length).to.be(1);
             var forms = wins[0].query('basigx-form-coordinatetransform');
             expect(forms.length).to.be(1);
+            expect(btn._win === wins[0]);
+            Ext.each(wins, function (w) {
+                w.close();
+            });
+            expect(btn._win === null);
             // teardown
             btn.destroy();
         });
@@ -73,11 +81,20 @@ describe('BasiGX.view.button.CoordinateTransform', function() {
                 ]
             });
             btn.click();
-            btn.destroy();
             var wins = Ext.ComponentQuery.query(
                 'window[name=coordinate-transform-window]'
             );
+            expect(wins.length).to.be(1);
+            Ext.each(wins, function (w) {
+                w.close();
+            });
+            wins = Ext.ComponentQuery.query(
+                'window[name=coordinate-transform-window]'
+            );
             expect(wins.length).to.be(0);
+            expect(btn._win === null);
+            // teardown
+            btn.destroy();
         });
     });
 });


### PR DESCRIPTION
Previously `AddWms` and `CoordinateTransform` windows could be shown only once. 

After the component was called repeatedly (e.g. after the window was closed), the console error was thrown, cause the window instance was not reset properly:
![image](https://user-images.githubusercontent.com/3939355/65514402-87438a80-dedd-11e9-9a2b-43cf0c025a31.png)


Please review @weskamm 