### PR TITLE
Prevent click event on HsiButton untoggle

### DIFF
--- a/src/plugin/HoverClick.js
+++ b/src/plugin/HoverClick.js
@@ -24,7 +24,13 @@ Ext.define('BasiGX.plugin.HoverClick', {
          * listen to any click event, regardless if a layer has a truthy
          * clickable property.
          */
-        clickable: true
+        clickable: true,
+
+        /**
+         * Control state of click event on the map. If the underlying HSI button
+         * gets untoggled, click interaction on the map should be deactivated.
+         */
+        clickActive: true
     },
 
     init: function (cmp) {
@@ -62,7 +68,7 @@ Ext.define('BasiGX.plugin.HoverClick', {
         var me = this;
         me.callParent();
 
-        if (me.getClickable()) {
+        if (me.getClickable() && me.getClickActive()) {
             var mapComponent = me.getCmp();
             var map = mapComponent.getMap();
             map.on('click', me.onClick, me);
@@ -124,7 +130,13 @@ Ext.define('BasiGX.plugin.HoverClick', {
      * @param {MouseEvent.onClick} evt The onClick event
      */
     onClick: function (evt) {
+
         var me = this;
+
+        if (!me.getClickActive()) {
+            return;
+        }
+
         var mapComponent = me.getCmp();
         var map = mapComponent.getMap();
         var mapView = map.getView();

--- a/src/view/button/Hsi.js
+++ b/src/view/button/Hsi.js
@@ -107,7 +107,7 @@ Ext.define('BasiGX.view.button.Hsi', {
 
     /**
      * Activates or deactivates the `pointerrest`-event depending on the passed
-     * status.
+     * status and prevents click events trigger if control was untoggled.
      *
      * TODO we should get rid of the guessing, or at least make it optional.
      *
@@ -120,5 +120,12 @@ Ext.define('BasiGX.view.button.Hsi', {
 
         mapComponent = BasiGX.util.Map.getMapComponent(me.getMapPanelXType());
         mapComponent.setPointerRest(status);
+
+        var plugins = mapComponent.getPlugins();
+        Ext.each(plugins, function(plugin) {
+            if (plugin instanceof BasiGX.plugin.HoverClick) {
+                plugin.setClickActive(status);
+            }
+        });
     }
 });


### PR DESCRIPTION
Introduce config flag `clickActive` to control, whether the `click` event on the map should be triggered or not.
The config state will be changed on `HsiButton` component toggle.

Please review @terrestris/devs 