### PR TITLE
Enhance ftname detection

### DIFF
--- a/src/view/grid/MultiSearchWFSSearchGrid.js
+++ b/src/view/grid/MultiSearchWFSSearchGrid.js
@@ -336,15 +336,23 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
             method: 'GET',
             success: function(response) {
                 me.setLoading(false);
-                if (Ext.isString(response.responseText)) {
-                    featureTypes = Ext.decode(response.responseText);
-                } else if (Ext.isObject(response.responseText)) {
-                    featureTypes = response.responseText;
-                } else {
-                    Ext.log.error('Error! Could not parse ' +
-                        'describe featuretype response!');
+                try {
+                    if (Ext.isString(response.responseText)) {
+                        featureTypes = Ext.decode(response.responseText);
+                    } else if (Ext.isObject(response.responseText)) {
+                        featureTypes = response.responseText;
+                    } else {
+                        Ext.log.error('Error! Could not parse ' +
+                            'describe featuretype response!');
+                    }
+                    if (featureTypes) {
+                        me.fireEvent('describeFeatureTypeResponse',
+                            featureTypes);
+                    }
+                } catch (error) {
+                    Ext.log.error('Error on describe featuretype request:',
+                        error);
                 }
-                me.fireEvent('describeFeatureTypeResponse', featureTypes);
             },
             failure: function(response) {
                 me.setLoading(false);

--- a/src/view/grid/MultiSearchWFSSearchGrid.js
+++ b/src/view/grid/MultiSearchWFSSearchGrid.js
@@ -575,7 +575,8 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
 
         var ftName = featureType.typeName;
         var layer = searchLayers.find(function(l) {
-            return l.get('name') === ftName;
+            var layerName = l.getSource().getParams().LAYERS;
+            return layerName && layerName.indexOf(ftName) > -1;
         });
 
         var searchable = layer && layer.get('searchable') &&
@@ -629,7 +630,8 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
                     var layer;
                     if (ftName) {
                         layer = searchLayers.find(function(l) {
-                            return l.get('name') === ftName;
+                            var layerName = l.getSource().getParams().LAYERS;
+                            return layerName && layerName.indexOf(ftName) > -1;
                         });
                     }
                     if (layer) {


### PR DESCRIPTION
### FEATURE | BUGFIX

* Pass featuretype namespace detected from `DescribeFeatureType` request to attribute filter
* Use spatial filter if only spatial restriction checkbox is set in search settings
* Enhance determination of search layers by using of original featuretype name instead of possibly customized layer name
* Enhance error handling on failed parsing of `DescribeFeatureType` response

Please review @terrestris/devs 

