### PR TITLE
Remove error prone click event from marker layer

### DIFF
--- a/src/view/panel/CoordinateMousePositionPanel.js
+++ b/src/view/panel/CoordinateMousePositionPanel.js
@@ -138,6 +138,29 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
      */
     updateTextfields: true,
 
+    listeners: {
+        /**
+         * Removes the marker from the map.
+         */
+        'removeMarker': function() {
+            var me = this;
+            if (me.markerLayer) {
+                me.markerLayer.getSource().clear();
+            }
+
+        },
+        /**
+         * Checks if given feature is our map marker.
+         * @param {ol.Feature} feat The feature to check.
+         * @return {boolean} True, if feature is our map marker.
+         * False otherwise.
+         */
+        'isMapMarker': function(feat) {
+            var me = this;
+            return me.isMapMarker(feat);
+        }
+    },
+
     /**
      * The initialization function
      */
@@ -497,13 +520,29 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
             me.olMap.addLayer(me.markerLayer);
         }
         var markerSource = me.markerLayer.getSource();
-        markerSource.clear();
-        markerSource.addFeature(new ol.Feature({
+        var feature = new ol.Feature({
             geometry: new ol.geom.Point(position)
-        }));
-        me.olMap.once('click', function() {
-            markerSource.clear();
         });
+        markerSource.clear();
+        markerSource.addFeature(feature);
+    },
+
+    /**
+     * Checks if a given feature is our map marker.
+     *
+     * @param {ol.Feature} feat The feature to check.
+     * @return {boolean} True, if feature is our map marker. False otherwise.
+     */
+    isMapMarker: function(feat) {
+        var me = this;
+        if (!me.markerLayer) {
+            return false;
+        }
+        var source = me.markerLayer.getSource();
+        if (!source) {
+            return false;
+        }
+        return source.getFeatures()[0] === feat;
     }
 
 });

--- a/src/view/panel/CoordinateMousePositionPanel.js
+++ b/src/view/panel/CoordinateMousePositionPanel.js
@@ -36,7 +36,8 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
         'Ext.button.Segmented',
 
         'BasiGX.view.component.Map',
-        'BasiGX.util.Projection'
+        'BasiGX.util.Projection',
+        'BasiGX.util.Layer'
     ],
 
     /**
@@ -517,6 +518,9 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
                 source: source,
                 style: style
             });
+            var LayerUtil = BasiGX.util.Layer;
+            var showInLayerSwitcherKey = LayerUtil.KEY_DISPLAY_IN_LAYERSWITCHER;
+            me.markerLayer.set(showInLayerSwitcherKey, false);
             me.olMap.addLayer(me.markerLayer);
         }
         var markerSource = me.markerLayer.getSource();


### PR DESCRIPTION
This removes the error prone click event that was added when placing a coordinate marker on the map.

Since we cannot simply suppress all other map events, the component itself cannot handle the marker click event properly. Therefore, we changed it so that now, the using application has to handle the click event. The using application can thereby harmonize the click events with all other used events.

In order to do so, we now provide eventlisteners for checking if a given feature is the coordinate marker, and for removing that marker.