### PR TITLE
introduces basigx-form-addarcgisrest

### DIFF
--- a/src/util/ArcGISRest.js
+++ b/src/util/ArcGISRest.js
@@ -71,8 +71,12 @@ Ext.define('BasiGX.util.ArcGISRest', {
         createOlLayerFromArcGISRest: function(layerConfig, useDefaultHeader) {
             var service = layerConfig.service;
             var url = layerConfig.url;
-            var serviceUrl = BasiGX.util.ArcGISRest.getArcGISRestRootUrl(url);
-            serviceUrl = [serviceUrl, service.name, service.type].join('/');
+            var rootUrl = BasiGX.util.ArcGISRest.getArcGISRestRootUrl(url);
+            if (!rootUrl) {
+                Ext.log.warn('Provided URL is not a valid ArcGISRest URL');
+                return Ext.Promise.reject();
+            }
+            var serviceUrl = [rootUrl, service.name, service.type].join('/');
             var onReject = function() {
                 return Ext.Promise.reject();
             };

--- a/src/util/ArcGISRest.js
+++ b/src/util/ArcGISRest.js
@@ -1,0 +1,118 @@
+/* Copyright (c) 2022-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * ArcGISRest Util
+ *
+ * Some methods to work with ArcGISRest
+ *
+ * @class BasiGX.util.ArcGISRest
+ */
+Ext.define('BasiGX.util.ArcGISRest', {
+    statics: {
+
+        /**
+         * Check if a url is an ArcGISRest URL.
+         *
+         * ArcGISRest URL must contain a path called '/services/'.
+         *
+         * @param {string} url The url to check.
+         * @return {boolean} True, if url is ArcGISRest URL. False otherwise.
+         */
+        isArcGISRestUrl: function(url) {
+            var urlObj = new URL(url);
+            var parts = urlObj.pathname.split('/');
+            return parts.indexOf('services') > -1;
+        },
+
+        /**
+         * Get the root URL of the ArcGISRest service.
+         *
+         * @param {string} url The URL to get the root URL from.
+         * @return {string} The root URL.
+         */
+        getArcGISRestRootUrl: function(url) {
+            if (!BasiGX.util.ArcGISRest.isArcGISRestUrl(url)) {
+                return;
+            }
+            var urlObj = new URL(url);
+            var parts = urlObj.pathname.split('/');
+            var serviceIndex = parts.indexOf('services');
+            var baseParts = parts.slice(0, serviceIndex + 1);
+            var basePath = baseParts.join('/');
+
+            return urlObj.origin + basePath;
+        },
+
+        /**
+         * Creates an olLayer from an ArcGISRest layer config.
+         *
+         * @param {object} layerConfig The layer config to base the olLayer on.
+         * @param {object} layerConfig.service The service config info.
+         * @param {string} layerConfig.service.type The service type.
+         * @param {string} layerConfig.service.name The service name.
+         * @param {string} layerConfig.url The service url.
+         * @param {boolean} useDefaultHeader Whether to use the default
+         * Xhr header.
+         * @return {Ext.Promise} A promise containing the olLayer.
+         */
+        createOlLayerFromArcGISRest: function(layerConfig, useDefaultHeader) {
+            var service = layerConfig.service;
+            var url = layerConfig.url;
+            var serviceUrl = BasiGX.util.ArcGISRest.getArcGISRestRootUrl(url);
+            serviceUrl = [serviceUrl, service.name, service.type].join('/');
+            var onReject = function() {
+                return Ext.Promise.reject();
+            };
+            return Ext.Ajax.request({
+                url: BasiGX.util.Url.setQueryParam(serviceUrl, 'f', 'json'),
+                method: 'GET',
+                useDefaultXhrHeader: useDefaultHeader
+            }, onReject).then(function(response) {
+                var responseJson = JSON.parse(response.responseText);
+                return Ext.Promise.resolve(responseJson);
+            }, onReject).then(function(serviceInfo) {
+                var layer = undefined;
+                switch(service.type) {
+                    case 'ImageServer':
+                    case 'MapServer':
+                        var source = new ol.source.TileArcGISRest({
+                            url: serviceUrl,
+                            projection: 'EPSG:' +
+                                serviceInfo.spatialReference.wkid
+                        });
+                        layer = new ol.layer.Tile({
+                            source: source,
+                            name: service.name,
+                            topic: true
+                        });
+                        break;
+                    case 'FeatureServer':
+                        // FeatureServers can only be requested
+                        // for single layers in a service.
+                        Ext.log.info('ArcGISRest FeatureServer is ' +
+                            'currently not supported.');
+                        break;
+                    default:
+                        break;
+                }
+                return Ext.Promise.resolve(layer);
+            }, function() {
+                Ext.log.warn('Could not create olLayer from ArcGISRest.');
+                return Ext.Promise.resolve();
+            });
+        }
+    }
+});

--- a/src/util/Url.js
+++ b/src/util/Url.js
@@ -97,6 +97,27 @@ Ext.define('BasiGX.util.Url', {
          */
         isUrl: function (str) {
             return str.startsWith('http://') || str.startsWith('https://');
+        },
+
+        /**
+         * Set a query parameter.
+         *
+         * This will overwrite an existing parameter with the
+         * same queryKey. If there are multiple query parameters
+         * with the same key, the others are deleted.
+         *
+         * @param {string} url The url.
+         * @param {string} queryKey The key of the query parameter.
+         * @param {string} queryValue The value of the query parameter.
+         * @return {string} The URL with the new query parameter.
+         */
+        setQueryParam: function(url, queryKey, queryValue) {
+            var urlObj = new URL(url);
+            var searchParams = urlObj.searchParams;
+            searchParams.set(queryKey, queryValue);
+            var newUrl = urlObj.origin +
+                urlObj.pathname + '?' + searchParams.toString();
+            return newUrl;
         }
 
     }

--- a/src/util/Url.js
+++ b/src/util/Url.js
@@ -100,7 +100,7 @@ Ext.define('BasiGX.util.Url', {
         },
 
         /**
-         * Set a query parameter.
+         * Sets a query parameter.
          *
          * This will overwrite an existing parameter with the
          * same queryKey. If there are multiple query parameters

--- a/src/ux/ContextSensitiveHelp.js
+++ b/src/ux/ContextSensitiveHelp.js
@@ -75,6 +75,7 @@ Ext.define('BasiGX.ux.ContextSensitiveHelp', {
         'basigx-button-togglelegend',
         'basigx-overview-map-button',
         'basigx-button-addwms',
+        'basigx-button-addarcgisrest',
         'basigx-button-measure',
         'basigx-button-coordinatetransform',
         'basigx-button-permalink',

--- a/src/view/button/AddArcGISRest.js
+++ b/src/view/button/AddArcGISRest.js
@@ -1,0 +1,174 @@
+/* Copyright (c) 2022-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * AddArcGISRest Button
+ *
+ * Button used to instanciate the basigx-form-addarcgisrest in order to add a
+ * ArcGIS REST layer to the map
+ *
+ * @class BasiGX.view.button.AddArcGISRest
+ */
+Ext.define('BasiGX.view.button.AddArcGISRest', {
+    extend: 'BasiGX.view.button.Base',
+    xtype: 'basigx-button-addarcgisrest',
+
+    requires: [
+        'Ext.window.Window',
+        'Ext.app.ViewModel',
+        'BasiGX.view.form.AddArcGISRest',
+        'BasiGX.util.Animate'
+    ],
+
+    /**
+     *
+     */
+    viewModel: {
+        data: {
+            tooltip: 'ArcGIS Rest Layer hinzufügen',
+            text: 'ArcGIS Rest <span style="font-size: 1.7em; ' +
+                'font-weight: normal;">⊕</span>',
+            windowTitle: 'ArcGIS Rest Layer hinzufügen',
+            documentation: '<h2>ArcGIS Rest Layer hinzufügen</h2>• Ein Klick' +
+                'auf den Button öffnet ein Fenster, in dem Sie mit Hilfe ' +
+                'einer ArcGIS Rest-URL einen beliebigen Kartendienst der ' +
+                'Karte hinzufügen können.'
+        }
+    },
+
+    /**
+     *
+     */
+    bind: {
+        text: '{text}'
+    },
+
+    /**
+     * A config object to show this tool in action (live demo) when using the
+     * context sensitive help
+     */
+    liveDemoConfig: [
+        {
+            moveMouseTo: {
+                component: 'basigx-button-addarcgisrest',
+                moveDuration: 2000
+            }
+        },
+        {
+            clickOnButton: 'basigx-button-addarcgisrest'
+        },
+        {
+            moveMouseTo: {
+                component: 'window[name=add-arcgisrest-window] ' +
+                    'textfield[name=url]',
+                moveDuration: 2000
+            }
+        },
+        {
+            enterText: {
+                component: 'window[name=add-arcgisrest-window] ' +
+                    'textfield[name=url]',
+                text: 'https://gis.epa.ie/arcgis/rest/services',
+                waitAfter: 3500
+            }
+        },
+        {
+            moveMouseTo:
+                'window[name=add-arcgisrest-window] ' +
+                'button[name=requestLayersBtn]'
+        },
+        {
+            clickOnButton: {
+                component:
+                    'window[name=add-arcgisrest-window] ' +
+                    'button[name=requestLayersBtn]',
+                waitAfter: 3000
+            }
+        },
+        {
+            scrollTo: {
+                component: 'window[name=add-arcgisrest-window] form',
+                target: {
+                    x: 0,
+                    y: 999,
+                    animate: true
+                }
+            }
+        },
+        {
+            moveMouseTo:
+                'window[name=add-arcgisrest-window] ' +
+                'button[name=add-checked-layers]'
+        },
+        {
+            destroy: 'window[name=add-arcgisrest-window]'
+        }
+    ],
+
+    /**
+     * The window instance which will be created by this button.
+     *
+     * @type {Ext.window.Window}
+     * @private
+     */
+    _win: null,
+
+    /**
+     *
+     */
+    config: {
+        windowConfig: {
+            // can be used by subclasses to apply/merge
+            // additional/other values for the window
+        }
+    },
+
+    handler: function() {
+        if (!this._win) {
+            var windowConfig = {
+                name: 'add-arcgisrest-window',
+                title: this.getViewModel().get('windowTitle'),
+                width: 500,
+                height: 400,
+                layout: 'fit',
+                constrain: true,
+                items: [{
+                    xtype: 'basigx-form-addarcgisrest'
+                }],
+                listeners: {
+                    destroy: this.onDestroy,
+                    scope: this
+                }
+            };
+
+            var windowConfigToApply = this.getWindowConfig();
+            Ext.apply(windowConfig, windowConfigToApply);
+
+            this._win = Ext.create('Ext.window.Window', windowConfig);
+            this._win.show();
+        } else {
+            BasiGX.util.Animate.shake(this._win);
+        }
+    },
+
+    /**
+     * Reset window reference
+     */
+    onDestroy: function() {
+        if (this._win) {
+            this._win = null;
+        }
+    }
+});

--- a/src/view/button/AddArcGISRest.js
+++ b/src/view/button/AddArcGISRest.js
@@ -37,13 +37,13 @@ Ext.define('BasiGX.view.button.AddArcGISRest', {
      */
     viewModel: {
         data: {
-            tooltip: 'ArcGIS Rest Layer hinzufügen',
-            text: 'ArcGIS Rest <span style="font-size: 1.7em; ' +
+            tooltip: 'ArcGIS REST Layer hinzufügen',
+            text: 'ArcGIS REST <span style="font-size: 1.7em; ' +
                 'font-weight: normal;">⊕</span>',
-            windowTitle: 'ArcGIS Rest Layer hinzufügen',
-            documentation: '<h2>ArcGIS Rest Layer hinzufügen</h2>• Ein Klick' +
+            windowTitle: 'ArcGIS REST Layer hinzufügen',
+            documentation: '<h2>ArcGIS REST Layer hinzufügen</h2>• Ein Klick' +
                 'auf den Button öffnet ein Fenster, in dem Sie mit Hilfe ' +
-                'einer ArcGIS Rest-URL einen beliebigen Kartendienst der ' +
+                'einer ArcGIS REST-URL einen beliebigen Kartendienst der ' +
                 'Karte hinzufügen können.'
         }
     },

--- a/src/view/form/AddArcGISRest.js
+++ b/src/view/form/AddArcGISRest.js
@@ -1,0 +1,643 @@
+/* Copyright (c) 2022-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * AddArcGISRest FormPanel
+ *
+ * Used to add an ArcGIS REST layer to the map
+ *
+ * @class BasiGX.view.form.AddArcGISRest
+ */
+Ext.define('BasiGX.view.form.AddArcGISRest', {
+    extend: 'Ext.form.Panel',
+    xtype: 'basigx-form-addarcgisrest',
+
+    requires: [
+        'Ext.button.Button',
+        'Ext.form.FieldSet',
+        'Ext.form.field.ComboBox',
+        'Ext.form.CheckboxGroup',
+        'Ext.Promise',
+        'BasiGX.util.Map',
+        'BasiGX.util.MsgBox',
+        'BasiGX.util.Url',
+        'BasiGX.util.ArcGISRest'
+    ],
+
+    viewModel: {
+        data: {
+            queryParamsFieldSetTitle: 'Anfrageparameter',
+            arcGISUrlTextFieldLabel: 'ArcGIS Service URL',
+            availableLayesFieldSetTitle: 'Verfügbare Layer',
+            resetBtnText: 'Zurücksetzen',
+            requestLayersBtnText: 'Verfügbare Layer abfragen',
+            checkAllLayersBtnText: 'Alle auswählen',
+            uncheckAllLayersBtnText: 'Nichts auswählen',
+            addCheckedLayersBtnText: 'Ausgewählte Layer hinzufügen',
+            errorRequestFailed: 'Die angegebene URL konnte nicht abgefragt ' +
+                    'werden',
+            msgRequestTimedOut: 'Die Anfrage wurde nicht schnell genug ' +
+                    'beantwortet und abgebrochen',
+            msgCorsMisconfiguration: 'HTTP access control (CORS) auf dem ' +
+                    'Zielserver vermutlich nicht korrekt konfiguriert',
+            msgUnauthorized: 'Der Client ist nicht gegenüber dem Zielserver ' +
+                    'authentifiziert',
+            msgForbidden: 'Der Client hat keinen Zugriff auf die angefragte ' +
+                    'Ressource',
+            msgFileNotFound: 'Die angefragte Ressource existiert nicht',
+            msgTooManyRequests: 'Der Client hat zu viele Anfragen gestellt',
+            msgServiceUnavailable: 'Der Server ist derzeit nicht verfügbar ' +
+                    '(zu viele Anfragen bzw. Wartungsmodus)',
+            msgGatewayTimeOut: 'Der Server fungierte als Gateway und das ' +
+                    'Originalziel hat zu langsam geantwortet',
+            msgClientError: 'Ein unspezifizierter Clientfehler ist aufgetreten',
+            msgServerError: 'Ein unspezifizierter Serverfehler ist aufgetreten',
+            msgInvalidUrl: 'Die angegebene URL ist keine valide ArcGISRest URL',
+            documentation: '<h2>ArcGISRest Layer hinzufügen</h2>• In ' +
+                'diesem Dialog können Sie mit Hilfe einer ArcGISRest-URL ' +
+                'einen beliebigen Kartendienst der Karte hinzufügen.'
+        }
+    },
+
+    config: {
+        /**
+         * Whether layers shall start `checked` or `unchecked` in the available
+         * layers fieldset.
+         */
+        candidatesInitiallyChecked: false,
+
+        /**
+         * Whether to add a `Check all layers` button to the toolbar to interact
+         * with the layers of a ArcGIS Rest response.
+         */
+        hasCheckAllBtn: false,
+
+        /**
+         * Whether to add a `Uncheck all layers` button to the toolbar to
+         * interact with the layers of a ArcGIS Rest response.
+         */
+        hasUncheckAllBtn: false,
+
+        /**
+         * With these ArcGIS urls we fill the combobox. If this is
+         * empty (default), no combobox will be rendered but a plain textfield.
+         */
+        arcGISBaseUrls: [],
+
+        /**
+         * Defines a URL which will be appended to all service requests.
+         * Especially useful when dealing with CORS problems.
+         */
+        proxyUrl: null,
+
+        /**
+         * Default url for the textfield or combobox.
+         */
+        defaultUrl: 'https://gis.epa.ie/arcgis/rest/services',
+
+        /**
+         * Whether we will send the `X-Requested-With` header when fetching the
+         * document from the URL. The `X-Requested-With` header is
+         * usually added for XHR, but adding it should lead to a preflight
+         * request (see https://goo.gl/6JzdUI), which some servers fail.
+         *
+         * @type {Boolean}
+         */
+        useDefaultXhrHeader: false
+    },
+
+    /**
+     * Keeps track of the viewModel key of the last error (if any).
+     *
+     * @private
+     */
+    lastErrorMsgKey: null,
+
+    defaultButton: 'requestLayersBtn',
+
+    items: [
+        {
+            xtype: 'fieldset',
+            layout: 'anchor',
+            defaults: {
+                anchor: '100%'
+            },
+            bind: {
+                title: '{queryParamsFieldSetTitle}'
+            },
+            items: [{
+                xtype: 'textfield',
+                bind: {
+                    fieldLabel: '{arcGISUrlTextFieldLabel}'
+                },
+                name: 'url',
+                allowBlank: false,
+                value: null,
+                listeners: {
+                    change: function(textfield) {
+                        var view = textfield.up('basigx-form-addarcgisrest');
+                        view.resetState();
+                    },
+                    beforerender: function(textfield) {
+                        var view = textfield.up('basigx-form-addarcgisrest');
+                        var countUrls = view.arcGISBaseUrls.length;
+                        if (countUrls !== 0) {
+                            textfield.setHidden(true);
+                        }
+                    }
+                }
+            }, {
+                xtype: 'combobox',
+                bind: {
+                    fieldLabel: '{arcGISUrlTextFieldLabel}'
+                },
+                store: null,
+                name: 'urlCombo',
+                allowBlank: false,
+                value: null,
+                listeners: {
+                    change: function(combobox) {
+                        var view = combobox.up('basigx-form-addarcgisrest');
+                        view.resetState();
+                    },
+                    beforerender: function(combobox) {
+                        var view = combobox.up('basigx-form-addarcgisrest');
+                        var countUrls = view.arcGISBaseUrls.length;
+                        if (countUrls === 0) {
+                            combobox.setHidden(true);
+                        } else {
+                            var urls = view.arcGISBaseUrls;
+                            combobox.setStore(urls);
+                        }
+                    }
+                }
+            }]
+        },
+        {
+            xtype: 'fieldset',
+            name: 'fs-available-layers',
+            layout: 'anchor',
+            scrollable: 'y',
+            maxHeight: 200,
+            defaults: {
+                anchor: '100%'
+            },
+            bind: {
+                title: '{availableLayesFieldSetTitle}'
+            },
+            items: {
+                xtype: 'checkboxgroup',
+                listeners: {
+                    change: {
+                        fn: function(cbGroup) {
+                            var form = cbGroup.up('basigx-form-addarcgisrest');
+                            form.updateControlToolbarState();
+                        },
+                        buffer: 50
+                    }
+                },
+                columns: 2,
+                vertical: true
+            }
+        }
+    ],
+
+    // Reset and Submit buttons
+    buttons: [
+        {
+            name: 'resetFormBtn',
+            bind: {
+                text: '{resetBtnText}'
+            },
+            handler: function(btn) {
+                var view = btn.up('basigx-form-addarcgisrest');
+                view.getForm().reset();
+                view.removeAddLayersComponents();
+                view.resetState();
+                var defaultValue = view.defaultUrl;
+                var combo = view.down('combobox[name=urlCombo]');
+                combo.setValue(defaultValue);
+                var textfield = view.down('textfield[name=url]');
+                textfield.setValue(defaultValue);
+            }
+        },
+        '->',
+        {
+            bind: {
+                text: '{requestLayersBtnText}'
+            },
+            name: 'requestLayersBtn',
+            reference: 'requestLayersBtn',
+            formBind: true, // only enabled once the form is valid
+            disabled: true,
+            handler: function(btn) {
+                var view = btn.up('basigx-form-addarcgisrest');
+                view.resetState();
+                view.requestLayers()
+                    .then(
+                        view.onGetServicesSuccess.bind(view),
+                        view.onGetServicesFailure.bind(view)
+                    );
+            }
+        }
+    ],
+
+    /**
+     * Initializes the form and sets up the parser instance.
+     */
+    initComponent: function() {
+        var me = this;
+        me.callParent();
+        var defaultValue = me.defaultUrl;
+        var combo = me.down('combobox[name=urlCombo]');
+        var textfield = me.down('textfield[name=url]');
+        combo.setValue(defaultValue);
+        textfield.setValue(defaultValue);
+    },
+
+    /**
+     * Resets our internal state tracking properties for tracking the tried
+     * versions and the last error message key we have determined.
+     *
+     * @private
+     */
+    resetState: function() {
+        var me = this;
+        me.lastErrorMsgKey = null;
+    },
+
+    /**
+     * Will be called with the `get layers` button. Issues an ArcGIS Rest folder
+     * request and sets up handlers for reacting on the response.
+     *
+     * @return {Ext.Promise} The resolved request.
+     */
+    requestLayers: function() {
+        var me = this;
+        var form = me.getForm();
+        if (!form.isValid()) {
+            return;
+        }
+        me.setLoading(true);
+        me.uncheckAllLayers();
+        me.removeAddLayersComponents();
+        var values = form.getValues();
+        var url = '';
+        var originalUrl = '';
+
+        if (me.getProxyUrl()) {
+            url += me.getProxyUrl();
+        }
+
+        if (me.arcGISBaseUrls.length === 0) {
+            originalUrl = values.url;
+        } else {
+            originalUrl = values.urlCombo;
+        }
+
+        if (!BasiGX.util.ArcGISRest.isArcGISRestUrl(originalUrl)) {
+            me.setLoading(false);
+            BasiGX.warn(me.getErrorMessage('msgInvalidUrl'), []);
+            return;
+        }
+
+        url += originalUrl;
+
+        url = BasiGX.util.Url.setQueryParam(url, 'f', 'json');
+
+        return Ext.Ajax.request({
+            url: url,
+            method: 'POST',
+            useDefaultXhrHeader: me.getUseDefaultXhrHeader()
+        });
+    },
+
+    /**
+     * Called if we could successfully query the services of an
+     * ArcGISRest folder. This method will examine the answer
+     * and eventually set up a fieldset for all the services that
+     * we have found in the server's answer.
+     *
+     * @param {XMLHttpRequest} response The response of the request.
+     */
+    onGetServicesSuccess: function(response) {
+        try {
+            var responseJson = JSON.parse(response.responseText);
+            var hasServicesKey = Object.prototype.hasOwnProperty.call(
+                responseJson, 'services'
+            );
+            if (!hasServicesKey) {
+                throw new Error('Response has no key "services"');
+            }
+        } catch (e) {
+            Ext.log.warn('Could not get services', e);
+            this.setLoading(false);
+            BasiGX.warn(this.getErrorMessage('msgServerError', []));
+            return;
+        }
+        var services = responseJson.services;
+
+        var layerConfigs = Ext.Array.map(services, function(service) {
+            return {
+                service: service,
+                url: response.request.url
+            };
+        });
+        // TODO remove this as soon as FeatureServer is supported.
+        layerConfigs = Ext.Array.filter(
+            layerConfigs, function(layerConfig) {
+                var isMapServer = layerConfig.service.type === 'MapServer';
+                var isImageServer = layerConfig.service.type === 'ImageServer';
+                return isMapServer || isImageServer;
+            }
+        );
+        this.fillAvailableLayersFieldset(layerConfigs);
+        this.updateControlToolbarState();
+        this.setLoading(false);
+    },
+
+    /**
+     * Called if we could not successfully query for the services of an
+     * ArcGISRest folder.
+     *
+     * @param {XMLHttpRequest} response The response of the request.
+     */
+    onGetServicesFailure: function(response) {
+        var me = this;
+        var status = response.status;
+        var errDetails = [];
+        // Keep track of the last error, to eventually inform the user
+        me.lastErrorMsgKey = me.responseStatusToErrorMsgKey(status);
+
+        // we might simply have timed out
+        if (response.timedout) {
+            me.lastErrorMsgKey = 'msgRequestTimedOut';
+        }
+
+        me.setLoading(false);
+        BasiGX.warn(me.getErrorMessage('errorRequestFailed', errDetails));
+    },
+
+    /**
+     * Returns a key for a viewModel property for the passed HTTP status code or
+     * null if we don't consider the status code an error.
+     *
+     * @param {Number} status The HTTP status code of the last response.
+     * @return {String} An error message key to be looked up in the viewModel.
+     * @private
+     */
+    responseStatusToErrorMsgKey: function(status) {
+        status = parseInt(status, 10);
+        // handle very common ones specifically
+        if (status === 0) {
+            // Most likely CORS
+            // * either not enabled at all
+            // * or misconfigured
+            return 'msgCorsMisconfiguration';
+        } else if (status === 401) {
+            return 'msgUnauthorized';
+        } else if (status === 403) {
+            return 'msgForbidden';
+        } else if (status === 404) {
+            return 'msgFileNotFound';
+        } else if (status === 429) {
+            return 'msgTooManyRequests';
+        } else if (status === 503) {
+            return 'msgServiceUnavailable';
+        } else if (status === 504) {
+            return 'msgGatewayTimeOut';
+        } else if (status >= 400 && status < 500) {
+            return 'msgClientError';
+        } else if (status >= 500) {
+            return 'msgServerError';
+        }
+        return null;
+    },
+
+    /**
+     * Returns the error message to display to the user for the passed key,
+     * optionally adding the passed details.
+     *
+     * @param {String} errorKey The key to look up in the view model for the
+     *     error.
+     * @param {Array<String>} [errorDetails] Optional array of details to
+     *     display.
+     * @return {String} The error message to display.
+     * @private
+     */
+    getErrorMessage: function(errorKey, errorDetails) {
+        var me = this;
+        var viewModel = me.getViewModel();
+
+        var msg = viewModel.get(errorKey);
+        if (me.lastErrorMsgKey !== null) {
+            msg += '<br /><br />' + viewModel.get(me.lastErrorMsgKey);
+        }
+        if (errorDetails && errorDetails.length > 0) {
+            msg += '<ul>';
+            Ext.each(errorDetails, function(errorDetail) {
+                msg += '<li>' + errorDetail + '</li>';
+            });
+            msg += '</ul>';
+        }
+        return msg;
+    },
+
+    /**
+     * Updates the disabled state of the buttons to control the layer
+     * checkboxes (e.g. check all, uncheck all, add selected).
+     */
+    updateControlToolbarState: function() {
+        var me = this;
+        var cbGroup = me.down('[name=fs-available-layers] checkboxgroup');
+        var allCbs = cbGroup.query('checkbox');
+        var allChecked = cbGroup.query('[checked=true]');
+        var allDisabled = cbGroup.query('[disabled=true]');
+        var checkAllBtn = me.down('[name=check-all-layers]');
+        var uncheckAllBtn = me.down('[name=uncheck-all-layers]');
+        var addBtn = me.down('[name=add-checked-layers]');
+        if (allCbs.length === 0) {
+            // no checkboxes, also no control toolbar, return
+            return;
+        }
+        if (allDisabled.length === allCbs.length) {
+            // all checkboxes are disabled, all controls can be disabled
+            addBtn.setDisabled(true);
+            if (checkAllBtn) {
+                checkAllBtn.setDisabled(true);
+            }
+            if (uncheckAllBtn) {
+                uncheckAllBtn.setDisabled(true);
+            }
+            return;
+        }
+        if (allChecked.length > 0) {
+            // at least one checkbox is checked
+            addBtn.setDisabled(false);
+        } else {
+            // not even one is checked
+            addBtn.setDisabled(true);
+        }
+
+        if (checkAllBtn) {
+            if (allCbs.length === allChecked.length) {
+                // all are checked already
+                checkAllBtn.setDisabled(true);
+            } else {
+                checkAllBtn.setDisabled(false);
+            }
+        }
+        if (uncheckAllBtn) {
+            if (allChecked.length === 0) {
+                // not a single one is checked
+                uncheckAllBtn.setDisabled(true);
+            } else {
+                uncheckAllBtn.setDisabled(false);
+            }
+        }
+    },
+
+    /**
+     * Takes an array of ArcGIS layer configs and updates the
+     * available layers fieldset with matching entries.
+     *
+     * @param {object[]} layers The ArcGIS layer configs for which we shall fill
+     *     the fieldset.
+     */
+    fillAvailableLayersFieldset: function(layers) {
+        var me = this;
+        me.removeAddLayersComponents();
+        var fs = me.down('[name=fs-available-layers]');
+        var cbGroup = fs.down('checkboxgroup');
+        var checkBoxes = [];
+        var candidatesInitiallyChecked = me.getCandidatesInitiallyChecked();
+        Ext.each(layers, function(layer) {
+            checkBoxes.push({
+                xtype: 'checkbox',
+                boxLabel: layer.service.name,
+                checked: candidatesInitiallyChecked,
+                arcGISLayerConfig: layer
+            });
+        });
+        cbGroup.add(checkBoxes);
+
+        var tbItems = [];
+
+        if (me.getHasCheckAllBtn()) {
+            tbItems.push({
+                xtype: 'button',
+                name: 'check-all-layers',
+                bind: {
+                    text: '{checkAllLayersBtnText}'
+                },
+                handler: me.checkAllLayers,
+                scope: me
+            });
+        }
+
+        if (me.getHasUncheckAllBtn()) {
+            tbItems.push({
+                xtype: 'button',
+                name: 'uncheck-all-layers',
+                bind: {
+                    text: '{uncheckAllLayersBtnText}'
+                },
+                handler: me.uncheckAllLayers,
+                scope: me
+            });
+        }
+
+        tbItems.push('->');
+        tbItems.push({
+            xtype: 'button',
+            name: 'add-checked-layers',
+            bind: {
+                text: '{addCheckedLayersBtnText}'
+            },
+            handler: me.addCheckedLayers,
+            scope: me
+        });
+
+        me.add({
+            xtype: 'toolbar',
+            name: 'interact-w-available-layers',
+            items: tbItems
+        });
+    },
+
+    /**
+     * Remove the checkboxes for layers from previous requests, and also the
+     * interact-toolbar.
+     */
+    removeAddLayersComponents: function() {
+        var me = this;
+        var cbGroup = me.down('[name=fs-available-layers] checkboxgroup');
+        var tb = me.down('toolbar[name=interact-w-available-layers]');
+        cbGroup.removeAll();
+        if (tb) {
+            me.remove(tb);
+        }
+    },
+
+    /**
+     * Examines the available layers fieldset, and adds all checked layers to
+     * the map.
+     */
+    addCheckedLayers: function() {
+        var me = this;
+        var fs = me.down('[name=fs-available-layers]');
+        var checkboxes = fs.query('checkbox[checked=true][disabled=false]');
+        var map = BasiGX.util.Map.getMapComponent().getMap();
+        var useDefaultHeader = me.getUseDefaultXhrHeader();
+        Ext.each(checkboxes, function(checkbox) {
+            var config = checkbox.arcGISLayerConfig;
+            BasiGX.util.ArcGISRest.createOlLayerFromArcGISRest(
+                config, useDefaultHeader
+            )
+                .then(function(layer) {
+                    if (!layer) {
+                        return;
+                    }
+                    me.fireEvent('beforearcgisrestadd', layer);
+                    map.addLayer(layer);
+                    me.fireEvent('arcgisrestadd', layer);
+                    checkbox.setDisabled(true);
+                    me.updateControlToolbarState();
+                });
+        });
+    },
+
+    /**
+     * Checks all checkboxes in the available layers fieldset.
+     */
+    checkAllLayers: function() {
+        var sel = '[name=fs-available-layers] checkbox[disabled=false]';
+        var checkboxes = this.query(sel);
+        Ext.each(checkboxes, function(checkbox) {
+            checkbox.setValue(true);
+        });
+    },
+
+    /**
+     * Unchecks all checkboxes in the available layers fieldset.
+     */
+    uncheckAllLayers: function() {
+        var sel = '[name=fs-available-layers] checkbox[disabled=false]';
+        var checkboxes = this.query(sel);
+        Ext.each(checkboxes, function(checkbox) {
+            checkbox.setValue(false);
+        });
+    }
+});

--- a/test/spec/util/ArcGISRest.test.js
+++ b/test/spec/util/ArcGISRest.test.js
@@ -1,0 +1,46 @@
+Ext.Loader.syncRequire(['BasiGX.util.ArcGISRest']);
+
+describe('BasiGX.util.ArcGISRest', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.util.ArcGISRest).to.not.be(undefined);
+        });
+    });
+
+    describe('#isArcGISRestUrl', function() {
+
+        it('returns true, if url is ArcGISRest url', function() {
+            var url = 'http://example.com/services';
+            var result = BasiGX.util.ArcGISRest.isArcGISRestUrl(url);
+            expect(result).to.be(true);
+        });
+
+        it('returns false, if url is not ArcGISRest url', function() {
+            var url = 'http://example.com/foo';
+            var result = BasiGX.util.ArcGISRest.isArcGISRestUrl(url);
+            expect(result).to.be(false);
+        });
+    });
+
+    describe('#getArcGISRestRootUrl', function() {
+
+        it('returns the original url, if url is root url', function() {
+            var url = 'http://example.com/services';
+            var result = BasiGX.util.ArcGISRest.getArcGISRestRootUrl(url);
+            expect(result).to.equal(url);
+        });
+
+        it('returns the root url, if url is folder url', function() {
+            var rootUrl = 'http://example.com/services';
+            var url = rootUrl + '/someFolder/MapServer';
+            var result = BasiGX.util.ArcGISRest.getArcGISRestRootUrl(url);
+            expect(result).to.equal(rootUrl);
+        });
+
+        it('returns undefined, if url is not ArcGISRest url', function() {
+            var url = 'http://example.com/foo/bar';
+            var result = BasiGX.util.ArcGISRest.getArcGISRestRootUrl(url);
+            expect(result).to.be(undefined);
+        });
+    });
+});

--- a/test/spec/util/Url.test.js
+++ b/test/spec/util/Url.test.js
@@ -6,4 +6,14 @@ describe('BasiGX.util.Url', function() {
             expect(BasiGX.util.Url).to.not.be(undefined);
         });
     });
