### PR TITLE
Make use of custom layer search configuration with WFS search

### DIFF
--- a/src/util/StringTemplate.js
+++ b/src/util/StringTemplate.js
@@ -1,0 +1,142 @@
+/* Copyright (c) 2019-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * StringTemplate Util
+ *
+ * This util contains some methods to manipulate string arguments using certain
+ * templates.
+ *
+ * @class BasiGX.util.StringTemplate
+ */
+Ext.define('BasiGX.util.StringTemplate', {
+
+    requires: [
+    ],
+
+    statics: {
+
+        /**
+         * The prefix used in a regular expression to match any placeholder
+         * field in the provided template.
+         *
+         * @type {String}
+         */
+        TEMPLATE_PLACEHOLDER_PREFIX: '{{',
+
+        /**
+         * The suffix used in a regular expression to match any placeholder
+         * field in the provided template.
+         *
+         * @type {String}
+         */
+        TEMPLATE_PLACEHOLDER_SUFFIX: '}}',
+
+        /**
+         * Returns the display text for the passed feature using provided
+         * template. Can be used for customized representation of
+         * feature properties e.g. on hovering or inside of search result
+         * grids.
+         *
+         * @param {ol.Feature} feature The affected feature.
+         * @param {String} template The template to fill with feature
+         *     attributes.
+         * @param {Object} config Object containing template config (suffix and
+         *     prefix). Optional.
+         * @return {String} The templated feature text.
+         */
+        getTextFromTemplate: function (feature, template, config) {
+            var staticMe = BasiGX.util.StringTemplate;
+            var placeHolderPrefix = staticMe.TEMPLATE_PLACEHOLDER_PREFIX;
+            var placeHolderSuffix = staticMe.TEMPLATE_PLACEHOLDER_SUFFIX;
+            if (config && config.prefix) {
+                placeHolderPrefix = config.prefix;
+            }
+            if (config && config.suffix) {
+                placeHolderSuffix = config.suffix;
+            }
+            var templatedText;
+
+            if (feature && template) {
+                // Find any character between two braces (including the braces
+                // in the result)
+                var regExp = new RegExp(placeHolderPrefix + '(.*?)' +
+                        placeHolderSuffix, 'g');
+                var regExpRes = template.match(regExp);
+
+                // If we have a regex result, it means we found a placeholder in
+                // the template and have to replace the placeholder with its
+                // appropriate value
+                if (regExpRes) {
+                    // Iterate over all regex match results and find the proper
+                    // attribute for the given placeholder, finally set the
+                    // desired value to the hover field text
+                    Ext.each(regExpRes, function (res) {
+                        // We count every non matching candidate. If this count
+                        // us equal to the objects length, we assume that there
+                        // is no match at all and set the output value to an
+                        // empty value
+                        var noMatchCnt = 0;
+
+                        var props = feature.getProperties ?
+                            feature.getProperties() : feature.properties;
+
+                        Ext.iterate(props, function (k, v) {
+                            // Remove the suffixes and find the matching
+                            // attribute column
+                            var phPrefixLength = decodeURIComponent(
+                                placeHolderPrefix).length;
+                            var phSuffixLength = decodeURIComponent(
+                                placeHolderSuffix).length;
+                            var placeHolderName = res.slice(phPrefixLength,
+                                res.length - phSuffixLength);
+                            if (placeHolderName === k) {
+                                template = template.replace(res, v);
+                                return false;
+                            } else {
+                                noMatchCnt++;
+                            }
+                        });
+
+                        // No key match found for this feature (e.g. if key not
+                        // present or value is null)
+                        if (noMatchCnt === Ext.Object.getSize(props)) {
+                            template = template.replace(res, '');
+                        }
+                        templatedText = template;
+                    });
+                } else if (feature.get && feature.get(template) &&
+                    !Ext.isEmpty(feature.get(template))) {
+                    // If we couldn't find any match, the template could be a
+                    // simple string containing the e.g. "hoverTemplate".
+                    // To obtain backwards-compatibility, we check if this
+                    // field is present and set the text accordingly
+                    template = feature.get(template);
+                    templatedText = template;
+                } else {
+                    // Try to use "id" as fallback.
+                    // If "id" is not available, the value will be "undefined"
+                    templatedText = feature.id;
+                }
+            }
+
+            // Replace all newline breaks with a html <br> tag
+            if (Ext.isString(templatedText)) {
+                templatedText = templatedText.replace(/\n/g, '<br>');
+            }
+            return templatedText;
+        }
+    }
+});

--- a/src/view/grid/MultiSearchWFSSearchGrid.js
+++ b/src/view/grid/MultiSearchWFSSearchGrid.js
@@ -612,7 +612,6 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
                     }
 
                     var displayfield;
-                    var featuretype = feature.id.split('.')[0];
 
                     if (useCustomTemplate) {
                         var templateUtil = BasiGX.util.StringTemplate;
@@ -632,7 +631,7 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
                     }
 
                     feature.properties.displayfield = displayfield;
