### PR TITLE
Search across multiple workspaces

### DIFF
--- a/src/view/grid/MultiSearchWFSSearchGrid.js
+++ b/src/view/grid/MultiSearchWFSSearchGrid.js
@@ -309,7 +309,6 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
      */
     describeFeatureTypes: function(searchterm, combo) {
         var me = this;
-        var typeNames = [];
         var featureTypes;
 
         me.searchResultVectorLayer.getSource().clear();
@@ -319,52 +318,69 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
         me.setCombo(combo);
 
         var searchLayers = combo.getConfiguredSearchLayers();
+        var workspaces = {};
 
         Ext.each(searchLayers, function(l) {
             if (l.getSource().getParams) {
-                typeNames.push(l.getSource().getParams().LAYERS);
+                var fqLayerName = l.getSource().getParams().LAYERS;
+                var split = fqLayerName.split(':');
+                if (split.length != 2) {
+                    split = ["", split[1]];
+                }
+                if (!workspaces.hasOwnProperty(split[0])) {
+                    workspaces[split[0]] = [];
+                }
+                workspaces[split[0]].push(fqLayerName);
             }
         });
 
-        var describeFeatureTypeParams = {
-            REQUEST: 'DescribeFeatureType',
-            SERVICE: 'WFS',
-            VERSION: '1.1.0',
-            OUTPUTFORMAT: 'application/json',
-            TYPENAME: typeNames.toString()
-        };
+        var params = Ext.Array.map(Object.keys(workspaces), function(workspace) {
+            return {
+                REQUEST: 'DescribeFeatureType',
+                SERVICE: 'WFS',
+                VERSION: '1.1.0',
+                OUTPUTFORMAT: 'application/json',
+                TYPENAME: workspaces[workspace].toString()
+            };
+        });
 
         me.setLoading(true);
 
-        Ext.Ajax.request({
-            url: combo.getWfsServerUrl(),
-            params: describeFeatureTypeParams,
-            method: 'GET',
-            success: function(response) {
-                me.setLoading(false);
+        Ext.Promise.all(Ext.Array.map(params, function(param) {
+            return Ext.Ajax.request({
+                url: combo.getWfsServerUrl(),
+                params: param,
+                method: 'GET'
+            });
+        })).then(function(responses) {
+            me.setLoading(false);
+            var dirtyFeatureTypes = Ext.Array.map(responses, function(response) {
                 try {
+                    var resFeatureTypes;
                     if (Ext.isString(response.responseText)) {
-                        featureTypes = Ext.decode(response.responseText);
+                        resFeatureTypes = Ext.decode(response.responseText);
                     } else if (Ext.isObject(response.responseText)) {
-                        featureTypes = response.responseText;
+                        resFeatureTypes = response.responseText;
                     } else {
                         Ext.log.error('Error! Could not parse ' +
                             'describe featuretype response!');
                     }
-                    if (featureTypes) {
-                        me.fireEvent('describeFeatureTypeResponse',
-                            featureTypes);
+                    if (resFeatureTypes) {
+                        return resFeatureTypes;
                     }
                 } catch (error) {
                     Ext.log.error('Error on describe featuretype request:',
                         error);
                 }
-            },
-            failure: function(response) {
-                me.setLoading(false);
-                Ext.log.error('Error on describe featuretype request:',
-                    response);
-            }
+            });
+            featureTypes = Ext.Array.clean(dirtyFeatureTypes);
+            me.fireEvent('describeFeatureTypeResponse',
+                featureTypes);
+
+        }).catch(function(response) {
+            me.setLoading(false);
+            Ext.log.error('Error on describe featuretype request:',
+                response);
         });
     },
 
@@ -374,41 +390,62 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
      *
      * This method requests the actual features fitting to the search term.
      *
-     * @param {Object} resp The ajax response containing DescribeFeatureType.
+     * @param {Array} responses The array of ajax responses containing DescribeFeatureType.
      */
-    getFeatures: function(resp) {
+    getFeatures: function(responses) {
         var me = this;
-        var featureTypes = resp.featureTypes;
-        var ns = resp.targetPrefix;
-        var cleanedFeatureType = me.cleanUpFeatureDataTypes(featureTypes);
-        var url = me.getCombo().getWfsServerUrl();
-        var xml = me.setupXmlPostBody(cleanedFeatureType, ns);
-        var features;
 
         me.setLoading(true);
-
-        Ext.Ajax.request({
-            url: url,
-            method: 'POST',
-            headers: BasiGX.util.CSRF.getHeader(),
-            xmlData: xml,
-            success: function(response) {
-                me.setLoading(false);
-                if (Ext.isString(response.responseText)) {
-                    features = Ext.decode(response.responseText).features;
-                } else if (Ext.isObject(response.responseText)) {
-                    features = response.responseText.features;
+        Ext.Promise.all(Ext.Array.map(responses, function(resp) {
+            var featureTypes = resp.featureTypes;
+            var ns = resp.targetPrefix;
+            var cleanedFeatureType = me.cleanUpFeatureDataTypes(featureTypes);
+            var url = me.getCombo().getWfsServerUrl();
+            var xml = me.setupXmlPostBody(cleanedFeatureType, ns);
+            var features;
+            return Ext.Ajax.request({
+                url: url,
+                method: 'POST',
+                headers: BasiGX.util.CSRF.getHeader(),
+                xmlData: xml,
+                success: function(response) {
+                    me.setLoading(false);
+                    if (Ext.isString(response.responseText)) {
+                        features = Ext.decode(response.responseText).features;
+                    } else if (Ext.isObject(response.responseText)) {
+                        features = response.responseText.features;
+                    } else {
+                        Ext.log.error('Error! Could not parse ' +
+                            'GetFeature response!');
+                    }
+                    me.fireEvent('getFeatureResponse', features);
+                },
+                failure: function(response) {
+                    me.setLoading(false);
+                    Ext.log.error('Error on GetFeature request:',
+                        response);
+                }
+            });
+        })).then(function(resps) {
+            me.setLoading(false);
+            var features = [];
+            Ext.Array.each(resps, function(resp) {
+                var feats;
+                if (Ext.isString(resp.responseText)) {
+                    feats = Ext.decode(resp.responseText).features;
+                } else if (Ext.isObject(resp.responseText)) {
+                    feats = resp.responseText.features;
                 } else {
                     Ext.log.error('Error! Could not parse ' +
                         'GetFeature response!');
                 }
-                me.fireEvent('getFeatureResponse', features);
-            },
-            failure: function(response) {
-                me.setLoading(false);
-                Ext.log.error('Error on GetFeature request:',
-                    response);
-            }
+                features = Ext.Array.merge(features, feats);
+            });
+            me.fireEvent('getFeatureResponse', features);
+        }).catch(function(response){
+            me.setLoading(false);
+            Ext.log.error('Error on GetFeature request:',
+                response);
         });
     },
 

--- a/src/view/grid/MultiSearchWFSSearchGrid.js
+++ b/src/view/grid/MultiSearchWFSSearchGrid.js
@@ -324,7 +324,7 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
             if (l.getSource().getParams) {
                 var fqLayerName = l.getSource().getParams().LAYERS;
                 var split = fqLayerName.split(':');
-                if (split.length != 2) {
+                if (split.length !== 2) {
                     split = ["", split[1]];
                 }
                 if (!workspaces.hasOwnProperty(split[0])) {
@@ -334,15 +334,16 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
             }
         });
 
-        var params = Ext.Array.map(Object.keys(workspaces), function(workspace) {
-            return {
-                REQUEST: 'DescribeFeatureType',
-                SERVICE: 'WFS',
-                VERSION: '1.1.0',
-                OUTPUTFORMAT: 'application/json',
-                TYPENAME: workspaces[workspace].toString()
-            };
-        });
+        var params = Ext.Array.map(Object.keys(workspaces),
+            function(workspace) {
+                return {
+                    REQUEST: 'DescribeFeatureType',
+                    SERVICE: 'WFS',
+                    VERSION: '1.1.0',
+                    OUTPUTFORMAT: 'application/json',
+                    TYPENAME: workspaces[workspace].toString()
+                };
+            });
 
         me.setLoading(true);
 
@@ -354,25 +355,26 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
             });
         })).then(function(responses) {
             me.setLoading(false);
-            var dirtyFeatureTypes = Ext.Array.map(responses, function(response) {
-                try {
-                    var resFeatureTypes;
-                    if (Ext.isString(response.responseText)) {
-                        resFeatureTypes = Ext.decode(response.responseText);
-                    } else if (Ext.isObject(response.responseText)) {
-                        resFeatureTypes = response.responseText;
-                    } else {
-                        Ext.log.error('Error! Could not parse ' +
-                            'describe featuretype response!');
+            var dirtyFeatureTypes = Ext.Array.map(responses,
+                function(response) {
+                    try {
+                        var resFeatureTypes;
+                        if (Ext.isString(response.responseText)) {
+                            resFeatureTypes = Ext.decode(response.responseText);
+                        } else if (Ext.isObject(response.responseText)) {
+                            resFeatureTypes = response.responseText;
+                        } else {
+                            Ext.log.error('Error! Could not parse ' +
+                                'describe featuretype response!');
+                        }
+                        if (resFeatureTypes) {
+                            return resFeatureTypes;
+                        }
+                    } catch (error) {
+                        Ext.log.error('Error on describe featuretype request:',
+                            error);
                     }
-                    if (resFeatureTypes) {
-                        return resFeatureTypes;
-                    }
-                } catch (error) {
-                    Ext.log.error('Error on describe featuretype request:',
-                        error);
-                }
-            });
+                });
             featureTypes = Ext.Array.clean(dirtyFeatureTypes);
             me.fireEvent('describeFeatureTypeResponse',
                 featureTypes);
@@ -390,7 +392,8 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
      *
      * This method requests the actual features fitting to the search term.
      *
-     * @param {Array} responses The array of ajax responses containing DescribeFeatureType.
+     * @param {Array} responses The array of ajax responses
+     *                          containing DescribeFeatureType.
      */
     getFeatures: function(responses) {
         var me = this;

--- a/src/view/grid/MultiSearchWFSSearchGrid.js
+++ b/src/view/grid/MultiSearchWFSSearchGrid.js
@@ -325,7 +325,7 @@ Ext.define('BasiGX.view.grid.MultiSearchWFSSearchGrid', {
                 var fqLayerName = l.getSource().getParams().LAYERS;
                 var split = fqLayerName.split(':');
                 if (split.length !== 2) {
-                    split = ["", split[1]];
+                    split = ['', split[1]];
                 }
                 if (!workspaces.hasOwnProperty(split[0])) {
                     workspaces[split[0]] = [];


### PR DESCRIPTION
This enables WFS searching on layers that are located in different workspaces.

We have to fire the `describeFeatureTypes` request for each workspace separately, as we otherwise loose the information of the workspace name for the `getFeature` request.