### PR TITLE
Change save/edit button state when table or geometry was edited

### DIFF
--- a/src/view/button/DigitizeModifyObject.js
+++ b/src/view/button/DigitizeModifyObject.js
@@ -137,9 +137,10 @@ Ext.define('BasiGX.view.button.DigitizeModifyObject', {
 
     /**
      * Fire a change event to inform other components
+     * @param {ol.source.Vector.VectorSourceEvent} evt The openlayers event.
      */
-    fireFeatureChanged: function() {
-        this.fireEvent('featurechanged');
+    fireFeatureChanged: function(evt) {
+        this.fireEvent('featurechanged', evt);
     },
 
     /**

--- a/src/view/button/DigitizeMoveObject.js
+++ b/src/view/button/DigitizeMoveObject.js
@@ -147,8 +147,9 @@ Ext.define('BasiGX.view.button.DigitizeMoveObject', {
 
     /**
      * Fire a change event to inform other components
+     * @param {ol.source.Vector.VectorSourceEvent} evt The openlayers event.
      */
-    fireFeatureChanged: function() {
-        this.fireEvent('featurechanged');
+    fireFeatureChanged: function(evt) {
+        this.fireEvent('featurechanged', evt);
     }
 });


### PR DESCRIPTION
Updates the button state of cancel and save button, if data was edited.

Also had to remove `changefeature` listener, as this will also be called when the style of a feature changes. This always happens when moving/modifying a geometry. Therefore, now the `featurechanged` events of the modify/move buttons also pass through the openlayers event.

