### PR TITLE
Refactor deprecated forEachLayerAtPixel

### DIFF
--- a/src/plugin/Hover.js
+++ b/src/plugin/Hover.js
@@ -327,6 +327,7 @@ Ext.define('BasiGX.plugin.Hover', {
         var mapComponent = me.getCmp();
         var map = mapComponent.getMap();
         var mapView = map.getView();
+        var allLayers = map.getAllLayers();
         var pixel = evt.pixel;
         var hoverableProp = me.self.LAYER_HOVERABLE_PROPERTY_NAME;
         var hoverFeaturesRevertProp = me.self.LAYER_HOVER_FEATURES_REVERT_NAME;
@@ -335,7 +336,7 @@ Ext.define('BasiGX.plugin.Hover', {
 
         me.cleanupHoverArtifacts();
 
-        map.forEachLayerAtPixel(pixel, function(layer, pixelValues) {
+        var callback = function(layer, pixelValues) {
             var source = layer.getSource();
             var resolution = mapView.getResolution();
             var projCode = mapView.getProjection().getCode();
@@ -423,8 +424,16 @@ Ext.define('BasiGX.plugin.Hover', {
                     });
                 }
             }
-        }, {
-            layerFilter: me.hoverLayerFilter.bind(me)
+        };
+
+        allLayers.forEach(function(lyr) {
+            var layerData = lyr.getData(pixel);
+            if (layerData) {
+                var alphaValue = layerData.at(3);
+                if (alphaValue > 0 && me.hoverLayerFilter(lyr)) {
+                    callback(lyr, layerData);
+                }
+            }
         });
 
         me.showHoverToolTip(evt, hoverLayers, hoverFeatures);

--- a/src/plugin/HoverClick.js
+++ b/src/plugin/HoverClick.js
@@ -140,6 +140,7 @@ Ext.define('BasiGX.plugin.HoverClick', {
         var mapComponent = me.getCmp();
         var map = mapComponent.getMap();
         var mapView = map.getView();
+        var allLayers = map.getAllLayers();
         var pixel = evt.pixel;
         var hoverFeaturesRevertProp = me.self.LAYER_HOVER_FEATURES_REVERT_NAME;
         var clickableProp = me.self.LAYER_CLICKABLE_PROPERTY_NAME;
@@ -148,7 +149,7 @@ Ext.define('BasiGX.plugin.HoverClick', {
 
         me.cleanupHoverArtifacts();
 
-        map.forEachLayerAtPixel(pixel, function(layer, pixelValues) {
+        var callback = function(layer, pixelValues) {
             if (!layer.get(clickableProp)) {
                 return;
             }
@@ -157,7 +158,6 @@ Ext.define('BasiGX.plugin.HoverClick', {
             var resolution = mapView.getResolution();
             var projCode = mapView.getProjection().getCode();
             var hoverFeaturesRevert = layer.get(hoverFeaturesRevertProp);
-
 
             if (source instanceof ol.source.TileWMS
                     || source instanceof ol.source.ImageWMS) {
@@ -235,9 +235,18 @@ Ext.define('BasiGX.plugin.HoverClick', {
                     }
                 });
             }
-        }, {
-            layerFilter: me.clickLayerFilter.bind(me)
+        };
+
+        allLayers.forEach(function(lyr) {
+            var layerData = lyr.getData(pixel);
+            if (layerData) {
+                var alphaValue = layerData.at(3);
+                if (alphaValue > 0 && me.clickLayerFilter(lyr)) {
+                    callback(lyr, layerData);
+                }
+            }
         });
+
     },
 
     /**


### PR DESCRIPTION
OpenLayers 7 removed deprecated functions like `forEachLayerAtPixel` (see https://github.com/openlayers/openlayers/releases/)

This change refactors/re-implements the use of this function in BasiGX