### PR TITLE
fix showing saveReminder after saving in feature grid

### DIFF
--- a/src/view/grid/FeatureGrid.js
+++ b/src/view/grid/FeatureGrid.js
@@ -470,7 +470,12 @@ Ext.define('BasiGX.view.grid.FeatureGrid', {
         var store = new GeoExt.data.store.Features({
             layer: this.editLayer,
             listeners: {
-                update: function() {
+                update: function(st, rec, operation) {
+                    // We do not want to trigger the editing
+                    // when changes were committed.
+                    if (operation === 'commit') {
+                        return;
+                    }
                     me.startEditingFeature();
                 }
             }


### PR DESCRIPTION
This prevents showing the saveReminder after saving changes in the feature grid.

The reminder was triggered by the update event of the store which itself was triggered by our `commitChanges` call when saving the changes.