### PR TITLE
Make hoverColor property of hover plugin configurable

### DIFF
--- a/src/plugin/Hover.js
+++ b/src/plugin/Hover.js
@@ -76,6 +76,7 @@ Ext.define('BasiGX.plugin.Hover', {
         hoverVectorLayerSource: null,
         hoverVectorLayer: null,
         hoverVectorLayerInteraction: null,
+        hoverColor: 'rgba(255, 0, 0, 0.6)',
         dynamicHoverColor: false,
         enableHoverSelection: true,
         /**
@@ -659,7 +660,7 @@ Ext.define('BasiGX.plugin.Hover', {
     highlightStyleFunction: function(feature, resolution, baseColor) {
         var me = this;
         var count = feature.get('count');
-        var hoverColor = 'rgba(255, 0, 0, 0.6)';
+        var hoverColor = me.getHoverColor();
         var dynamicHoverColor = me.getDynamicHoverColor();
         var radius = 14;
         var fontSize = 10;

--- a/test/spec/plugin/Hover.test.js
+++ b/test/spec/plugin/Hover.test.js
@@ -186,6 +186,9 @@ describe('BasiGX.plugin.Hover', function() {
                     ol.interaction.Select
                 );
             });
+            it('has a default hoverColor value set', function () {
+                expect(plugin.getHoverColor()).to.be('rgba(255, 0, 0, 0.6)');
+            });
         });
         describe('defaults are changeable', function() {
             var mapComponentConfigured;
@@ -194,11 +197,13 @@ describe('BasiGX.plugin.Hover', function() {
             var layer;
             var interaction;
             var testObjs2;
+            var hoverColor;
 
             beforeEach(function() {
                 source = new ol.source.Vector();
                 layer = new ol.layer.Vector();
                 interaction = new ol.interaction.Select();
+                hoverColor = 'rgba(0, 255, 0, 1)';
                 testObjs2 = TestUtil.setupTestObjects({
                     mapComponentOpts: {
                         plugins: {
@@ -209,6 +214,7 @@ describe('BasiGX.plugin.Hover', function() {
                             featureInfoEpsg: 'EPSG:1337',
                             hoverVectorLayerSource: source,
                             hoverVectorLayer: layer,
+                            hoverColor: hoverColor,
                             hoverVectorLayerInteraction: interaction
                         }
                     }
@@ -249,6 +255,11 @@ describe('BasiGX.plugin.Hover', function() {
             it('has the expected hoverVectorLayerInteraction', function() {
                 expect(pluginConfigured.getHoverVectorLayerInteraction()).to.be(
                     interaction
+                );
+            });
+            it('has the expected hoverColor', function () {
+                expect(pluginConfigured.getHoverColor()).to.be(
+                    hoverColor
                 );
             });
         });


### PR DESCRIPTION
Adds possibility to set custom color while hovering over features.

The default behaviour (red color with 0.6 opacity) is unchanged.

Please review @weskamm 