### PR TITLE
Add proxy URL config to add wms form

### DIFF
--- a/src/view/form/AddWms.js
+++ b/src/view/form/AddWms.js
@@ -137,6 +137,12 @@ Ext.define('BasiGX.view.form.AddWms', {
         wmsBaseUrls: [],
 
         /**
+         * Defines a URL which will be appended to all capabilites requests.
+         * Especially useful when dealing with CORS problems.
+         */
+        proxyUrl: null,
+
+        /**
          * Default url for the textfield or combobox.
          */
         defaultUrl: 'https://ows.terrestris.de/osm/service',
@@ -420,12 +426,16 @@ Ext.define('BasiGX.view.form.AddWms', {
         me.setLoading(true);
         me.removeAddLayersComponents();
         var values = form.getValues();
-        var url;
+        var url = '';
+
+        if (me.getProxyUrl()) {
+            url += me.getProxyUrl()
+        }
 
         if (me.wmsBaseUrls.length === 0) {
-            url = values.url;
+            url += values.url;
         } else {
-            url = values.urlCombo;
+            url += values.urlCombo;
         }
 
         var version;

--- a/src/view/form/AddWms.js
+++ b/src/view/form/AddWms.js
@@ -429,7 +429,7 @@ Ext.define('BasiGX.view.form.AddWms', {
         var url = '';
 
         if (me.getProxyUrl()) {
-            url += me.getProxyUrl()
+            url += me.getProxyUrl();
         }
 
         if (me.wmsBaseUrls.length === 0) {


### PR DESCRIPTION
This adds a config option to specify a proxy URL which will be applied to the capabilites requests.

Useful e.g. when having issues with CORS

@terrestris/devs please review