### PR TITLE
Allow pre-loading projection definitions to avoid requests to epsg.io

### DIFF
--- a/src/model/Projection.js
+++ b/src/model/Projection.js
@@ -1,0 +1,61 @@
+/* Copyright (c) 2016-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * Projection mode for use with the Projections Store
+ *
+ * @class BasiGX.model.Projection
+ */
+Ext.define('BasiGX.model.Projection', {
+    extend: 'Ext.data.Model',
+    idProperty: 'code',
+    fields: [{
+        name: 'code',
+        type: 'int'
+    }, {
+        name: 'accuracy',
+        type: 'string'
+    }, {
+        name: 'area',
+        type: 'string'
+    }, {
+        name: 'authority',
+        type: 'string'
+    }, {
+        name: 'bbox',
+        type: 'auto'
+    }, {
+        name: 'default_trans',
+        type: 'number'
+    }, {
+        name: 'kind',
+        type: 'string'
+    }, {
+        name: 'name',
+        type: 'string'
+    }, {
+        name: 'proj4',
+        type: 'string'
+    }, {
+        name: 'trans',
+        type: 'auto'
+    }, {
+        name: 'unit',
+        type: 'string'
+    }, {
+        name: 'wkt',
+        type: 'string'
+    }]
+});

--- a/src/model/Projection.js
+++ b/src/model/Projection.js
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Projection mode for use with the Projections Store
+ * Projection model for use with the Projections Store
  *
  * @class BasiGX.model.Projection
  */

--- a/src/store/Projections.js
+++ b/src/store/Projections.js
@@ -21,49 +21,7 @@
 Ext.define('BasiGX.store.Projections', {
     extend: 'Ext.data.Store',
     alias: 'store.basigx-projections',
+    model: 'BasiGX.model.Projection',
     singleton: true,
-
-    data: [],
-
-    fields: [{
-        name: 'id',
-        type: 'string',
-        identifier: true
-    }, {
-        name: 'accuracy',
-        type: 'string'
-    }, {
-        name: 'area',
-        type: 'string'
-    }, {
-        name: 'authority',
-        type: 'string'
-    }, {
-        name: 'bbox',
-        type: 'auto'
-    }, {
-        name: 'code',
-        type: 'string'
-    }, {
-        name: 'default_trans',
-        type: 'number'
-    }, {
-        name: 'kind',
-        type: 'string'
-    }, {
-        name: 'name',
-        type: 'string'
-    }, {
-        name: 'proj4',
-        type: 'string'
-    }, {
-        name: 'trans',
-        type: 'auto'
-    }, {
-        name: 'unit',
-        type: 'string'
-    }, {
-        name: 'wkt',
-        type: 'string'
-    }]
+    data: []
 });

--- a/src/store/Projections.js
+++ b/src/store/Projections.js
@@ -1,0 +1,69 @@
+/* Copyright (c) 2016-present terrestris GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * Data Store to set and store local projections
+ *
+ * @class BasiGX.store.Projections
+ */
+Ext.define('BasiGX.store.Projections', {
+    extend: 'Ext.data.Store',
+    alias: 'store.basigx-projections',
+    singleton: true,
+
+    data: [],
+
+    fields: [{
+        name: 'id',
+        type: 'string',
+        identifier: true
+    }, {
+        name: 'accuracy',
+        type: 'string'
+    }, {
+        name: 'area',
+        type: 'string'
+    }, {
+        name: 'authority',
+        type: 'string'
+    }, {
+        name: 'bbox',
+        type: 'auto'
+    }, {
+        name: 'code',
+        type: 'string'
+    }, {
+        name: 'default_trans',
+        type: 'number'
+    }, {
+        name: 'kind',
+        type: 'string'
+    }, {
+        name: 'name',
+        type: 'string'
+    }, {
+        name: 'proj4',
+        type: 'string'
+    }, {
+        name: 'trans',
+        type: 'auto'
+    }, {
+        name: 'unit',
+        type: 'string'
+    }, {
+        name: 'wkt',
+        type: 'string'
+    }]
+});

