### PR TITLE
Enable button in the addWms form when the textbox is hidden

### DIFF
--- a/src/view/form/AddWms.js
+++ b/src/view/form/AddWms.js
@@ -228,6 +228,7 @@ Ext.define('BasiGX.view.form.AddWms', {
                         var countUrls = view.wmsBaseUrls.length;
                         if (countUrls !== 0) {
                             textfield.setHidden(true);
+                            textfield.allowBlank = true;
                         }
                     }
                 }

--- a/src/view/form/AddWms.js
+++ b/src/view/form/AddWms.js
@@ -251,6 +251,7 @@ Ext.define('BasiGX.view.form.AddWms', {
                         var countUrls = view.wmsBaseUrls.length;
                         if (countUrls === 0) {
                             combobox.setHidden(true);
+                            combobox.allowBlank = true;
                         } else {
                             var urlWms = view.wmsBaseUrls;
                             combobox.setStore(urlWms);


### PR DESCRIPTION
This pull request ensures that the "Request available layers" button becomes enabled if a user enters or pastes a URL in the WMS-URL box. 

Currently if the combobox has a list of entries then the texfField is hidden, but it does not allow blank values, so the form is never valid and the button is disabled (a user however could select something from the dropdown and then paste text as a workaround). 

![image](https://user-images.githubusercontent.com/490840/128309934-43873385-91f3-42f0-8730-c3fae9ed9167.png)
