### PR TITLE
Use a maintained GH action to setup ruby

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -12,15 +12,15 @@ jobs:
 
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
 
     - name: Cache Node.js modules 💾
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: node_modules
         key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -11,15 +11,15 @@ jobs:
 
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
 
     - name: Cache Node.js modules 💾
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           node_modules
@@ -29,7 +29,7 @@ jobs:
           ${{ runner.OS }}-
 
     - name: Cache ext 💾
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ext-6.2.0

--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -50,7 +50,7 @@ jobs:
         unzip -qo geoext3-master.zip
 
     - name: Install ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.6'
 

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -11,15 +11,15 @@ jobs:
 
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
 
     - name: Cache Node.js modules 💾
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           node_modules
@@ -29,7 +29,7 @@ jobs:
           ${{ runner.OS }}-
 
     - name: Cache ext 💾
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ext-6.2.0

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -50,7 +50,7 @@ jobs:
         unzip -qo geoext3-master.zip
 
     - name: Install ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.6'
 


### PR DESCRIPTION
This fixes failed CI checks like this one: https://github.com/terrestris/BasiGX/actions/runs/4563233373/jobs/8051469360

Compare e.g. https://github.com/geoext/geoext/pull/722

Please review.