### PR TITLE
Optional filterFn config for GraphicPool components

### DIFF
--- a/src/view/panel/GraphicPool.js
+++ b/src/view/panel/GraphicPool.js
@@ -86,6 +86,12 @@ Ext.define('BasiGX.view.panel.GraphicPool', {
         },
 
         /**
+          * Optional filter function. Can be useful to filter some images in
+          * unsupported format from store.
+        */
+        filterFn: null,
+
+        /**
          * flag that indicates that a csrf-token should be sent to backend
          * interfaces on every ajax / form submit.
          */
@@ -132,7 +138,8 @@ Ext.define('BasiGX.view.panel.GraphicPool', {
             backendUrls: me.getBackendUrls(),
             overItemCls: me.getOverItemCls(),
             height: me.getWindowHeight(),
-            width: me.getWindowWidth()
+            width: me.getWindowWidth(),
+            filterFn: me.getFilterFn()
         });
         var viewModel = me.getViewModel();
         var btnText = viewModel.get('chooseImageBtnText');

--- a/src/view/panel/GraphicPool.js
+++ b/src/view/panel/GraphicPool.js
@@ -59,7 +59,7 @@ Ext.define('BasiGX.view.panel.GraphicPool', {
     },
 
     /**
-     * the layout to use
+     * The layout to use
      */
     layout: 'vbox',
 
@@ -69,6 +69,11 @@ Ext.define('BasiGX.view.panel.GraphicPool', {
     * @private
     */
     pictureView: null,
+
+    /**
+     * Add vertical scrollbar
+     */
+    scrollable: 'y',
 
     /**
      *

--- a/src/view/panel/GraphicPool.js
+++ b/src/view/panel/GraphicPool.js
@@ -91,8 +91,17 @@ Ext.define('BasiGX.view.panel.GraphicPool', {
         },
 
         /**
-          * Optional filter function. Can be useful to filter some images in
-          * unsupported format from store.
+         * Optional filter function. Can be useful to filter some images in
+         * unsupported format from store.
+         *
+         * For instance, the following filter would return PNG images only:
+         *
+         * {
+         *    filterFn: function(item) {
+         *        return item.data.fileType === 'image/png';
+         *    }
+         * }
+         *
         */
         filterFn: null,
 

--- a/src/view/view/GraphicPool.js
+++ b/src/view/view/GraphicPool.js
@@ -84,6 +84,15 @@ Ext.define('BasiGX.view.view.GraphicPool', {
         /**
          * Optional filter function. Can be useful to filter some images in
          * unsupported format from store.
+         *
+         * For instance, the following filter would return PNG images only:
+         *
+         * {
+         *    filterFn: function(item) {
+         *        return item.data.fileType === 'image/png';
+         *    }
+         * }
+         *
          */
         filterFn: null,
 

--- a/src/view/view/GraphicPool.js
+++ b/src/view/view/GraphicPool.js
@@ -82,6 +82,12 @@ Ext.define('BasiGX.view.view.GraphicPool', {
         backendUrls: null,
 
         /**
+         * Optional filter function. Can be useful to filter some images in
+         * unsupported format from store.
+         */
+        filterFn: null,
+
+        /**
          *
          */
         itemSelector: 'div.thumb-wrap',
@@ -114,7 +120,6 @@ Ext.define('BasiGX.view.view.GraphicPool', {
 
         var store = Ext.create('Ext.data.Store', {
             sorters: 'fileName',
-            //            TODO: add and make a model configurable?
             proxy: {
                 type: 'ajax',
                 url: BasiGX.util.Url.getWebProjectBaseUrl() +
@@ -125,6 +130,12 @@ Ext.define('BasiGX.view.view.GraphicPool', {
                 }
             }
         });
+
+        // apply store filter if passed
+        if (Ext.isFunction(me.getFilterFn())) {
+            store.setFilters(me.getFilterFn());
+        }
+
         store.load();
 
         var srcUrl = BasiGX.util.Url.getWebProjectBaseUrl() +


### PR DESCRIPTION
Pass optional filter function to `GraphicPool` components which can be used to exclude some records from pool.

Use case:
Pool contains images in different formats, but only PNGs should be displayed.

Additionally adds missed vertical scrollbar to view component.

@terrestris/devs 

