### PR TITLE
AddWMS: Use inherited CRS list to check for compatibility

### DIFF
--- a/src/view/form/AddWms.js
+++ b/src/view/form/AddWms.js
@@ -824,7 +824,7 @@ Ext.define('BasiGX.view.form.AddWms', {
      * compatible. It will return an array of layers if we could determine any,
      * and the boolean value `false` if not.
      *
-     * @param {Object} capabilities The GetCapabilties object as it is returned
+     * @param {Object} capabilities The GetCapabilities object as it is returned
      *     by our parser.
      * @return {ol.layer.Tile[]|boolean} Eitehr an array of comüatible layers or
      *     'false'.

--- a/src/view/form/AddWms.js
+++ b/src/view/form/AddWms.js
@@ -198,6 +198,8 @@ Ext.define('BasiGX.view.form.AddWms', {
      */
     triedVersions: [],
 
+    defaultButton: 'requestLayersBtn',
+
     items: [
         {
             xtype: 'fieldset',
@@ -341,6 +343,7 @@ Ext.define('BasiGX.view.form.AddWms', {
                 text: '{requestLayersBtnText}'
             },
             name: 'requestLayersBtn',
+            reference: 'requestLayersBtn',
             formBind: true, // only enabled once the form is valid
             disabled: true,
             handler: function(btn) {


### PR DESCRIPTION
According to the WMS spec all CRS in the layer's hierarchy are inherited. With this PR this is considered when checking for a layer's compatibility.

Also sets the 'fetch layers' button as default button.

@terrestris/devs Please review.