### PR TITLE
chore: update np to 7.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -423,10 +423,16 @@
             "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
             "dev": true
         },
+        "@types/json-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/json-buffer/-/json-buffer-3.0.0.tgz",
+            "integrity": "sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ==",
+            "dev": true
+        },
         "@types/keyv": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.2.tgz",
-            "integrity": "sha512-/FvAK2p4jQOaJ6CGDHJTqZcUtbZe820qIeTg7o0Shg7drB4JHeL+V/dhSaly7NXx6u8eSee+r7coT+yuJEvDLg==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+            "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
             "dev": true,
             "requires": {
                 "@types/node": "*"
@@ -549,52 +555,12 @@
             }
         },
         "ansi-align": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-            "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+            "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
             "dev": true,
             "requires": {
-                "string-width": "^3.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
-                },
-                "emoji-regex": {
-                    "version": "7.0.3",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^4.1.0"
-                    }
-                }
+                "string-width": "^4.1.0"
             }
         },
         "ansi-colors": {
@@ -843,21 +809,27 @@
             }
         },
         "boxen": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.0.1.tgz",
-            "integrity": "sha512-49VBlw+PrWEF51aCmy7QIteYPIFZxSpvqBdP/2itCPPlJ49kj9zg/XPRFrdkne2W+CfwXUls8exMvu1RysZpKA==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+            "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
             "dev": true,
             "requires": {
                 "ansi-align": "^3.0.0",
                 "camelcase": "^6.2.0",
                 "chalk": "^4.1.0",
                 "cli-boxes": "^2.2.1",
-                "string-width": "^4.2.0",
+                "string-width": "^4.2.2",
                 "type-fest": "^0.20.2",
                 "widest-line": "^3.1.0",
                 "wrap-ansi": "^7.0.0"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+                    "dev": true
+                },
                 "ansi-styles": {
                     "version": "4.3.0",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -897,6 +869,26 @@
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+                    "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+                    "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.1"
+                    }
                 },
                 "supports-color": {
                     "version": "7.2.0",
@@ -953,7 +945,7 @@
         "builtins": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-            "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+            "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
             "dev": true
         },
         "bytes": {
@@ -1104,7 +1096,7 @@
         "cli-truncate": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
-            "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+            "integrity": "sha512-f4r4yJnbT++qUPI9NR4XLDLq41gQ+uqnPItWG0F5ZkehuNiTTa3EY0S4AqTSUOeJ7/zU41oWPQSNkW5BqPL9bg==",
             "dev": true,
             "requires": {
                 "slice-ansi": "0.0.4",
@@ -1114,13 +1106,13 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
                     "dev": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
                     "dev": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
@@ -1129,13 +1121,13 @@
                 "slice-ansi": {
                     "version": "0.0.4",
                     "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-                    "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+                    "integrity": "sha512-up04hB2hR92PgjpyU3y/eg91yIBILyjVY26NvvciY3EVVPjybkMszMpXQ9QAkcS3I5rtJBDLoTxxg+qvW8c7rw==",
                     "dev": true
                 },
                 "string-width": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
                     "dev": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
@@ -1146,7 +1138,7 @@
                 "strip-ansi": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
                     "dev": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
@@ -1264,9 +1256,9 @@
             }
         },
         "clone-response": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-            "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+            "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
             "dev": true,
             "requires": {
                 "mimic-response": "^1.0.0"
@@ -1283,7 +1275,7 @@
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
             "dev": true
         },
         "color-convert": {
@@ -1321,6 +1313,16 @@
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
             "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
             "dev": true
+        },
+        "compress-brotli": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.8.tgz",
+            "integrity": "sha512-lVcQsjhxhIXsuupfy9fmZUFtAIdBmXA7EGY6GBdgZ++qkM9zG4YFT8iU7FoBxzryNDMOpD1HIFHUSX4D87oqhQ==",
+            "dev": true,
+            "requires": {
+                "@types/json-buffer": "~3.0.0",
+                "json-buffer": "~3.0.1"
+            }
         },
         "compressible": {
             "version": "2.0.18",
@@ -1496,9 +1498,9 @@
             }
         },
         "cosmiconfig": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-            "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+            "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
             "dev": true,
             "requires": {
                 "@types/parse-json": "^4.0.0",
@@ -1734,9 +1736,9 @@
             }
         },
         "duplexer3": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
+            "integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==",
             "dev": true
         },
         "ecc-jsbn": {
@@ -1758,7 +1760,7 @@
         "elegant-spinner": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-            "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+            "integrity": "sha512-B+ZM+RXvRqQaAmkMlO/oSe5nMUOaUnyfGYCEHoR8wrXsZR2mA0XVibsxV1bvTwxdRWah1PkQqso2EzhILGHtEQ==",
             "dev": true
         },
         "emoji-regex": {
@@ -2122,9 +2124,9 @@
             },
             "dependencies": {
                 "signal-exit": {
-                    "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-                    "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+                    "version": "3.0.7",
+                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+                    "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
                     "dev": true
                 }
             }
