### PR TITLE
Check for empty arrays prior to reduce call in BasiGX.view.form.AddArcGISRest

### DIFF
--- a/src/view/form/AddArcGISRest.js
+++ b/src/view/form/AddArcGISRest.js
@@ -422,7 +422,7 @@ Ext.define('BasiGX.view.form.AddArcGISRest', {
         return Ext.Promise.all(mappedPromises)
             .then(function(responses) {
                 var configs = [];
-                if (Ext.isEmpty(responses) == false) {
+                if (!Ext.isEmpty(responses)) {
                     configs = Ext.Array.reduce(responses, function(acc, conf) {
                         if (!conf) {
                             return acc;

--- a/src/view/form/AddArcGISRest.js
+++ b/src/view/form/AddArcGISRest.js
@@ -421,12 +421,15 @@ Ext.define('BasiGX.view.form.AddArcGISRest', {
         });
         return Ext.Promise.all(mappedPromises)
             .then(function(responses) {
-                var configs = Ext.Array.reduce(responses, function(acc, conf) {
-                    if (!conf) {
-                        return acc;
-                    }
-                    return Ext.Array.merge(acc, conf);
-                });
+                var configs = [];
+                if (Ext.isEmpty(responses) == false) {
+                    configs = Ext.Array.reduce(responses, function(acc, conf) {
+                        if (!conf) {
+                            return acc;
+                        }
+                        return Ext.Array.merge(acc, conf);
+                    });
+                }
                 return Ext.Promise.resolve(configs);
             });
     },


### PR DESCRIPTION
If a server has no FeaureServers then an error is thrown when calling ` Ext.Array.reduce` on an empty array: `TypeError: Reduce of empty array with no initial value`.
This check simply avoids calling the function when `responses` is empty. 