### PR TITLE
Check for proj codes as str or int in CoordinateMousePositionPanel

### DIFF
--- a/src/view/panel/CoordinateMousePositionPanel.js
+++ b/src/view/panel/CoordinateMousePositionPanel.js
@@ -339,8 +339,8 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
                 var mapCode = me.olMap.getView().getProjection().getCode()
                     .split(':')[1];
                 var filtered = Ext.Array.filter(proj4jObjects, function(obj) {
-                    // Loose equality check since code could be a string or an int
-                    return obj.code == mapCode;
+                    // convert values to strings as they can be either a string or an int
+                    return obj.code.toString() == mapCode.toString();
                 });
                 me.getViewModel().setData({
                     srsName: !Ext.isEmpty(filtered) ? filtered[0].name : ''

--- a/src/view/panel/CoordinateMousePositionPanel.js
+++ b/src/view/panel/CoordinateMousePositionPanel.js
@@ -343,7 +343,7 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
                     return obj.code == mapCode;
                 });
                 me.getViewModel().setData({
-                    srsName: filtered ? filtered[0].name : ''
+                    srsName: !Ext.isEmpty(filtered) ? filtered[0].name : ''
                 });
             }
         }

--- a/src/view/panel/CoordinateMousePositionPanel.js
+++ b/src/view/panel/CoordinateMousePositionPanel.js
@@ -340,7 +340,7 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
                     .split(':')[1];
                 var filtered = Ext.Array.filter(proj4jObjects, function(obj) {
                     // Loose equality check since code could be a string or an int
-                    return obj.code === mapCode;
+                    return obj.code == mapCode;
                 });
                 me.getViewModel().setData({
                     srsName: filtered ? filtered[0].name : ''

--- a/src/view/panel/CoordinateMousePositionPanel.js
+++ b/src/view/panel/CoordinateMousePositionPanel.js
@@ -340,7 +340,7 @@ Ext.define('BasiGX.view.panel.CoordinateMousePositionPanel', {
                     .split(':')[1];
                 var filtered = Ext.Array.filter(proj4jObjects, function(obj) {
                     // convert values to strings as they can be either a string or an int
-                    return obj.code.toString() == mapCode.toString();
+                    Ext.isDefined(obj.code) && (obj.code.toString() === mapCode.toString())
                 });
                 me.getViewModel().setData({
                     srsName: !Ext.isEmpty(filtered) ? filtered[0].name : ''


### PR DESCRIPTION
The comment states `// Loose equality check since code could be a string or an int` however an exact check is used. 
This then causes `filtered` to be an empty array when checking `3857 ==== "3857" `between a projection code in the store and the projection code from the map. 

Results in the JS error:

```
CoordinateMousePositionPanel.js?_dc=1737122544728:347 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'name')
    at constructor.generateCrsChangeButtonGroup (CoordinateMousePositionPanel.js?_dc=1737122544728:347:53)
    at CoordinateMousePositionPanel.js?_dc=1737122544728:273:20
```

In addition the `filtered ? filtered[0].name : ''` will return `true` for an empty array (which is always created using Ext.Array.filter)  - updated to account for this. 