### PR TITLE
Add close trigger to `MultiSearchCombo` component

### DIFF
--- a/src/view/form/field/MultiSearchCombo.js
+++ b/src/view/form/field/MultiSearchCombo.js
@@ -169,6 +169,27 @@ Ext.define('BasiGX.view.form.field.MultiSearchCombo', {
             handler: function() {
                 this.showSettingsWindow();
             }
+        },
+        close: {
+            cls: 'multisearch-open-container-trigger',
+            handler: function (combo, trigger) {
+                this.changeContainerVisibility(combo, trigger);
+            }
+        }
+    },
+
+    /**
+     * Called by the close trigger, changes visibility of search results
+     * container.
+     * @param {BasiGX.view.form.field.MultiSearchCombo} combo Multisearch combo.
+     */
+    changeContainerVisibility:  function(combo) {
+        if (combo.searchContainer) {
+            if (combo.searchContainer.isVisible()) {
+                combo.cleanupSearch();
+            } else {
+                combo.refreshSearchResults();
+            }
         }
     },
 
@@ -269,6 +290,13 @@ Ext.define('BasiGX.view.form.field.MultiSearchCombo', {
 
         if (searchLayer) {
             searchLayer.getSource().clear();
+        }
+
+        var closeTrigger = me.triggers.close;
+        if (closeTrigger) {
+            var openCls = 'multisearch-open-container-trigger';
+            var closeCls = 'multisearch-close-container-trigger';
+            closeTrigger.el.removeCls(closeCls).addCls(openCls);
         }
 
         if (me.searchContainer) {
@@ -401,6 +429,12 @@ Ext.define('BasiGX.view.form.field.MultiSearchCombo', {
         }
         me.searchContainer.show();
 
+        var closeTrigger = me.triggers.close;
+        if (closeTrigger) {
+            var openCls = 'multisearch-open-container-trigger';
+            var closeCls = 'multisearch-close-container-trigger';
+            closeTrigger.el.removeCls(openCls).addCls(closeCls);
+        }
     },
 
     /**
@@ -411,7 +445,9 @@ Ext.define('BasiGX.view.form.field.MultiSearchCombo', {
 
         var value = me.getValue();
 
+
         if (value && value.length >= me.minChars) {
+            me.showResults();
             me.doGazetteerSearch(value);
             me.doObjectSearch(value);
         } else {

--- a/src/view/form/field/MultiSearchCombo.js
+++ b/src/view/form/field/MultiSearchCombo.js
@@ -172,8 +172,8 @@ Ext.define('BasiGX.view.form.field.MultiSearchCombo', {
         },
         close: {
             cls: 'multisearch-open-container-trigger',
-            handler: function (combo, trigger) {
-                this.changeContainerVisibility(combo, trigger);
+            handler: function (combo) {
+                this.changeContainerVisibility(combo);
             }
         }
     },


### PR DESCRIPTION
Previously the search result container could be only removed if the search field was cleared.

Added a trigger which allows to hide and show results again.

![image](https://user-images.githubusercontent.com/3939355/70818642-87646f80-1dd4-11ea-98b2-9e20a9ca4949.png)

Also added 2 further configs to `MultiSearchWFSSearchGrid` component:
* `zoomToSearchResults` - whether the map should zoom to clicked search result, default is false (old behaviour)
* `zoomToScale` - optional config which defines scale value, which should be used as max zoom by click on search result if `zoomToSearchResults` option is set to true.

Please review @terrestris/devs 
