### PR TITLE
Update measure area tool for ol6

### DIFF
--- a/src/view/button/Measure.js
+++ b/src/view/button/Measure.js
@@ -759,10 +759,8 @@ Ext.define('BasiGX.view.button.Measure', {
 
         if (me.geodesic) {
             var sourceProj = me.map.getView().getProjection();
-            var geom = (polygon.clone().transform(
-                sourceProj, 'EPSG:4326'));
-            var coordinates = geom.getLinearRing(0).getCoordinates();
-            area = Math.abs(ol.sphere.getArea(coordinates));
+            var geom = polygon.clone();
+            area = Math.abs(ol.sphere.getArea(geom, sourceProj));
         } else {
             area = polygon.getArea();
         }

--- a/src/view/button/Measure.js
+++ b/src/view/button/Measure.js
@@ -759,8 +759,7 @@ Ext.define('BasiGX.view.button.Measure', {
 
         if (me.geodesic) {
             var sourceProj = me.map.getView().getProjection();
-            var geom = polygon.clone();
-            area = Math.abs(ol.sphere.getArea(geom, sourceProj));
+            area = Math.abs(ol.sphere.getArea(polygon, sourceProj));
         } else {
             area = polygon.getArea();
         }

--- a/test/spec/view/button/Measure.test.js
+++ b/test/spec/view/button/Measure.test.js
@@ -358,4 +358,15 @@ describe('BasiGX.view.button.Measure', function() {
             });
         });
     });
+
+    describe('#formatArea', function() {
+        it('formats the area of a polygon as expected', function() {
+
+            var vertices = [[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]];
+            var geom = new ol.geom.Polygon([vertices]);
+
+            var area = btn.formatArea(geom);
+            expect(area).to.be('24.94 m<sup>2</sup>');
+        });
+    });	
 });

--- a/test/spec/view/button/Measure.test.js
+++ b/test/spec/view/button/Measure.test.js
@@ -368,5 +368,5 @@ describe('BasiGX.view.button.Measure', function() {
             var area = btn.formatArea(geom);
             expect(area).to.be('24.94 m<sup>2</sup>');
         });
-    });	
+    });
 });


### PR DESCRIPTION
From https://openlayers.org/en/latest/apidoc/module-ol_sphere.html - `getArea` expects a geometry rather than an array of coordinates. 
Otherwise the following error is thrown: `e.getType is not a function`