### PR TITLE
Allow horizontal scrolling on Add WMS form

### DIFF
--- a/src/view/form/AddWms.js
+++ b/src/view/form/AddWms.js
@@ -295,7 +295,7 @@ Ext.define('BasiGX.view.form.AddWms', {
             xtype: 'fieldset',
             name: 'fs-available-layers',
             layout: 'anchor',
-            scrollable: 'y',
+            scrollable: true,
             maxHeight: 200,
             defaults: {
                 anchor: '100%'


### PR DESCRIPTION
This change adds a horizontal scrollbar so all WMS layers can be seen in the fieldset when layers span multiple columns (image of updated form below):

![image](https://user-images.githubusercontent.com/490840/130478589-c2ba20de-6b55-471c-ae5a-c5e5fcfba4b2.png)
