### PR TITLE
Enable Clickable Links for Hover Plugin

### DIFF
--- a/src/plugin/Hover.js
+++ b/src/plugin/Hover.js
@@ -20,7 +20,8 @@ Ext.define('BasiGX.plugin.Hover', {
     extend: 'Ext.plugin.Abstract',
 
     requires: [
-        'BasiGX.util.StringTemplate'
+        'BasiGX.util.StringTemplate',
+        'BasiGX.util.Url'
     ],
 
     alias: 'plugin.hover',
@@ -91,7 +92,12 @@ Ext.define('BasiGX.plugin.Hover', {
          */
         mapPaddingPositioning: 30,
         maxHeight: null,
-        className: 'ol-overlay-container ol-selectable'
+        className: 'ol-overlay-container ol-selectable',
+        /**
+         * If true, renders urls as clickable links.
+         * If false, renders urls as plain strings.
+         */
+        enableClickableLinks: false
     },
 
     /**
@@ -601,6 +607,7 @@ Ext.define('BasiGX.plugin.Hover', {
         var innerHtml = '';
         var hoverfieldProp = me.self.LAYER_HOVERFIELD_PROPERTY_NAME;
         var templateUtil = BasiGX.util.StringTemplate;
+        var urlUtil = BasiGX.util.Url;
         var templateConfig = {
             prefix: me.self.HOVER_TEMPLATE_PLACEHOLDER_PREFIX,
             suffix: me.self.HOVER_TEMPLATE_PLACEHOLDER_SUFFIX
@@ -619,7 +626,18 @@ Ext.define('BasiGX.plugin.Hover', {
                         var count = feat.get('count');
                         innerHtml += '<br />' + count + '<br />';
                     } else {
-                        innerHtml += '<br />' + hoverText + '<br />';
+                        if (
+                            me.getEnableClickableLinks()
+                            && urlUtil.isUrl(hoverText)
+                        ) {
+                            innerHtml += '<br /><a href="'
+                                + hoverText
+                                + '" target="_blank">'
+                                + hoverText
+                                + '</a><br />';
+                        } else {
+                            innerHtml += '<br />' + hoverText + '<br />';
+                        }
                     }
                 }
             });

--- a/src/util/Url.js
+++ b/src/util/Url.js
@@ -86,6 +86,17 @@ Ext.define('BasiGX.util.Url', {
             var loc = window.location;
             var baseUrl = loc.protocol + '//' + loc.host + '/';
             return baseUrl;
+        },
+
+        /**
+         * Checks if a string is a url, i.e. if it starts
+         * with http(s)://.
+         *
+         * @param {String} str The string to check.
+         * @return {Boolean} true, if string is a url, false otherwise.
+         */
+        isUrl: function (str) {
+            return str.startsWith("http://") || str.startsWith("https://");
         }
 
     }


### PR DESCRIPTION
This enables rendering clickable links in the popup of the `hover` and `hoverClick` plugins.

When setting the config `enableClickableLinks` to `true`, strings that start with `http(s)://` will be rendered as anchors with `target="_blank"`.

To maintain backwards compatibility, the default of the config is set to `false`.

![image](https://user-images.githubusercontent.com/12186477/87554476-75251980-c6b4-11ea-81c3-0341a2ee4ec9.png)
