### PR TITLE
Introduces hoverClick plugin

### DIFF
--- a/src/plugin/HoverClick.js
+++ b/src/plugin/HoverClick.js
@@ -14,13 +14,13 @@ Ext.define('BasiGX.plugin.HoverClick', {
 
     config: {
         /**
-         * Enable/Disable hovering globally. If true, the plugin will not
+         * Enable/Disable hovering globally. If false, the plugin will not
          * listen to any hover event, regardless if a layer has a truthy
          * hoverable property.
          */
         hoverable: true,
         /**
-         * Enable/Disable clicking globally. If true, the plugin will not
+         * Enable/Disable clicking globally. If false, the plugin will not
          * listen to any click event, regardless if a layer has a truthy
          * clickable property.
          */
@@ -137,7 +137,7 @@ Ext.define('BasiGX.plugin.HoverClick', {
 
             if (source instanceof ol.source.TileWMS
                     || source instanceof ol.source.ImageWMS) {
-                // me.cleanupHoverArtifacts();
+
                 var url = source.getGetFeatureInfoUrl(
                     evt.coordinate,
                     resolution,

--- a/src/plugin/HoverClick.js
+++ b/src/plugin/HoverClick.js
@@ -242,10 +242,6 @@ Ext.define('BasiGX.plugin.HoverClick', {
         var map = mapComponent.getMap();
         var proj = me.getFeatureInfoEpsg();
         var clickableProp = me.self.LAYER_CLICKABLE_PROPERTY_NAME;
-        if (clickableProp === undefined) {
-            clickableProp = me.self.LAYER_HOVERABLE_PROPERTY_NAME;
-        }
-
         var clickable = layer.get(clickableProp);
 
         if (projection) {

--- a/src/plugin/HoverClick.js
+++ b/src/plugin/HoverClick.js
@@ -7,9 +7,7 @@ Ext.define('BasiGX.plugin.HoverClick', {
     inheritableStatics: {
         /**
          * The property of a layer that holds a boolean value which indicates
-         * whether this layer qualifies for clicking. If this property is
-         * undefined the value of LAYER_HOVERABLE_PROPERTY_NAME will be used
-         * to maintain backwards compatibility.
+         * whether this layer qualifies for clicking.
          */
         LAYER_CLICKABLE_PROPERTY_NAME: 'clickable'
     },

--- a/src/plugin/HoverClick.js
+++ b/src/plugin/HoverClick.js
@@ -1,0 +1,268 @@
+Ext.define('BasiGX.plugin.HoverClick', {
+    extend: 'BasiGX.plugin.Hover',
+
+    alias: 'plugin.hoverClick',
+    pluginId: 'hoverClick',
+
+    inheritableStatics: {
+        /**
+         * The property of a layer that holds a boolean value which indicates
+         * whether this layer qualifies for clicking. If this property is
+         * undefined the value of LAYER_HOVERABLE_PROPERTY_NAME will be used
+         * to maintain backwards compatibility.
+         */
+        LAYER_CLICKABLE_PROPERTY_NAME: 'clickable'
+    },
+
+    config: {
+        /**
+         * Enable/Disable hovering globally. If true, the plugin will not
+         * listen to any hover event, regardless if a layer has a truthy
+         * hoverable property.
+         */
+        hoverable: true,
+        /**
+         * Enable/Disable clicking globally. If true, the plugin will not
+         * listen to any click event, regardless if a layer has a truthy
+         * clickable property.
+         */
+        clickable: true
+    },
+
+    init: function (cmp) {
+        var me = this;
+
+        me.checkSelectEventOrigin();
+
+        me.addHoverVectorLayerSource();
+        me.addHoverVectorLayer();
+
+        if (me.getEnableHoverSelection() && me.getClickable()) {
+            me.addHoverVectorLayerInteraction();
+        }
+
+        me.setupMapEventListeners();
+        me.setCmp(cmp);
+
+        cmp.setPointerRest(me.getPointerRest());
+        cmp.setPointerRestInterval(me.getPointerRestInterval());
+        cmp.setPointerRestPixelTolerance(me.getPointerRestPixelTolerance());
+
+        if (me.getHoverable()) {
+            cmp.on('pointerrest', me.onPointerRest, me);
+            cmp.on('pointerrestout', me.cleanupHoverArtifacts, me);
+        }
+    },
+
+    /**
+     * Adds the onClick event to the registered super events,
+     * if clickable is true.
+     *
+     * @private
+     */
+    setupMapEventListeners: function () {
+        var me = this;
+        me.callParent();
+
+        if (me.getClickable()) {
+            var mapComponent = me.getCmp();
+            var map = mapComponent.getMap();
+            map.on('click', me.onClick, me);
+        }
+    },
+
+    /**
+     *
+     */
+    addHoverVectorLayerInteraction: function () {
+        var me = this;
+        var mapComponent = me.getCmp();
+        var map = mapComponent.getMap();
+
+        if (!me.getHoverVectorLayerInteraction()) {
+            var interaction = new ol.interaction.Select({
+                multi: me.selectMulti,
+                style: me.selectStyleFunction,
+                layers: [me.getHoverVectorLayer()],
+                filter: me.clickable ? me.filterClickableFeatures : undefined
+            });
+            if (me.selectEventOrigin === 'collection') {
+                var featureCollection = interaction.getFeatures();
+                featureCollection.on('add', me.onFeatureClicked, me);
+            } else {
+                interaction.on('select', me.onFeatureClicked, me);
+            }
+            map.addInteraction(interaction);
+            me.setHoverVectorLayerInteraction(interaction);
+        }
+    },
+
+    /**
+     * Filters the clickable features by checking the
+     * isClickable property.
+     *
+     * @param {ol.feature} feature the feature to check.
+     * @return {Boolean} Whether the feature is clickable.
+     */
+    filterClickableFeatures: function (feature) {
+        return feature.isClickable;
+    },
+
+    /**
+     * The handler for the click event on the map.
+     *
+     * @param {MouseEvent.onClick} evt The onClick event
+     */
+    onClick: function (evt) {
+        var me = this;
+        var mapComponent = me.getCmp();
+        var map = mapComponent.getMap();
+        var mapView = map.getView();
+        var pixel = evt.pixel;
+        var hoverFeaturesRevertProp = me.self.LAYER_HOVER_FEATURES_REVERT_NAME;
+        var clickableProp = me.self.LAYER_CLICKABLE_PROPERTY_NAME;
+        var hoverLayers = [];
+        var hoverFeatures = [];
+
+        me.cleanupHoverArtifacts();
+
+        map.forEachLayerAtPixel(pixel, function(layer, pixelValues) {
+            if (!layer.get(clickableProp)) {
+                return;
+            }
+
+            var source = layer.getSource();
+            var resolution = mapView.getResolution();
+            var projCode = mapView.getProjection().getCode();
+            var hoverFeaturesRevert = layer.get(hoverFeaturesRevertProp);
+
+
+            if (source instanceof ol.source.TileWMS
+                    || source instanceof ol.source.ImageWMS) {
+                // me.cleanupHoverArtifacts();
+                var url = source.getGetFeatureInfoUrl(
+                    evt.coordinate,
+                    resolution,
+                    projCode,
+                    {
+                        'INFO_FORMAT': 'application/json',
+                        'FEATURE_COUNT': me.getFeatureInfoCount()
+                    }
+                );
+
+                me.requestAsynchronously(url, function(resp) {
+                    // TODO: replace evt/coords with real response geometry
+                    var respFeatures = (new ol.format.GeoJSON())
+                        .readFeatures(resp.responseText);
+                    var respProjection = (new ol.format.GeoJSON())
+                        .readProjection(resp.responseText);
+
+                    me.showHoverFeature(
+                        layer, respFeatures, respProjection
+                    );
+
+                    Ext.each(respFeatures, function(feature) {
+                        feature.set('layer', layer);
+                        var featureStyle = me.highlightStyleFunction(
+                            feature, resolution, pixelValues);
+                        feature.setStyle(featureStyle);
+                        hoverFeatures.push(feature);
+                    });
+                    if (hoverFeaturesRevert) {
+                        hoverFeatures.reverse();
+                    }
+
+                    hoverLayers.push(layer);
+                });
+            } else if (source instanceof ol.source.Vector) {
+                // VECTOR!
+                map.forEachFeatureAtPixel(pixel, function(feat) {
+                    if (layer.get('type') === 'WFS' ||
+                            layer.get('type') === 'WFSCluster') {
+                        var hvl = me.getHoverVectorLayer();
+                        // TODO This should be dynamically generated
+                        // from the clusterStyle
+                        hvl.setStyle(me.highlightStyleFunction);
+                    }
+                    if (!Ext.Array.contains(hoverLayers, layer)) {
+                        hoverLayers.push(layer);
+                    }
+                    if (feat.get('layer') === layer) {
+                        var clone = feat.clone();
+                        clone.setId(feat.getId());
+
+                        var hoverFeaturesIds = Ext.Array.map(hoverFeatures,
+                            function(hoverFeat) {
+                                return hoverFeat.getId();
+                            });
+                        if (!Ext.Array.contains(hoverFeaturesIds,
+                            feat.getId())) {
+                            var style = me.highlightStyleFunction(
+                                clone, resolution, pixel);
+                            clone.setStyle(style);
+                            hoverFeatures.push(clone);
+                        }
+                    }
+                    me.showHoverFeature(layer, hoverFeatures);
+                    me.currentHoverTarget = feat;
+                }, me, function(vectorCand) {
+                    return vectorCand === layer;
+                });
+            }
+        }, this, me.clickLayerFilter, this);
+    },
+
+    /**
+     * @param {ol.layer.Base} candidate The layer to check.
+     * @return {Boolean} Whether the passed layer should be clickable.
+     */
+    clickLayerFilter: function (candidate) {
+        var me = this;
+        var clickableProp = me.self.LAYER_CLICKABLE_PROPERTY_NAME;
+
+        if (candidate.get(clickableProp) ||
+                candidate.get('type') === 'WFSCluster') {
+            return true;
+        } else {
+            return false;
+        }
+    },
+
+    /**
+     * Adds the passed features to the hover vector layer.
+     *
+     * @param {ol.layer.Layer} layer The layer. Currently unused in the method.
+     * @param {Array<ol.Feature>} features The features to hover by adding them
+     *     to the source of the hover vector layer.
+     * @param {ol.Projection} projection The projection of the features.
+     */
+    showHoverFeature: function(layer, features, projection) {
+        var me = this;
+        var mapComponent = me.getCmp();
+        var map = mapComponent.getMap();
+        var proj = me.getFeatureInfoEpsg();
+        var clickableProp = me.self.LAYER_CLICKABLE_PROPERTY_NAME;
+        if (clickableProp === undefined) {
+            clickableProp = me.self.LAYER_HOVERABLE_PROPERTY_NAME;
+        }
+
+        var clickable = layer.get(clickableProp);
+
+        if (projection) {
+            proj = projection;
+        }
+        var source = me.getHoverVectorLayerSource();
+        Ext.each(features, function(feat) {
+            feat.isClickable = clickable;
+            var g = feat.getGeometry();
+            if (g) {
+                g.transform(proj, map.getView().getProjection());
+            }
+            if (!Ext.Array.contains(source.getFeatures(),
+                feat)) {
+                source.addFeature(feat);
+            }
+        });
+    }
+
+});

--- a/test/spec/plugin/HoverClick.test.js
+++ b/test/spec/plugin/HoverClick.test.js
@@ -1,0 +1,148 @@
+
+Ext.Loader.syncRequire(['BasiGX.plugin.HoverClick']);
+
+describe('BasiGX.plugin.HoverClick', function() {
+
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.plugin.HoverClick).to.not.be(undefined);
+        });
+        it('can be instantiated', function() {
+            var plugin = Ext.create('BasiGX.plugin.HoverClick');
+            expect(plugin).to.be.a(BasiGX.plugin.HoverClick);
+        });
+    });
+
+    describe('Static properties', function() {
+        describe('they are defined for the base plugin', function() {
+            it('works for #LAYER_CLICKABLE_PROPERTY_NAME', function () {
+                var prop = BasiGX.plugin.HoverClick.LAYER_CLICKABLE_PROPERTY_NAME;
+                expect(prop).to.not.be(undefined);
+            });
+        });
+        describe('they are inherited for subclasses', function() {
+            var ParentClass = BasiGX.plugin.HoverClick;
+            var ExtendedClass = null;
+            beforeEach(function() {
+                ExtendedClass = Ext.define('TestExtendHover', {
+                    extend: 'BasiGX.plugin.HoverClick',
+                    alias: 'plugin.test-extend-hoverclick',
+                    pluginId: 'test-hoverClick'
+                });
+            });
+            afterEach(function() {
+                Ext.undefine('TestExtendHover');
+                ExtendedClass = null;
+            });
+            it('works for #LAYER_CLICKABLE_PROPERTY_NAME', function() {
+                var originalProp = ParentClass.LAYER_CLICKABLE_PROPERTY_NAME;
+                var prop = ExtendedClass.LAYER_CLICKABLE_PROPERTY_NAME;
+                expect(prop).to.not.be(undefined);
+                expect(prop).to.be(originalProp);
+            });
+        });
+        describe('they can be overridden for subclasses', function() {
+            var ParentClass = BasiGX.plugin.HoverClick;
+            var ExtendedClass = null;
+            beforeEach(function() {
+                ExtendedClass = Ext.define('TestExtendHover', {
+                    extend: 'BasiGX.plugin.HoverClick',
+                    alias: 'plugin.test-extend-hoverclick',
+                    pluginId: 'test-hoverClick',
+                    inheritableStatics: {
+                        LAYER_CLICKABLE_PROPERTY_NAME: 'a'
+                    }
+                });
+            });
+            afterEach(function() {
+                Ext.undefine('TestExtendHover');
+                ExtendedClass = null;
+            });
+            it('works for #LAYER_CLICKABLE_PROPERTY_NAME', function() {
+                var originalProp = ParentClass.LAYER_CLICKABLE_PROPERTY_NAME;
+                var prop = ExtendedClass.LAYER_CLICKABLE_PROPERTY_NAME;
+                expect(prop).to.not.be(undefined);
+                expect(prop).to.not.be(originalProp);
+                expect(prop).to.be('a');
+            });
+        });
+    });
+
+    describe('Usage as plugin for BasiGX.view.component.Map', function() {
+        var plugin;
+        var mapComponent;
+        var testObjs;
+        beforeEach(function() {
+            testObjs = TestUtil.setupTestObjects({
+                mapComponentOpts: {plugins: ['hoverClick']}
+            });
+            mapComponent = testObjs.mapComponent;
+            plugin = mapComponent.getPlugin('hoverClick');
+        });
+        afterEach(function() {
+            TestUtil.teardownTestObjects(testObjs);
+        });
+        it('creates an instance by pluginId', function() {
+            expect(plugin).to.be.a(BasiGX.plugin.HoverClick);
+        });
+        it('sets the component as member in plugin', function() {
+            expect(plugin.getCmp()).to.be(mapComponent);
+        });
+    });
+
+    describe('Configuration options', function() {
+        var plugin;
+        var mapComponent;
+        var testObjs;
+        beforeEach(function() {
+            testObjs = TestUtil.setupTestObjects({
+                mapComponentOpts: {plugins: ['hoverClick']}
+            });
+            mapComponent = testObjs.mapComponent;
+            plugin = mapComponent.getPlugin('hoverClick');
+        });
+        afterEach(function() {
+            TestUtil.teardownTestObjects(testObjs);
+        });
+
+        describe('sane defaults', function() {
+            it('has hoverable set to true', function() {
+                expect(plugin.getHoverable()).to.be(true);
+            });
+            it('has clickable set to true', function() {
+                expect(plugin.getClickable()).to.be(true);
+            });
+        });
+        describe('defaults are changeable', function() {
+            var mapComponentConfigured;
+            var pluginConfigured;
+            var testObjs2;
+
+            beforeEach(function() {
+                testObjs2 = TestUtil.setupTestObjects({
+                    mapComponentOpts: {
+                        plugins: {
+                            ptype: 'hoverClick',
+                            hoverable: false,
+                            clickable: false
+                        }
+                    }
+                });
+                mapComponentConfigured = testObjs2.mapComponent;
+                pluginConfigured = mapComponentConfigured.getPlugin('hoverClick');
+            });
+            afterEach(function() {
+                TestUtil.teardownTestObjects(testObjs2);
+            });
+
+            it('has hoverable set to false', function() {
+                expect(pluginConfigured.getHoverable()).to.be(false);
+            });
+            it('has clickable set to false', function() {
+                expect(pluginConfigured.getClickable()).to.be(false);
+            });
+
+        });
+    });
+
+});


### PR DESCRIPTION
This introduces the hoverClick plugin.

This plugin extends the hover plugin to disable/enable click and hover events separately.

To do so, two configs  `hoverable`, `clickable` were added to enable/disable hovering and clicking globally. These values just set the general options to disable/enable hovering and clicking. A layer  needs to have a truthy `hoverable` or `clickable` property to actually enable hovering and clicking respectively.

Now, separate requests for the click and the hover event will be fired.

Please note that it is required to manually cleanup the feature selection (`hoverClickPlugin.cleanupHoverArtifacts()`) after the `hoverfeaturesclick` event was fired, as in contrast to the `pointerrest` event, we cannot know when the cleanup should be triggered.
