### PR TITLE
Initialize coords to map's starting center

### DIFF
--- a/src/view/panel/CoordinateMousePositionPanel.js
+++ b/src/view/panel/CoordinateMousePositionPanel.js
@@ -375,7 +375,8 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
         var me = this;
         if (me.olMap) {
             var center = me.olMap.getView().getCenter();
-            center = ol.proj.transform(center, me.olMousePositionControl.getProjection(),
+            center = ol.proj.transform(center, 
+                me.olMousePositionControl.getProjection(),
                 me.olMap.getView().getProjection());
 
             me.getViewModel().setData({

--- a/src/view/panel/CoordinateMousePositionPanel.js
+++ b/src/view/panel/CoordinateMousePositionPanel.js
@@ -375,7 +375,7 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
         var me = this;
         if (me.olMap) {
             var center = me.olMap.getView().getCenter();
-            center = ol.proj.transform(center, 
+            center = ol.proj.transform(center,
                 me.olMousePositionControl.getProjection(),
                 me.olMap.getView().getProjection());
 

--- a/src/view/panel/CoordinateMousePositionPanel.js
+++ b/src/view/panel/CoordinateMousePositionPanel.js
@@ -178,6 +178,7 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
         me.on('afterrender', function() {
             me.initOlMouseControl();
             me.initProjections();
+            me.initCenter();
         });
         me.callParent();
     },
@@ -200,7 +201,7 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
 
     /**
      * Initilization of projections using BasiGX.util.Projection for passed
-     * EPSG codes / currently active propjection in map
+     * EPSG codes / currently active projection in map
      */
     initProjections: function() {
         var me = this;
@@ -365,6 +366,23 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
         observer.observe(coordElement, {
             childList: true
         });
+    },
+
+    /**
+     * Initializes the text boxes with the map's initial center
+     */
+    initCenter: function() {
+        var me = this;
+        if (me.olMap) {
+            var center = me.olMap.getView().getCenter();
+            center = ol.proj.transform(center, me.olMousePositionControl.getProjection(),
+                me.olMap.getView().getProjection());
+
+            me.getViewModel().setData({
+                xVal: center[0],
+                yVal: center[1]
+            });
+        }
     },
 
     /**


### PR DESCRIPTION
If a map is available use its initial centre point to fill text boxes. If a user sets X,Y on the model these will take precedent. See #521. 

A couple of questions:

- should this be made an option so it can be enabled/disabled?
- there doesn't seem to be a way to set the starting projection for CoordinateMousePositionPanel (it is always the map projection?), so the centroid takes the map projection. 