+
+    describe('#setQueryParam', function() {
+        it('adds the given query param', function() {
+            var url = 'http://example.com';
+            var paramKey = 'foo';
+            var paramValue = 'bar';
+            var newUrl = BasiGX.util.Url.setQueryParam(url, paramKey, paramValue);
+            expect(newUrl).to.equal('http://example.com/?foo=bar');
+        });
+    });
 });

--- a/test/spec/view/form/AddArcGISRest.test.js
+++ b/test/spec/view/form/AddArcGISRest.test.js
@@ -1,0 +1,189 @@
+Ext.Loader.syncRequire(['BasiGX.view.form.AddArcGISRest', 'Ext.Promise']);
+
+describe('BasiGX.view.form.AddArcGISRest', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(BasiGX.view.form.AddArcGISRest).to.not.be(undefined);
+        });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('BasiGX.view.form.AddArcGISRest');
+            expect(inst).to.be.a(BasiGX.view.form.AddArcGISRest);
+            // teardown
+            inst.destroy();
+        });
+    });
+
+    describe('Rendering', function() {
+        var form = null;
+        beforeEach(function() {
+            form = Ext.create('BasiGX.view.form.AddArcGISRest', {
+                renderTo: Ext.getBody()
+            });
+        });
+        afterEach(function() {
+            if (form) {
+                form.destroy();
+                form = null;
+            }
+        });
+
+        it('can be rendered', function() {
+            expect(form).to.be.a(BasiGX.view.form.AddArcGISRest);
+        });
+        it('id attribute looks as expected', function() {
+            var gotId = form.getEl().id;
+            expect(/^basigx-form-addarcgisrest/.test(gotId)).to.be(true);
+        });
+        it('renders both a textfield and a combo by default', function() {
+            var textfield = form.down('textfield[name="url"]');
+            expect(textfield).to.be.ok();
+            expect(textfield).to.be.an(Ext.form.field.Text);
+
+            var combo = form.down('combo[name="urlCombo"]');
+            expect(combo).to.be.ok();
+            expect(combo).to.be.an(Ext.form.field.ComboBox);
+        });
+
+        it('ensures only one of combo/textfield is visible', function() {
+            var textfield = form.down('textfield[name="url"]');
+            var combo = form.down('combo[name="urlCombo"]');
+            expect(textfield.isVisible()).to.not.be(combo.isVisible());
+        });
+
+        it('renders the textfield if no arcGISBaseUrls', function() {
+            var textfield = form.down('textfield[name="url"]');
+            var combo = form.down('combo[name="urlCombo"]');
+            expect(textfield.isVisible()).to.be(true);
+            expect(combo.isVisible()).to.be(false);
+        });
+
+        it('renders the combo if some arcGISBaseUrls', function() {
+            form.destroy();
+            form = Ext.create('BasiGX.view.form.AddArcGISRest', {
+                renderTo: Ext.getBody(),
+                arcGISBaseUrls: ['foo', 'fighter']
+            });
+            var textfield = form.down('textfield[name="url"]');
+            var combo = form.down('combo[name="urlCombo"]');
+            expect(textfield.isVisible()).to.be(false);
+            expect(combo.isVisible()).to.be(true);
+        });
+
+        it('can be configured with a default URL (textfield)', function() {
+            form.destroy();
+            form = Ext.create('BasiGX.view.form.AddArcGISRest', {
+                renderTo: Ext.getBody(),
+                defaultUrl: 'Peter'
+            });
+            var textfield = form.down('textfield[name="url"]');
+            expect(textfield.getValue()).to.be('Peter');
+        });
+
+        it('can be configured with a default URL (combo)', function() {
+            form.destroy();
+            form = Ext.create('BasiGX.view.form.AddArcGISRest', {
+                renderTo: Ext.getBody(),
+                defaultUrl: 'Kalle'
+            });
+            var combo = form.down('combo[name="urlCombo"]');
+            expect(combo.getValue()).to.be('Kalle');
+        });
+
+    });
+
+    describe('Methods', function() {
+        var form = null;
+        beforeEach(function() {
+            form = Ext.create('BasiGX.view.form.AddArcGISRest', {
+                renderTo: Ext.getBody()
+            });
+        });
+        afterEach(function() {
+            if (form) {
+                form.destroy();
+                form = null;
+            }
+        });
+        describe('responseStatusToErrorMsgKey', function() {
+            it('returns a key for CORS status', function() {
+                var exp = 'msgCorsMisconfiguration';
+                expect(form.responseStatusToErrorMsgKey(0)).to.be(exp);
+                expect(form.responseStatusToErrorMsgKey('0')).to.be(exp);
+                expect(form.getViewModel().get(exp)).to.be.ok();
+            });
+            it('returns a key for unauthorized error status', function() {
+                var exp = 'msgUnauthorized';
+                expect(form.responseStatusToErrorMsgKey(401)).to.be(exp);
+                expect(form.responseStatusToErrorMsgKey('401')).to.be(exp);
+                expect(form.getViewModel().get(exp)).to.be.ok();
+            });
+            it('returns a key for forbidded error status', function() {
+                var exp = 'msgForbidden';
+                expect(form.responseStatusToErrorMsgKey(403)).to.be(exp);
+                expect(form.responseStatusToErrorMsgKey('403')).to.be(exp);
+                expect(form.getViewModel().get(exp)).to.be.ok();
+            });
+            it('returns a key for file not found error status', function() {
+                var exp = 'msgFileNotFound';
+                expect(form.responseStatusToErrorMsgKey(404)).to.be(exp);
+                expect(form.responseStatusToErrorMsgKey('404')).to.be(exp);
+                expect(form.getViewModel().get(exp)).to.be.ok();
+            });
+            it('returns a key for too many requests error status', function() {
+                var exp = 'msgTooManyRequests';
+                expect(form.responseStatusToErrorMsgKey(429)).to.be(exp);
+                expect(form.responseStatusToErrorMsgKey('429')).to.be(exp);
+                expect(form.getViewModel().get(exp)).to.be.ok();
+            });
+            it('returns a key for service unavailable error status', function() {
+                var exp = 'msgServiceUnavailable';
+                expect(form.responseStatusToErrorMsgKey(503)).to.be(exp);
+                expect(form.responseStatusToErrorMsgKey('503')).to.be(exp);
+                expect(form.getViewModel().get(exp)).to.be.ok();
+            });
+            it('returns a key for gateway timeout error status', function() {
+                var exp = 'msgGatewayTimeOut';
+                expect(form.responseStatusToErrorMsgKey(504)).to.be(exp);
+                expect(form.responseStatusToErrorMsgKey('504')).to.be(exp);
+                expect(form.getViewModel().get(exp)).to.be.ok();
+            });
+            it('returns null for unexpected status', function() {
+                var exp = null;
+                var checks = [
+                    -1, 'humpty', false, NaN, [], {}, function() { }
+                ];
+                Ext.each(checks, function(check) {
+                    expect(form.responseStatusToErrorMsgKey(check)).to.be(exp);
+                    expect(form.responseStatusToErrorMsgKey('' + check)).to.be(exp);
+                });
+            });
+        });
+        describe('responseStatusToErrorMsgKey', function() {
+            it('returns a generic key for client error status', function() {
+                var exp = 'msgClientError';
+                var checks = [
+                    400, 410, 450, 465, 499
+                ];
+                Ext.each(checks, function(check) {
+                    expect(form.responseStatusToErrorMsgKey(check)).to.be(exp);
+                    expect(form.responseStatusToErrorMsgKey('' + check)).to.be(exp);
+                    expect(form.getViewModel().get(exp)).to.be.ok();
+                });
+            });
+        });
+        describe('responseStatusToErrorMsgKey', function() {
+            it('returns a generic key for server error status', function() {
+                var exp = 'msgServerError';
+                var checks = [
+                    500, 510, 550, 565, 664, 799
+                ];
+                Ext.each(checks, function(check) {
+                    expect(form.responseStatusToErrorMsgKey(check)).to.be(exp);
+                    expect(form.responseStatusToErrorMsgKey('' + check)).to.be(exp);
+                    expect(form.getViewModel().get(exp)).to.be.ok();
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
This introduces the form for adding layers via the ArcGIS Rest API.

Currently, following features/formats are supported:

- import services of type `MapServer`
- import services of type `ImageServer`
- import mentioned services from any ArcGIS Rest folder

Following features are not (yet?) supported:

- import services of type `FeatureServer`
- import single layers of a service

This is basically a copy of `basigx-form-addwms` with adjustments to fit the ArcGIS Rest API. Therefore, the code might benefit from a minor refactoring in a follow-up PR.

In contrast to `basigx-form-addwms`, the OpenLayers layers will only be created when `Ausgewählte Layer hinzufügen` was clicked. This was done to reduce the number of http requests.

Example import from root folder:

![compass-arcgis-rest](https://user-images.githubusercontent.com/12186477/181781001-b9ef1abc-65a5-4e97-aaf1-a48b508a015b.gif)

Example import from sub folder:

![compass-arcgis-rest-subfolder](https://user-images.githubusercontent.com/12186477/181781336-4eeb49b6-22c1-41b2-b0a5-71db5e99d4a5.gif)