### PR TITLE
Add util function BasiGX.util.Layer.cascadeLayers

### DIFF
--- a/src/util/Layer.js
+++ b/src/util/Layer.js
@@ -262,6 +262,34 @@ Ext.define('BasiGX.util.Layer', {
             });
 
             return visibleLayers;
+        },
+
+        /**
+         * Cascades down a given LayerGroup, calling the given function for
+         * each LayerGroup / Layer.
+         *
+         * @param  {ol.layer.Group} lyrGroup The layer group to cascade down
+         * @param  {Function} fn A function to call on every LayerGroup / Layer
+         * @return {void}
+         */
+        cascadeLayers: function(lyrGroup, fn) {
+            if (!(lyrGroup instanceof ol.layer.Group)) {
+                // skip on wrong input type
+                Ext.Logger.warn(
+                    'No ol.layer.Group given to ' +
+                    'BasiGX.util.Layer.cascadeLayers. It is unlikely that ' +
+                    'this will work properly. Skipping!');
+                return null;
+            }
+
+            lyrGroup.getLayers().forEach(function(layerOrGroup) {
+                if (Ext.isFunction(fn)) {
+                    fn(layerOrGroup);
+                }
+                if (layerOrGroup instanceof ol.layer.Group) {
+                    BasiGX.util.Layer.cascadeLayers(layerOrGroup, fn);
+                }
+            });
         }
     }
 });

--- a/test/spec/util/Layer.test.js
+++ b/test/spec/util/Layer.test.js
@@ -355,6 +355,44 @@ describe('BasiGX.util.Layer', function() {
         });
     });
 
+    describe('#cascadeLayers', function() {
+        it('is a defined function', function() {
+            expect(BasiGX.util.Layer.cascadeLayers).to.be.a(Function);
+        });
+
+        var tileLayer = new ol.layer.Image();
+        var imageLayer = new ol.layer.Image();
+        var vectorLayer = new ol.layer.Vector();
+
+        var nestedGroup = new ol.layer.Group({
+            layers: [
+                new ol.layer.Group({
+                    layers: [
+                        tileLayer, imageLayer,
+                        new ol.layer.Group({
+                            layers: [vectorLayer]
+                        })
+                    ]
+                })
+            ]
+        });
+
+        var cnt = 0;
+        BasiGX.util.Layer.cascadeLayers(nestedGroup, function(lyr) {
+            lyr.set('foo', 'bar');
+            cnt++;
+        });
+
+        it('executes given function for every layer', function() {
+            expect(cnt).to.be(5);
+        });
+        it('allows to modify layers / layer groups', function() {
+            expect(tileLayer.get('foo')).to.be('bar');
+            expect(imageLayer.get('foo')).to.be('bar');
+            expect(vectorLayer.get('foo')).to.be('bar');
+        });
+    });
+
     after(function() {
         TestUtil.teardownTestObjects(testObjs);
     });


### PR DESCRIPTION
This adds a util function `BasiGX.util.Layer.cascadeLayers`, which cascades down a given OL LayerGroup and calling the given function for each LayerGroup / Layer.