### PR TITLE
Add optional AJAX proxy URL config for CswForm

### DIFF
--- a/src/view/form/CSW.js
+++ b/src/view/form/CSW.js
@@ -130,7 +130,14 @@ Ext.define('BasiGX.view.form.CSW', {
              * @type {Boolean}
              */
             disableCaching: true
-        }
+        },
+
+        /**
+         * Optional AJAX proxy URL, which will be added before the 'real'
+         * target CSW URL, e.g. '../my-proxy.action?baseUrl='
+         * @cfg {String}
+         */
+        ajaxProxy: null
     },
 
     /**
@@ -361,6 +368,11 @@ Ext.define('BasiGX.view.form.CSW', {
             url = values.cswUrl;
         } else {
             url = values.cswUrlCombo;
+        }
+
+        // add optional AJAX proxy URL
+        if (!Ext.isEmpty(me.ajaxProxy)) {
+            url = me.ajaxProxy + url;
         }
 
         var postBody =


### PR DESCRIPTION
This adds the possibility to configure the `BasiGX.view.form.CSW` component with an optional AJAX proxy URL, which is placed before the "real" target CSW URL.