--- a/src/util/Projection.js
+++ b/src/util/Projection.js
@@ -56,6 +56,7 @@ Ext.define('BasiGX.util.Projection', {
                             if (response && response.responseText &&
                                 response.status === 200) {
                                 var resultObj = Ext.decode(response.responseText);
+                                projectionsStore.add(Ext.apply({}, resultObj.results[0]));
                                 resolve(resultObj.results[0]);
                             } else {
                                 reject(response.status);

--- a/src/util/Projection.js
+++ b/src/util/Projection.js
@@ -17,6 +17,9 @@
  * @class BasiGX.util.Projection
  */
 Ext.define('BasiGX.util.Projection', {
+    requires: [
+        'BasiGX.store.Projections'
+    ],
 
     statics: {
 
@@ -29,39 +32,41 @@ Ext.define('BasiGX.util.Projection', {
          * @return {Ext.Promise} An ExtJS promise resolving if all EPSG
          * information has successfully been fetched from https://epsg.io
          */
-        fetchProj4jCrsDefinitions: function(epsgCodeArray) {
+        fetchProj4jCrsDefinitions: function (epsgCodeArray) {
             if (!Ext.isArray(epsgCodeArray)) {
                 return Ext.Promise.reject('No valid array of EPSG codes ' +
                     ' provided.');
             }
-            var epsgPromises = [];
             var epsgIoBaseUrl = 'https://epsg.io/?q={0}&format=json';
-            Ext.each(Ext.Array.unique(epsgCodeArray), function(epsgCodeStr) {
+            var projectionsStore = BasiGX.store.Projections;
+            var epsgPromises = Ext.Array.map(Ext.Array.unique(epsgCodeArray), function (epsgCodeStr) {
                 var epsgCode = epsgCodeStr.toUpperCase().replace('EPSG:', '');
-                var epsgPromise = new Ext.Promise(function(resolve, reject) {
+                var existingDef = projectionsStore.getById(epsgCodeStr.toUpperCase());
+
+                if (existingDef) {
+                    return Ext.Promise.resolve(existingDef.getData());
+                }
+
+                return new Ext.Promise(function (resolve, reject) {
                     var epsgUrl = Ext.String.format(epsgIoBaseUrl, epsgCode);
                     Ext.Ajax.request({
                         url: epsgUrl,
                         useDefaultXhrHeader: false,
-                        success: function(response) {
+                        success: function (response) {
                             if (response && response.responseText &&
                                 response.status === 200) {
-                                var resultObj = Ext.decode(response.
-                                    responseText);
+                                var resultObj = Ext.decode(response.responseText);
                                 resolve(resultObj.results[0]);
                             } else {
                                 reject(response.status);
                             }
                         },
-                        failure: function(response) {
+                        failure: function (response) {
                             reject(response.status);
                         }
                     });
-
                 });
-                epsgPromises.push(epsgPromise);
             });
-
             return Ext.Promise.all(epsgPromises);
         },
 

--- a/src/view/panel/CoordinateMousePositionPanel.js
+++ b/src/view/panel/CoordinateMousePositionPanel.js
@@ -339,7 +339,8 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
                 var mapCode = me.olMap.getView().getProjection().getCode()
                     .split(':')[1];
                 var filtered = Ext.Array.filter(proj4jObjects, function(obj) {
-                    return obj.code === mapCode;
+                    // Loose equality check since code could be a string or an int
+                    return obj.code == mapCode;
                 });
                 me.getViewModel().setData({
                     srsName: filtered ? filtered[0].name : ''

--- a/test/spec/util/Projection.test.js
+++ b/test/spec/util/Projection.test.js
@@ -8,5 +8,75 @@ describe('BasiGX.util.Projection', function() {
         it('can use proj4js', function() {
             expect(proj4).to.not.be(undefined);
         });
+        it('can use BasiGX.store.Projections', function() {
+            expect(BasiGX.store.Projections).to.not.be(undefined);
+        });
+    });
+
+    describe('Advanced', function() {
+        var projectionsStore = BasiGX.store.Projections;
+        var xhr;
+        var requests = [];
+        beforeEach(function() {
+            xhr = sinon.useFakeXMLHttpRequest();
+            xhr.onCreate = function (xhr) {
+                requests.push(xhr);
+            }
+        });
+
+        afterEach(function() {
+            projectionsStore.removeAll();
+            xhr.restore();
+            requests = [];
+        });
+
+        it('requests data from epsg.io for each EPSG code provided', function() {
+            var promise = BasiGX.util.Projection.fetchProj4jCrsDefinitions([
+                'EPSG:4326',
+                'EPSG:3857'
+            ]);
+
+            expect(requests[0].url).to.contain('https://epsg.io/?q=4326');
+            expect(requests[1].url).to.contain('https://epsg.io/?q=3857');
+
+            // respond with dummy data so the promise resolves
+            requests[0].respond(200, { "Content-Type": "application/json" }, '{ "results": [{ "code": 4326 }] }');
+            requests[1].respond(200, { "Content-Type": "application/json" }, '{ "results": [{ "code": 3857 }] }');
+            return promise;
+        });
+
+        it('uses data from the projections store when available', function() {
+            // pre-load two definitions
+            projectionsStore.loadData([{
+                code: 4326,
+                name: 'WGS 84',
+                proj4: '+proj=longlat +datum=WGS84 +no_defs +type=crs',
+                unit: 'degree (supplier to define representation)',
+            }, {
+                code: 3857,
+                name: 'WGS 84 / Pseudo-Mercator',
+                proj4: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs +type=crs',
+                unit: 'metre'
+            }]);
+
+            // request three definitions
+            var promise = BasiGX.util.Projection.fetchProj4jCrsDefinitions([
+                'EPSG:4326',
+                'EPSG:3857',
+                'EPSG:29902'
+            ]);
+
+            // number of xhr requersts should be only 1, for the non pre-loaded definition
+            expect(requests.length).to.be(1);
+            expect(requests[0].url).to.contain('https://epsg.io/?q=29902');
+
+            // respond with dummy data so the promise resolves
+            requests[0].respond(200, { "Content-Type": "application/json" }, '{ "results": [{ "code": 29902 }] }');
+            return promise.then(function (data) {
+                expect(+data[0].code).to.be(4326);
+                expect(+data[1].code).to.be(3857);
+                expect(+data[2].code).to.be(29902);
+            });
+        });
     });
 });


### PR DESCRIPTION
In relation to https://github.com/compassinformatics/cpsi-mapview/issues/615

This PR allows consumers of BasiGX to pre-load epsg.io responses to avoid requests to that service.

It uses a singleton store, `BasiGX.store.Projections` to which definitions can be added. When `fetchProj4jCrsDefinitions` is called it will check if the definition exists in the store, if it exists it will use it, if not it will request the definition from epsg.io.

Definitions can be pre-loaded like this:
```javascript
projectionsStore.loadData([{
    id: 'EPSG:4326',
    code: '4326',
    name: 'WGS 84',
    proj4: '+proj=longlat +datum=WGS84 +no_defs +type=crs',
    unit: 'degree (supplier to define representation)',
}, {
    id: 'EPSG:29902',
    code: '29902',
    name: 'TM65 / Irish Grid',
    proj4: '+proj=tmerc +lat_0=53.5 +lon_0=-8 +k=1.000035 +x_0=200000 +y_0=250000 +a=6377340.189 +rf=299.3249646 +towgs84=482.5,-130.6,564.6,-1.042,-0.214,-0.631,8.15 +units=m +no_defs +type=crs',
    unit: 'metre',
}, {
    id: 'EPSG:2157',
    code: '2157',
    name: 'IRENET95 / Irish Transverse Mercator',
    proj4: '+proj=tmerc +lat_0=53.5 +lon_0=-8 +k=0.99982 +x_0=600000 +y_0=750000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs',
    unit: 'metre'
}, {
    id: 'EPSG:3857',
    code: '3857',
    name: 'WGS 84 / Pseudo-Mercator',
    proj4: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs +type=crs',
    unit: 'metre'
}]);
```