-                    feature.properties.featuretype = featuretype;
+                    feature.properties.featuretype = ftName;
 
                     var olFeat = parser.readFeatures(feature, {
                         dataProjection: combo.getWfsDataProjection(),

--- a/src/view/grid/MultiSearchWFSSearchGrid.js
+++ b/src/view/grid/MultiSearchWFSSearchGrid.js
@@ -1,3 +1,4 @@
+/* eslint max-len: ["error", { "comments": 100 }] */
 /* Copyright (c) 2016-present terrestris GmbH & Co. KG
  *
  * This program is free software: you can redistribute it and/or modify
@@ -478,13 +479,24 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
                                 '</ogc:Literal>' +
                             '</ogc:PropertyIsLike>';
                         break;
+                    // TODO add support for xsd:date
                     case 'xsd:int':
                     case 'xsd:number':
+                        var type = 'java.lang.Double';
+                        // Creates custom filter function `stringFormat` which
+                        // doesn't oficially contained in geoserver filter
+                        // functions list.
+                        // To get this filter work, the additional geoserver
+                        // extension `terrestris-filterfunctions` must be
+                        // installed (see
+                        // https://github.com/terrestris/terrestris-filterfunctions
+                        // for further details)
                         comparisonFilter =
                             '<ogc:PropertyIsLike wildCard="*" singleChar="."' +
                                 ' escape="\\" matchCase="false">' +
                                 '<ogc:Function name="stringFormat">' +
                                     '<ogc:Literal>%f</ogc:Literal>' +
+                                    '<ogc:Literal>' + type + '</ogc:Literal>' +
                                     '<ogc:PropertyName>' +
                                         prop.name +
                                     '</ogc:PropertyName>' +

--- a/test/spec/util/StringTemplate.test.js
+++ b/test/spec/util/StringTemplate.test.js
@@ -1,0 +1,81 @@
+Ext.Loader.syncRequire(['BasiGX.util.StringTemplate']);
+
+describe('BasiGX.util.StringTemplate', function () {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.util.StringTemplate).to.not.be(undefined);
+        });
+    });
+
+    describe('Static methods', function() {
+
+        var feature = null;
+
+        beforeEach(function () {
+            feature = new ol.Feature({
+                id: 123,
+                geometry: new ol.geom.Point([10, 10]),
+                featProp: 'featValue',
+                anotherFeatProp: 'anotherFeatValue'
+            });
+        });
+
+        afterEach(function() {
+            feature = null;
+        });
+
+        describe('#getTextFromTemplate', function() {
+            it('is defined', function() {
+                expect(BasiGX.util.StringTemplate.getTextFromTemplate).to.not.be(undefined);
+            });
+            it('is returns templated value for provided feature for single ' +
+                'template occurance', function() {
+                var tpl = '{{featProp}}';
+                var got = BasiGX.util.StringTemplate.getTextFromTemplate(feature, tpl);
+                expect(got).to.be(feature.get('featProp'));
+            });
+            it('is returns templated value for provided feature for multiple ' +
+                'template occurancies', function() {
+                var tpl = '{{featProp}}{{anotherFeatProp}}';
+                var got = BasiGX.util.StringTemplate.getTextFromTemplate(feature, tpl);
+                var tplValue = feature.get('featProp') + feature.get('anotherFeatProp');
+                expect(got).to.be(tplValue);
+            });
+            it('is makes use of template config if provided', function() {
+                var tpl = '<featProp>';
+                var config = {
+                    prefix: '<',
+                    suffix: '>'
+                };
+                var got = BasiGX.util.StringTemplate.getTextFromTemplate(feature, tpl, config);
+                expect(got).to.be(feature.get('featProp'));
+            });
+            it('returns feature id if custom template could not be applied', function() {
+                var tpl = '{{featProp}}';
+                var config = {
+                    prefix: '<',
+                    suffix: '>'
+                };
+                var got = BasiGX.util.StringTemplate.getTextFromTemplate(feature, tpl, config);
+                expect(got).to.be(feature.id);
+            });
+            it('returns undefined if any template could not be applied and '+
+                'feature has no id', function() {
+                var tpl = '{{featProp}}';
+                var config = {
+                    prefix: '<',
+                    suffix: '>'
+                };
+                delete feature.id;
+                var got = BasiGX.util.StringTemplate.getTextFromTemplate(feature, tpl, config);
+                expect(got).to.be(undefined);
+            });
+            it('replaces newline breaks in template by a html <br> tag', function() {
+                var tpl = '{{featProp}}\n{{anotherFeatProp}}';
+                var got = BasiGX.util.StringTemplate.getTextFromTemplate(feature, tpl);
+                var tplValue = feature.get('featProp') + '<br>' + feature.get('anotherFeatProp');
+                expect(got).to.be(tplValue);
+            });
+        });
+    });
+});


### PR DESCRIPTION
### BREAKING CHANGE | FEATURE
## Support for querying of numerical attributes
Previously only `PropertyIsLike`  filter was implemented so only string based attributes could be searched through via WFS. 
This MR extends `MutiSearchWFSSearchGrid` class and adds possibility to query numeric attributes (`xsd:number` or `xsd:int`) as well.

To achieve this, an additional filter function `stringFormat` was implemented.

Please note, that numeric attributes can be only be queried and filtered, if an additional extension [`terrestris-filterfunctions-0.0.1.jar`](https://nexus.terrestris.de/repository/public/de/terrestris/terrestris-filterfunctions/0.0.1/terrestris-filterfunctions-0.0.1.jar) is available in geoserver. Please refer to https://github.com/terrestris/terrestris-filterfunctions for further details. 

## Support for certain layer attributes
If layer is configured with custom property `searchable` and has a non empty array of `searchColumns` as further config defined, only these columns will be queried via `GetFeature` request. Otherwise all layer attributes will be used while searching (default behaviour)

## Support for certain layer search results template
If layer is configured with a custom property `searchable` and has a further non empty property `searchTemplate`, this template will be used to represent found features inside of search results grid.
Otherwise the attribute, which contains the search term will be shown as result title instead (default behaviour).

Also introduced `StringTemplate` util and moved `getHoverTextFromTemplate` method of `Hover.js` class inside, since this method can be used for both hover and WFS search results.

Please review @terrestris/devs 