### PR TITLE
Fix feature grid layout

### DIFF
--- a/src/view/grid/FeatureGrid.js
+++ b/src/view/grid/FeatureGrid.js
@@ -162,6 +162,11 @@ Ext.define('BasiGX.view.grid.FeatureGrid', {
     editLayer: undefined,
     items: [],
 
+    layout: {
+        type: 'vbox',
+        align: 'stretch'
+    },
+
     constructor: function() {
         var me = this;
 
@@ -198,6 +203,7 @@ Ext.define('BasiGX.view.grid.FeatureGrid', {
         }
         var gridOpts = {
             xtype: 'grid',
+            flex: 1,
             height: gridHeight,
             selModel: 'checkboxmodel',
             enableLocking: this.getEnableLocking(),

--- a/src/view/grid/FeatureGrid.js
+++ b/src/view/grid/FeatureGrid.js
@@ -205,6 +205,7 @@ Ext.define('BasiGX.view.grid.FeatureGrid', {
             xtype: 'grid',
             flex: 1,
             height: gridHeight,
+            forceFit: true,
             selModel: 'checkboxmodel',
             enableLocking: this.getEnableLocking(),
             header: this.getGridHeader(),

--- a/src/view/grid/FeatureGrid.js
+++ b/src/view/grid/FeatureGrid.js
@@ -111,6 +111,12 @@ Ext.define('BasiGX.view.grid.FeatureGrid', {
          * Configures the grid header. See https://docs.sencha.com/extjs/6.2.0/classic/Ext.grid.Panel.html#cfg-header
          */
         gridHeader: undefined,
+
+        /**
+         * Height of grid toolbar. Defaults to 50px.
+         */
+        gridToolbarHeight: 50,
+
         /* eslint-enable */
         /**
          * Configures filtering on the grid.
@@ -186,9 +192,9 @@ Ext.define('BasiGX.view.grid.FeatureGrid', {
      */
     initComponent: function() {
         this.callParent();
-        var gridHeight = 456;
+        var gridHeight = this.height;
         if (this.enableEditing || this.enableRefreshButton) {
-            gridHeight = 406;
+            gridHeight = gridHeight - this.getGridToolbarHeight();
         }
         var gridOpts = {
             xtype: 'grid',
@@ -1096,7 +1102,7 @@ Ext.define('BasiGX.view.grid.FeatureGrid', {
 
         var editTools = {
             xtype: 'buttongroup',
-            height: 50,
+            height: this.getGridToolbarHeight(),
             tbar: [{
                 xtype: 'button',
                 name: 'featuregrid-reload-btn',

--- a/src/view/grid/FeatureGrid.js
+++ b/src/view/grid/FeatureGrid.js
@@ -564,7 +564,7 @@ Ext.define('BasiGX.view.grid.FeatureGrid', {
         var columns = [];
         if (this.getAddZoomButton()) {
             columns.push({
-                minWidth: 35,
+                maxWidth: 35,
                 menuDisabled: true,
                 enableColumnHide: false,
                 hideable: false,
@@ -575,7 +575,6 @@ Ext.define('BasiGX.view.grid.FeatureGrid', {
                     return '<span class="fa fa-search" ' +
                         'style="cursor: pointer;"></span>';
                 },
-                width: 32,
                 sorter: this.selectionCompareFunction.bind(this)
             });
         }


### PR DESCRIPTION
* Auto adapt height of the grid on parent element resize to fit all available place
* Get rid of some hardcoded height values, make height of grid toolbar configurable
* Force columns to fit into available grid width (excepting zoom action column, which width is restricted by 35px)

Please review @terrestris/devs 