@@ -2455,7 +2457,7 @@
         "github-url-from-git": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
-            "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
+            "integrity": "sha512-WWOec4aRI7YAykQ9+BHmzjyNlkfJFG8QLXnDTsLz/kZefq7qkzdfo4p6fkYYMIq1aj+gZcQs/1HQhQh3DPPxlQ==",
             "dev": true
         },
         "glob": {
@@ -2615,7 +2617,7 @@
         "has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
             "dev": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
@@ -2624,7 +2626,7 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
                     "dev": true
                 }
             }
@@ -2762,13 +2764,13 @@
         "import-lazy": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+            "integrity": "sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==",
             "dev": true
         },
         "import-local": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
-            "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
+            "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
             "dev": true,
             "requires": {
                 "pkg-dir": "^4.2.0",
@@ -2947,15 +2949,15 @@
                     "dev": true
                 },
                 "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+                    "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
                     "dev": true
                 },
                 "cli-cursor": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-                    "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+                    "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
                     "dev": true,
                     "requires": {
                         "restore-cursor": "^2.0.0"
@@ -2970,7 +2972,7 @@
                 "figures": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-                    "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+                    "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
                     "dev": true,
                     "requires": {
                         "escape-string-regexp": "^1.0.5"
@@ -3000,7 +3002,7 @@
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
                     "dev": true
                 },
                 "mimic-fn": {
@@ -3012,13 +3014,13 @@
                 "mute-stream": {
                     "version": "0.0.7",
                     "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-                    "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+                    "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
                     "dev": true
                 },
                 "onetime": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-                    "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+                    "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
                     "dev": true,
                     "requires": {
                         "mimic-fn": "^1.0.0"
@@ -3027,7 +3029,7 @@
                 "restore-cursor": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-                    "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+                    "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
                     "dev": true,
                     "requires": {
                         "onetime": "^2.0.0",
@@ -3047,7 +3049,7 @@
                         "strip-ansi": {
                             "version": "4.0.0",
                             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
                             "dev": true,
                             "requires": {
                                 "ansi-regex": "^3.0.0"
@@ -3065,9 +3067,9 @@
                     },
                     "dependencies": {
                         "ansi-regex": {
-                            "version": "4.1.0",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                            "version": "4.1.1",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+                            "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
                             "dev": true
                         }
                     }
@@ -3588,11 +3590,12 @@
             "dev": true
         },
         "keyv": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
-            "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.3.tgz",
+            "integrity": "sha512-AcysI17RvakTh8ir03+a3zJr5r0ovnAH/XTXei/4HIv3bL2K/jzvgivLK9UuI/JbU1aJjM3NSAnVvVVd3n+4DQ==",
             "dev": true,
             "requires": {
+                "compress-brotli": "^1.3.8",
                 "json-buffer": "3.0.1"
             }
         },
@@ -3653,7 +3656,7 @@
                 "is-stream": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                    "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+                    "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
                     "dev": true
                 },
                 "p-map": {
@@ -3679,7 +3682,7 @@
         "listr-silent-renderer": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-            "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+            "integrity": "sha512-L26cIFm7/oZeSNVhWB6faeorXhMg4HNlb/dS/7jHhr708jxlXrtrBWo4YUxZQkc6dGoxEAe6J/D3juTRBUzjtA==",
             "dev": true
         },
         "listr-update-renderer": {
@@ -3701,19 +3704,19 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
                     "dev": true
                 },
                 "ansi-styles": {
                     "version": "2.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
                     "dev": true
                 },
                 "chalk": {
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "^2.2.1",
@@ -3726,7 +3729,7 @@
                 "figures": {
                     "version": "1.7.0",
                     "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-                    "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+                    "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
                     "dev": true,
                     "requires": {
                         "escape-string-regexp": "^1.0.5",
@@ -3736,13 +3739,13 @@
                 "indent-string": {
                     "version": "3.2.0",
                     "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-                    "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+                    "integrity": "sha512-BYqTHXTGUIvg7t1r4sJNKcbDZkL92nkXA8YtRpbjFHRHGDL/NtUeiBJMeE60kIFN/Mg8ESaWQvftaYMGJzQZCQ==",
                     "dev": true
                 },
                 "log-symbols": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-                    "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+                    "integrity": "sha512-mmPrW0Fh2fxOzdBbFv4g1m6pR72haFLPJ2G5SJEELf1y+iaQrDG6cWCPjy54RHYbZAt7X+ls690Kw62AdWXBzQ==",
                     "dev": true,
                     "requires": {
                         "chalk": "^1.0.0"
@@ -3751,7 +3754,7 @@
                 "strip-ansi": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
                     "dev": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
@@ -3760,7 +3763,7 @@
                 "supports-color": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
                     "dev": true
                 }
             }
@@ -3780,7 +3783,7 @@
                 "cli-cursor": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-                    "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+                    "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
                     "dev": true,
                     "requires": {
                         "restore-cursor": "^2.0.0"
@@ -3789,7 +3792,7 @@
                 "figures": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-                    "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+                    "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
                     "dev": true,
                     "requires": {
                         "escape-string-regexp": "^1.0.5"
@@ -3804,7 +3807,7 @@
                 "onetime": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-                    "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+                    "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
                     "dev": true,
                     "requires": {
                         "mimic-fn": "^1.0.0"
@@ -3813,7 +3816,7 @@
                 "restore-cursor": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-                    "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+                    "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
                     "dev": true,
                     "requires": {
                         "onetime": "^2.0.0",
@@ -3852,7 +3855,7 @@
         "lodash.isequal": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
             "dev": true
         },
         "lodash.merge": {
@@ -3870,7 +3873,7 @@
         "lodash.zip": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
-            "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
+            "integrity": "sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==",
             "dev": true
         },
         "log-driver": {
@@ -3891,7 +3894,7 @@
         "log-update": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
-            "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+            "integrity": "sha512-vlP11XfFGyeNQlmEn9tJ66rEW1coA/79m5z6BCkudjbAGE83uhAcGYrBFwfs3AdLiLzGRusRPAbSPK9xZteCmg==",
             "dev": true,
             "requires": {
                 "ansi-escapes": "^3.0.0",
@@ -3906,15 +3909,15 @@
                     "dev": true
                 },
                 "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+                    "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
                     "dev": true
                 },
                 "cli-cursor": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-                    "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+                    "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
                     "dev": true,
                     "requires": {
                         "restore-cursor": "^2.0.0"
@@ -3923,7 +3926,7 @@
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
                     "dev": true
                 },
                 "mimic-fn": {
@@ -3935,7 +3938,7 @@
                 "onetime": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-                    "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+                    "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
                     "dev": true,
                     "requires": {
                         "mimic-fn": "^1.0.0"
@@ -3944,7 +3947,7 @@
                 "restore-cursor": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-                    "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+                    "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
                     "dev": true,
                     "requires": {
                         "onetime": "^2.0.0",
@@ -3964,7 +3967,7 @@
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
                     "dev": true,
                     "requires": {
                         "ansi-regex": "^3.0.0"
@@ -3973,7 +3976,7 @@
                 "wrap-ansi": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-                    "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+                    "integrity": "sha512-iXR3tDXpbnTpzjKSylUJRkLuOrEC7hwEB221cgn6wtF8wpmz28puFXAEfPT5zrjM3wahygB//VuWEr1vTkDcNQ==",
                     "dev": true,
                     "requires": {
                         "string-width": "^2.1.1",
@@ -4056,24 +4059,6 @@
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
             "dev": true
-        },
-        "mem": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-6.1.1.tgz",
-            "integrity": "sha512-Ci6bIfq/UgcxPTYa8dQQ5FY3BzKkT894bwXWXxC/zqs0XgMO2cT20CGkOqda7gZNkmK5VP4x89IGZ6K7hfbn3Q==",
-            "dev": true,
-            "requires": {
-                "map-age-cleaner": "^0.1.3",
-                "mimic-fn": "^3.0.0"
-            },
-            "dependencies": {
-                "mimic-fn": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-                    "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-                    "dev": true
-                }
-            }
         },
         "meow": {
             "version": "8.1.2",
@@ -4529,9 +4514,9 @@
             "dev": true
         },
         "np": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/np/-/np-7.5.0.tgz",
-            "integrity": "sha512-CdpgqtO6JpDKJjQ2gueY0jnbz6APWA9wFXSwPv5bXg4seSBibHqQ8JyWxYlS8YRfVbpeDtj582wcAWTlfy5qNA==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/np/-/np-7.6.2.tgz",
+            "integrity": "sha512-gExmKGKixh7ITc4Q+Lv7nfCby0CVKvzri9zN8970oKD8976T4L5dw8QWUtMcXcIjhFF6h5lbvztao/NurDbmxQ==",
             "dev": true,
             "requires": {
                 "@samverschueren/stream-to-observable": "^0.3.1",
@@ -4632,9 +4617,9 @@
                     }
                 },
                 "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "version": "7.3.7",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
@@ -4691,7 +4676,7 @@
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
             "dev": true
         },
         "oauth-sign": {
@@ -4908,7 +4893,7 @@
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
             "dev": true
         },
         "ow": {
@@ -4926,9 +4911,9 @@
             },
             "dependencies": {
                 "@sindresorhus/is": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
-                    "integrity": "sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==",
+                    "version": "4.6.0",
+                    "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+                    "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
                     "dev": true
                 }
             }
@@ -4942,7 +4927,7 @@
         "p-defer": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+            "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
             "dev": true
         },
         "p-event": {
@@ -4999,13 +4984,14 @@
             }
         },
         "p-memoize": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-4.0.1.tgz",
-            "integrity": "sha512-km0sP12uE0dOZ5qP+s7kGVf07QngxyG0gS8sYFvFWhqlgzOsSy+m71aUejf/0akxj5W7gE//2G74qTv6b4iMog==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-4.0.4.tgz",
+            "integrity": "sha512-ijdh0DP4Mk6J4FXlOM6vPPoCjPytcEseW8p/k5SDTSSfGV3E9bpt9Yzfifvzp6iohIieoLTkXRb32OWV0fB2Lw==",
             "dev": true,
             "requires": {
-                "mem": "^6.0.1",
-                "mimic-fn": "^3.0.0"
+                "map-age-cleaner": "^0.1.3",
+                "mimic-fn": "^3.0.0",
+                "p-settle": "^4.1.1"
             },
             "dependencies": {
                 "mimic-fn": {
@@ -5013,6 +4999,33 @@
                     "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
                     "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
                     "dev": true
+                }
+            }
+        },
+        "p-reflect": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-reflect/-/p-reflect-2.1.0.tgz",
+            "integrity": "sha512-paHV8NUz8zDHu5lhr/ngGWQiW067DK/+IbJ+RfZ4k+s8y4EKyYCz8pGYWjxCg35eHztpJAt+NUgvN4L+GCbPlg==",
+            "dev": true
+        },
+        "p-settle": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/p-settle/-/p-settle-4.1.1.tgz",
+            "integrity": "sha512-6THGh13mt3gypcNMm0ADqVNCcYa3BK6DWsuJWFCuEKP1rpY+OKGp7gaZwVmLspmic01+fsg/fN57MfvDzZ/PuQ==",
+            "dev": true,
+            "requires": {
+                "p-limit": "^2.2.2",
+                "p-reflect": "^2.1.0"
+            },
+            "dependencies": {
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
                 }
             }
         },
