### PR TITLE
Add check for ArcGISRest service requests returning errors

### DIFF
--- a/src/view/form/AddArcGISRest.js
+++ b/src/view/form/AddArcGISRest.js
@@ -463,6 +463,11 @@ Ext.define('BasiGX.view.form.AddArcGISRest', {
      */
     getFeatureServerConfigs: function(response, layerConfig) {
         var res = JSON.parse(response.responseText);
+
+        if (!res.layers) {
+            return [];
+        }
+
         var configs = Ext.Array.map(res.layers, function(layer) {
             var config = Ext.clone(layerConfig);
             config.url = response.request.url;


### PR DESCRIPTION
If `response.responseText` contains an error  e.g. `'{"error":{"code":400,"message":"Invalid URL","details":[]}}'` then `res.layers` is undefined causing a JS error `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'map')` and the form to become stuck. 

This update adds a simple check and returns an empty array to prevent this. 
