### PR TITLE
uncheck layers before removing

### DIFF
--- a/src/view/form/AddWms.js
+++ b/src/view/form/AddWms.js
@@ -427,6 +427,7 @@ Ext.define('BasiGX.view.form.AddWms', {
             return;
         }
         me.setLoading(true);
+        me.uncheckAllLayers();
         me.removeAddLayersComponents();
         var values = form.getValues();
         var url = '';


### PR DESCRIPTION
This unchecks all layers before removing them if another wms was requested. This ensures that the on change handler on the checkboxes is working as expected.

Fixes https://github.com/compassinformatics/cpsi-mapview/issues/300