@@ -5090,7 +5103,7 @@
                 "decompress-response": {
                     "version": "3.3.0",
                     "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-                    "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+                    "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
                     "dev": true,
                     "requires": {
                         "mimic-response": "^1.0.0"
@@ -5133,7 +5146,7 @@
                 "json-buffer": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-                    "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+                    "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
                     "dev": true
                 },
                 "keyv": {
@@ -5172,7 +5185,7 @@
                 "responselike": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-                    "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+                    "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
                     "dev": true,
                     "requires": {
                         "lowercase-keys": "^1.0.0"
@@ -5297,7 +5310,7 @@
         "prepend-http": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-            "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+            "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
             "dev": true
         },
         "process-nextick-args": {
@@ -5692,12 +5705,12 @@
             "dev": true
         },
         "registry-auth-token": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-            "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.2.tgz",
+            "integrity": "sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==",
             "dev": true,
             "requires": {
-                "rc": "^1.2.8"
+                "rc": "1.2.8"
             }
         },
         "registry-url": {
@@ -5788,9 +5801,9 @@
             "dev": true
         },
         "responselike": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-            "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+            "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
             "dev": true,
             "requires": {
                 "lowercase-keys": "^2.0.0"
@@ -6971,9 +6984,9 @@
                     }
                 },
                 "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "version": "7.3.7",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
@@ -7002,7 +7015,7 @@
         "url-parse-lax": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-            "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+            "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
             "dev": true,
             "requires": {
                 "prepend-http": "^2.0.0"
@@ -7035,7 +7048,7 @@
         "vali-date": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+            "integrity": "sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==",
             "dev": true
         },
         "validate-npm-package-license": {
@@ -7051,7 +7064,7 @@
         "validate-npm-package-name": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-            "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+            "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
             "dev": true,
             "requires": {
                 "builtins": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "karma-mocha-reporter": "2.2.5",
         "karma-sinon": "1.0.5",
         "mocha": "9.0.3",
-        "np": "7.5.0",
+        "np": "7.6.2",
         "open-cli": "7.0.0",
         "puppeteer": "10.2.0",
         "rimraf": "3.0.2",


### PR DESCRIPTION
Updates np manually to hopefully fix the release. We'll also have to see why dependabot didn't pick up the new `np` version.

@terrestris/devs Please review