### PR TITLE
Enhance hovering of vector layer features

### DIFF
--- a/src/plugin/Hover.js
+++ b/src/plugin/Hover.js
@@ -384,10 +384,16 @@ Ext.define('BasiGX.plugin.Hover', {
                             // from the clusterStyle
                             hvl.setStyle(me.highlightStyleFunction);
                         }
-                        var featureClone = feat.clone();
-                        featureClone.set('layer', layer);
                         hoverLayers.push(layer);
-                        hoverFeatures.push(featureClone);
+                        if (feat.get('layer') === layer) {
+                            var clone = feat.clone();
+                            if (!Ext.Array.contains(hoverFeatures, clone)) {
+                                var style = me.highlightStyleFunction(
+                                    clone, resolution, pixel);
+                                clone.setStyle(style);
+                                hoverFeatures.push(clone);
+                            }
+                        }
                         me.showHoverFeature(layer, hoverFeatures);
                         me.currentHoverTarget = feat;
                     }, me, function(vectorCand) {


### PR DESCRIPTION
## Bugfix

Previously multiple clones of same feature were shown while hovering over any vector layer and default feature style (blue point with transparent fill for points etc.) was always used for highlighing.

This PR provides the following fixes: 
* Enhance check for hover feature candidates and prevent adding of dublicated features
* Set highlighing style on hovered features properly

Please review @terrestris/devs 
