### PR TITLE
Multisearch: Show layer on record click

### DIFF
--- a/src/view/grid/MultiSearchWFSSearchGrid.js
+++ b/src/view/grid/MultiSearchWFSSearchGrid.js
@@ -775,6 +775,7 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
         var extent;
         var x;
         var y;
+        var layerName = record.getData().featuretype;
 
         layer.getSource().clear();
 
@@ -801,6 +802,13 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
                 });
             } else {
                 olView.setCenter([x, y]);
+            }
+        }
+        // set layer visibility of clicked feature to true
+        if (layerName) {
+            var layer = BasiGX.util.Layer.getLayerByName();
+            if (!layer.getVisible()) {
+                layer.setVisible(true);
             }
         }
     }

--- a/src/view/grid/MultiSearchWFSSearchGrid.js
+++ b/src/view/grid/MultiSearchWFSSearchGrid.js
@@ -806,9 +806,9 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
         }
         // set layer visibility of clicked feature to true
         if (layerName) {
-            var layer = BasiGX.util.Layer.getLayerByName();
-            if (!layer.getVisible()) {
-                layer.setVisible(true);
+            var olLayer = BasiGX.util.Layer.getLayerByName();
+            if (!olLayer.getVisible()) {
+                olLayer.setVisible(true);
             }
         }
     }

--- a/src/view/grid/MultiSearchWFSSearchGrid.js
+++ b/src/view/grid/MultiSearchWFSSearchGrid.js
@@ -806,7 +806,7 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
         }
         // set layer visibility of clicked feature to true
         if (layerName) {
-            var olLayer = BasiGX.util.Layer.getLayerByName();
+            var olLayer = BasiGX.util.Layer.getLayerByName(layerName);
             if (!olLayer.getVisible()) {
                 olLayer.setVisible(true);
             }


### PR DESCRIPTION
- Sets the layer of a found and clicked record to visible

When a layer is set to unvisible in the clients layer-tree and a search result of that layer is clicked, the map zooms to an unvisible feature on the map. This should fix this behaviour.

Please note @terrestris/devs 