### PR TITLE
Introduce support of arcGIS REST FeatureServer layers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,6 +53,23 @@ npm i @terrestris/basigx
         ...
 ```
 
+## IE
+
+BasiGX does not officially support Internet Explorer. If BasiGX is used in an environment where supporting IE is required,
+please make sure to add required polyfills to your project.
+
+Example:
+
+Download a polyfill for `Url()` (e.g. https://www.npmjs.com/package/url-polyfill) and reference it in your `app.json`:
+
+```json
+ "js": [
+    {
+      "path": "./<path>/<to>/<your>/polyfill.min.js"
+    },
+ ]
+```
+
 ## Feedback
 
 Feedback is more than welcome. Please open an issue or contact us directly via `info@terrestris.de`

--- a/src/util/ArcGISRest.js
+++ b/src/util/ArcGISRest.js
@@ -126,7 +126,7 @@ Ext.define('BasiGX.util.ArcGISRest', {
          * @param {string} layerConfig.service.type The service type.
          * @param {string} layerConfig.service.name The service name.
          * @param {string} layerConfig.url The service url.
-         * @param {object} layerConfig.layer (optional) The layer confings of
+         * @param {object} layerConfig.layer (optional) The layer config of
          * a FeatureServer layer.
          * @param {number} layerConfig.layer.id The id of a FeatureServer layer.
          * @param {string} layerConfig.layer.name The name of a FeatureServer

--- a/src/util/ArcGISRest.js
+++ b/src/util/ArcGISRest.js
@@ -94,9 +94,12 @@ Ext.define('BasiGX.util.ArcGISRest', {
          * @param {string} serviceUrl The URL of the service.
          * @param {number} layerId The id of the layer in the FeatureServer.
          * @param {string} format The output format.
+         * @param {string} filter The filter condition.
          * @return {string} The query URL.
          */
-        createFeatureServerQueryUrl: function(serviceUrl, layerId, format) {
+        createFeatureServerQueryUrl: function(
+            serviceUrl, layerId, format, filter
+        ) {
             if (!BasiGX.util.ArcGISRest.isArcGISRestUrl(serviceUrl)) {
                 return;
             }
@@ -112,8 +115,13 @@ Ext.define('BasiGX.util.ArcGISRest', {
             }
             // The query endpoint has a required 'where' parameter. In
             // order to get all features, we apply a where-clause that
-            // always returns true.
-            url = BasiGX.util.Url.setQueryParam(url, 'where', '1=1');
+            // always returns true. This behavior can be overwritten
+            // by specifying a 'filter' argument.
+            var filterToUse = '1=1';
+            if (filter) {
+                filterToUse = filter;
+            }
+            url = BasiGX.util.Url.setQueryParam(url, 'where', filterToUse);
 
             return url;
         },
@@ -127,7 +135,7 @@ Ext.define('BasiGX.util.ArcGISRest', {
          * @param {string} layerConfig.service.name The service name.
          * @param {string} layerConfig.url The service url.
          * @param {object} layerConfig.layer (optional) The layer config of
-         * a FeatureServer layer.
+         * a FeatureServer layer. Mandatory for layers of type Feature Server.
          * @param {number} layerConfig.layer.id The id of a FeatureServer layer.
          * @param {string} layerConfig.layer.name The name of a FeatureServer
          * layer.

--- a/src/util/ArcGISRest.js
+++ b/src/util/ArcGISRest.js
@@ -21,6 +21,11 @@
  * @class BasiGX.util.ArcGISRest
  */
 Ext.define('BasiGX.util.ArcGISRest', {
+
+    requires: [
+        'BasiGX.util.Url'
+    ],
+
     statics: {
 
         /**
@@ -57,6 +62,63 @@ Ext.define('BasiGX.util.ArcGISRest', {
         },
 
         /**
+         * Creates the URL for a FeatureServer request.
+         *
+         * @param {string} serviceUrl The URL of the service.
+         * @param {string} serverName The name of the FeatureServer.
+         * @param {string} format The output format.
+         * @return {string} The URL to the FeatureServer.
+         */
+        createFeatureServerUrl: function(serviceUrl, serverName, format) {
+            if (!BasiGX.util.ArcGISRest.isArcGISRestUrl(serviceUrl)) {
+                return;
+            }
+            var urlObj = new URL(serviceUrl);
+            var parts = urlObj.pathname.split('/');
+            parts.push(serverName);
+            parts.push('FeatureServer');
+            var path = parts.join('/');
+
+            var url = urlObj.origin + path;
+            if (format) {
+                url = BasiGX.util.Url.setQueryParam(url, 'f', format);
+            }
+
+            return url;
+
+        },
+
+        /**
+         * Creates a query URL for a layer of a FeatureServer.
+         *
+         * @param {string} serviceUrl The URL of the service.
+         * @param {number} layerId The id of the layer in the FeatureServer.
+         * @param {string} format The output format.
+         * @return {string} The query URL.
+         */
+        createFeatureServerQueryUrl: function(serviceUrl, layerId, format) {
+            if (!BasiGX.util.ArcGISRest.isArcGISRestUrl(serviceUrl)) {
+                return;
+            }
+            var urlObj = new URL(serviceUrl);
+            var parts = urlObj.pathname.split('/');
+            parts.push(layerId);
+            parts.push('query');
+            var path = parts.join('/');
+
+            var url = urlObj.origin + path;
+            if (format) {
+                url = BasiGX.util.Url.setQueryParam(url, 'f', format);
+            }
+            // The query endpoint has a required 'where' parameter. In
+            // order to get all features, we apply a where-clause that
+            // always returns true.
+            url = BasiGX.util.Url.setQueryParam(url, 'where', '1=1');
+
+            return url;
+        },
+
+        /**
          * Creates an olLayer from an ArcGISRest layer config.
          *
          * @param {object} layerConfig The layer config to base the olLayer on.
@@ -64,14 +126,20 @@ Ext.define('BasiGX.util.ArcGISRest', {
          * @param {string} layerConfig.service.type The service type.
          * @param {string} layerConfig.service.name The service name.
          * @param {string} layerConfig.url The service url.
+         * @param {object} layerConfig.layer (optional) The layer confings of
+         * a FeatureServer layer.
+         * @param {number} layerConfig.layer.id The id of a FeatureServer layer.
+         * @param {string} layerConfig.layer.name The name of a FeatureServer
+         * layer.
          * @param {boolean} useDefaultHeader Whether to use the default
          * Xhr header.
          * @return {Ext.Promise} A promise containing the olLayer.
          */
         createOlLayerFromArcGISRest: function(layerConfig, useDefaultHeader) {
+            var staticMe = BasiGX.util.ArcGISRest;
             var service = layerConfig.service;
             var url = layerConfig.url;
-            var rootUrl = BasiGX.util.ArcGISRest.getArcGISRestRootUrl(url);
+            var rootUrl = staticMe.getArcGISRestRootUrl(url);
             if (!rootUrl) {
                 Ext.log.warn('Provided URL is not a valid ArcGISRest URL');
                 return Ext.Promise.reject();
@@ -89,10 +157,11 @@ Ext.define('BasiGX.util.ArcGISRest', {
                 return Ext.Promise.resolve(responseJson);
             }, onReject).then(function(serviceInfo) {
                 var layer = undefined;
+                var source = undefined;
                 switch(service.type) {
                     case 'ImageServer':
                     case 'MapServer':
-                        var source = new ol.source.TileArcGISRest({
+                        source = new ol.source.TileArcGISRest({
                             url: serviceUrl,
                             projection: 'EPSG:' +
                                 serviceInfo.spatialReference.wkid
@@ -104,10 +173,21 @@ Ext.define('BasiGX.util.ArcGISRest', {
                         });
                         break;
                     case 'FeatureServer':
-                        // FeatureServers can only be requested
-                        // for single layers in a service.
-                        Ext.log.info('ArcGISRest FeatureServer is ' +
-                            'currently not supported.');
+                        var esrijsonFormat = new ol.format.EsriJSON();
+
+                        var sourceUrl = staticMe.createFeatureServerQueryUrl(
+                            url, layerConfig.layer.id, 'json');
+
+                        source = new ol.source.Vector({
+                            url: sourceUrl,
+                            format: esrijsonFormat
+                        });
+
+                        layer = new ol.layer.Vector({
+                            source: source,
+                            name: service.name + '/' + layerConfig.layer.name,
+                            topic: true
+                        });
                         break;
                     default:
                         break;

--- a/src/view/form/AddArcGISRest.js
+++ b/src/view/form/AddArcGISRest.js
@@ -360,7 +360,7 @@ Ext.define('BasiGX.view.form.AddArcGISRest', {
                 return layerConfig.service.type === 'FeatureServer';
             }
         );
-        this.loadFeatureServersLayers(featureServers)
+        this.loadLayersOfFeatureServers(featureServers)
             .then(function(featureServerConfigs) {
                 layerConfigs = Ext.Array.filter(
                     layerConfigs, function(layerConfig) {
@@ -405,7 +405,7 @@ Ext.define('BasiGX.view.form.AddArcGISRest', {
      * layerConfigs, where each layerConfig represents a single layer of a
      * FeatureServer.
      */
-    loadFeatureServersLayers: function(featureServers) {
+    loadLayersOfFeatureServers: function(featureServers) {
         var me = this;
         return new Ext.Promise(function(resolve) {
             var allLayerConfigs = [];

--- a/test/spec/util/ArcGISRest.test.js
+++ b/test/spec/util/ArcGISRest.test.js
@@ -88,5 +88,16 @@ describe('BasiGX.util.ArcGISRest', function() {
             expect(result).to.equal(url);
         });
 
+        it('returns the featureServer url with a specified filter', function() {
+            var serviceUrl = 'http://example.com/services/foo/FeatureServer';
+            var layerId = 0;
+            var filter = 'foo=bar';
+            var url = serviceUrl + '/' + layerId + '/query' +
+                '?where=' + encodeURIComponent(filter);
+            var result = BasiGX.util.ArcGISRest.createFeatureServerQueryUrl(
+                serviceUrl, layerId, undefined, filter);
+            expect(result).to.equal(url);
+        });
+
     });
 });

--- a/test/spec/util/ArcGISRest.test.js
+++ b/test/spec/util/ArcGISRest.test.js
@@ -43,4 +43,50 @@ describe('BasiGX.util.ArcGISRest', function() {
             expect(result).to.be(undefined);
         });
     });
+
+    describe('#createFeatureServerUrl', function() {
+
+        it('returns the featureServer url', function() {
+            var serviceUrl = 'http://example.com/services';
+            var featureServerName = 'foo';
+            var url = serviceUrl + '/' + featureServerName + '/FeatureServer';
+            var result = BasiGX.util.ArcGISRest.createFeatureServerUrl(
+                serviceUrl, featureServerName);
+            expect(result).to.equal(url);
+        });
+
+        it('returns the featureServer url with a specified format', function() {
+            var serviceUrl = 'http://example.com/services';
+            var featureServerName = 'foo';
+            var format = 'bar';
+            var url = serviceUrl + '/' + featureServerName + '/FeatureServer?f=' + format;
+            var result = BasiGX.util.ArcGISRest.createFeatureServerUrl(
+                serviceUrl, featureServerName, format);
+            expect(result).to.equal(url);
+        });
+    });
+
+    describe('#createFeatureServerQueryUrl', function() {
+
+        it('returns the featureServer query url', function() {
+            var serviceUrl = 'http://example.com/services/foo/FeatureServer';
+            var layerId = 0;
+            var url = serviceUrl + '/' + layerId + '/query?where='+ encodeURIComponent('1=1');
+            var result = BasiGX.util.ArcGISRest.createFeatureServerQueryUrl(
+                serviceUrl, layerId);
+            expect(result).to.equal(url);
+        });
+
+        it('returns the featureServer url with a specified format', function() {
+            var serviceUrl = 'http://example.com/services/foo/FeatureServer';
+            var layerId = 0;
+            var format = 'bar';
+            var url = serviceUrl + '/' + layerId + '/query' +
+                '?f=' + format + '&where=' + encodeURIComponent('1=1');
+            var result = BasiGX.util.ArcGISRest.createFeatureServerQueryUrl(
+                serviceUrl, layerId, format);
+            expect(result).to.equal(url);
+        });
+
+    });
 });


### PR DESCRIPTION
This adds support for ArcGIS REST FeatureServer layers.

Currently, only importing single layers of a FeatureServer are supported. We get the layer information by firing http requests to all services in an arcGIS folder that are of type FeatureServer. We then take the layer definitions from the responses and add them to the list of checkboxes in the UI. When importing, all features of a single layer will be requested and added as unstyled ol.layer.Vector.

![compass-arcgis-rest-featureserver](https://user-images.githubusercontent.com/12186477/183652324-befa69de-b8df-49ad-8377-6241ff15632b.gif)
 