### PR TITLE
Fix keybindings of row expander plugin to be consistent

### DIFF
--- a/src/ux/RowExpanderWithComponents.js
+++ b/src/ux/RowExpanderWithComponents.js
@@ -218,6 +218,35 @@ Ext.define('BasiGX.ux.RowExpanderWithComponents', {
     },
 
     /**
+     * Overrides the key bindings to be consistent with standard ext trees.
+     * Also see https://www.w3.org/TR/wai-aria-practices/#treegrid
+     *
+     * @param {Object} view the view
+     * @param {Object} record the record
+     * @param {Object} row the row
+     * @param {Number} rowIdx the row index
+     * @param {KeyEvent} e the key event
+     */
+    onKeyDown: function(view, record, row, rowIdx, e) {
+        var me = this;
+        var key = e.getKey();
+        var pos = view.getNavigationModel().getPosition();
+        var isCollapsed;
+
+        if (pos) {
+            row = Ext.fly(row);
+            isCollapsed = row.hasCls(me.rowCollapsedCls);
+
+            if (e.ctrlKey && key === 39 && isCollapsed) {
+                me.toggleRow(rowIdx, record);
+            }
+            if (e.ctrlKey && key === 37 && !isCollapsed) {
+                me.toggleRow(rowIdx, record);
+            }
+        }
+    },
+
+    /**
      * Converts all string values with {{}} to code
      * Example: '{{record.get('test'}}' converts to record.get('test')
      *

--- a/src/view/panel/LegendTree.js
+++ b/src/view/panel/LegendTree.js
@@ -257,7 +257,6 @@ Ext.define('BasiGX.view.panel.LegendTree', {
      * @return {String} A CSS class to use.
      */
     getCssForRow: function(rec) {
-
         var color = this.getColorFromRow(rec);
 
         // if color is still not defined, return old default


### PR DESCRIPTION
This makes the keybindings of the row expander plugin consistent with standard ext trees.

@terrestris/devs Please review.