### PR TITLE
Handle hovering over vector layers correctly

### DIFF
--- a/src/plugin/Hover.js
+++ b/src/plugin/Hover.js
@@ -389,10 +389,19 @@ Ext.define('BasiGX.plugin.Hover', {
                             // from the clusterStyle
                             hvl.setStyle(me.highlightStyleFunction);
                         }
-                        hoverLayers.push(layer);
+                        if(!Ext.Array.contains(hoverLayers, layer)) {
+                            hoverLayers.push(layer);
+                        }
                         if (feat.get('layer') === layer) {
                             var clone = feat.clone();
-                            if (!Ext.Array.contains(hoverFeatures, clone)) {
+                            clone.setId(feat.getId());
+
+                            var hoverFeaturesIds = Ext.Array.map(hoverFeatures,
+                                function(hoverFeat) {
+                                    return hoverFeat.getId();
+                                });
+                            if (!Ext.Array.contains(hoverFeaturesIds,
+                                feat.getId())) {
                                 var style = me.highlightStyleFunction(
                                     clone, resolution, pixel);
                                 clone.setStyle(style);

--- a/src/plugin/Hover.js
+++ b/src/plugin/Hover.js
@@ -389,7 +389,7 @@ Ext.define('BasiGX.plugin.Hover', {
                             // from the clusterStyle
                             hvl.setStyle(me.highlightStyleFunction);
                         }
-                        if(!Ext.Array.contains(hoverLayers, layer)) {
+                        if (!Ext.Array.contains(hoverLayers, layer)) {
                             hoverLayers.push(layer);
                         }
                         if (feat.get('layer') === layer) {


### PR DESCRIPTION
In addition to https://github.com/terrestris/BasiGX/pull/527 this change fixes some strange behaviour when hovering over vector layers.

First time hovering over a vector was fine, but every subsequent hover action on the same feature resulted in a growing layer (and also feature) list in the popup. The problem also occured at locations where two or more features had the same (or at least similar) geometry.

To avoid the growing layer list, there is a simple check whether the layer is already contained in the `hoverLayers` array.
To avoid the growing feature (template/attribute) list of a layer, the (maybe generated) `id` of `feat` is also applied to its clone to be able to check whether this feature should be added in the next iteration or not.

Please review @terrestris/devs 