### PR TITLE
Add option to add marker to coordinatemouseposition

### DIFF
--- a/src/view/panel/CoordinateMousePositionPanel.js
+++ b/src/view/panel/CoordinateMousePositionPanel.js
@@ -84,6 +84,22 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
     olMap: null,
 
     /**
+     * The layer for the marker
+     */
+    markerLayer: null,
+
+    /**
+     * True, if marker should be shown at coordinate.
+     * False otherwise.
+     */
+    showMarker: false,
+
+    /**
+     * Optional style for the marker.
+     */
+    markerStyle: null,
+
+    /**
      * The OpenLayers MousePosition control
      */
     olMousePositionControl: null,
@@ -455,7 +471,39 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
             me.olMousePositionControl.getProjection(),
             me.olMap.getView().getProjection()
         );
+        if (me.showMarker) {
+            me.showMarkerOnMap(targetCenter);
+        }
         me.olMap.getView().setCenter(targetCenter);
+    },
+
+    /**
+     * Places a marker on the map.
+     *
+     * @param {[number, number]} position The position for the marker.
+     */
+    showMarkerOnMap: function(position) {
+        var me = this;
+        if (!me.markerLayer) {
+            var source = new ol.source.Vector();
+            var style = undefined;
+            if (me.markerStyle) {
+                style = me.markerStyle;
+            }
+            me.markerLayer = new ol.layer.Vector({
+                source: source,
+                style: style
+            });
+            me.olMap.addLayer(me.markerLayer);
+        }
+        var markerSource = me.markerLayer.getSource();
+        markerSource.clear();
+        markerSource.addFeature(new ol.Feature({
+            geometry: new ol.geom.Point(position)
+        }));
+        me.olMap.once('click', function() {
+            markerSource.clear();
+        });
     }
 
 });


### PR DESCRIPTION
This adds an optional marker to the map, when the `centerToCoordinate` button was clicked. The marker will be removed with the next map click. By default, the marker uses the default ol style. A custom style can be added via config. Same goes for the layer, where the marker should be added to.

Example with styled marker:
![compass-marker-on-coordinate](https://user-images.githubusercontent.com/12186477/184155500-733caa81-a28b-4cdc-bdea-ac320e2b92ce.gif)

